### PR TITLE
Update the automake include files to add missing items

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,9 +30,9 @@ ACLOCAL_AMFLAGS= -I m4
 
 include src/include.am
 include wolfssh/include.am
-include examples/echoserver/include.am
-include examples/server/include.am
+include examples/include.am
 include test/include.am
+include certs/include.am
 
 
 TEST_EXTENSIONS = .test

--- a/certs/include.am
+++ b/certs/include.am
@@ -1,0 +1,16 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+
+EXTRA_DIST+= \
+            certs/key-gretel.pem \
+            certs/publickeys.txt \
+            certs/server-key.der \
+            certs/key-ecc.pem \
+            certs/key-hansel.pem \
+            certs/server-cert.der \
+            certs/server-key.pem \
+            certs/key-ecc.pub \
+            certs/passwd.txt \
+            certs/server-cert.pem

--- a/examples/include.am
+++ b/examples/include.am
@@ -1,0 +1,6 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+include examples/echoserver/include.am
+include examples/server/include.am

--- a/examples/server/include.am
+++ b/examples/server/include.am
@@ -1,10 +1,12 @@
 # vim:ft=automake
 # All paths should be given relative to the root
 
-noinst_PROGRAMS += examples/server/server
-examples_server_server_SOURCES      = examples/server/server.c
-examples_server_server_LDADD        = src/libwolfssh.la
-examples_server_server_DEPENDENCIES = src/libwolfssh.la
+#noinst_PROGRAMS += examples/server/server
+#examples_server_server_SOURCES      = examples/server/server.c
+#examples_server_server_LDADD        = src/libwolfssh.la
+#examples_server_server_DEPENDENCIES = src/libwolfssh.la
+#
+#dist_example_DATA+= examples/server/server.c
+#DISTCLEANFILES+= examples/server/.libs/server
 
-dist_example_DATA+= examples/server/server.c
-DISTCLEANFILES+= examples/server/.libs/server
+EXTRA_DIST+= examples/server/server.c

--- a/wolfssh/include.am
+++ b/wolfssh/include.am
@@ -5,12 +5,15 @@
 
 nobase_include_HEADERS+= \
                          wolfssh/version.h \
-						 wolfssh/internal.h \
                          wolfssh/ssh.h \
                          wolfssh/port.h \
                          wolfssh/memory.h \
                          wolfssh/settings.h \
                          wolfssh/error.h \
                          wolfssh/visibility.h \
+                         wolfssh/misc.h \
                          wolfssh/log.h
+
+noinst_HEADERS+= \
+                         wolfssh/internal.h
 


### PR DESCRIPTION
1. Some files were missing from make dist.
2. Reorg examples/include.am.
3. Stop building example server for now, but keep the source.
