### PR TITLE
Update misc inline code

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -49,8 +49,10 @@
 
 /* Check for if compiling misc.c when not needed. */
 #if !defined(WOLFSSH_MISC_INCLUDED) && !defined(NO_INLINE)
-    #error misc.c does not need to be compiled when not defined NO_INLINE
-#endif
+
+    #warning misc.c does not need to be compiled when using inline (NO_INLINE not defined)
+
+#else /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE */
 
 
 #ifndef min
@@ -103,6 +105,9 @@ STATIC INLINE int ConstantCompare(const uint8_t* a, const uint8_t* b,
 
 
 #undef STATIC
+
+
+#endif /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE */
 
 
 #endif /* WOLFSSH_MISC_C */


### PR DESCRIPTION
Change misc.c error to warning and exclude the misc.c code from being compiled. Most people include all .c files and by default inlining is allowed, which in turn causes an #error in misc.c and it must be excluded. Since we know its already been properly included there is no reason to throw error here. Instead, show warning and exclude code in .c file.

Copied from wolfSSL pull request #521.