### PR TITLE
err_sys() static analysis issue

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -86,17 +86,22 @@ typedef int SOCKET_T;
     #define CYASSL_THREAD __stdcall
 #endif
 
+#ifdef __GNUC__
+    #define NORETURN __attribute__((noreturn))
+#else
+    #define NORETURN
+#endif
+
 
 typedef struct {
     SOCKET_T clientFd;
 } thread_ctx_t;
 
 
-static INLINE void err_sys(const char* msg)
+static INLINE NORETURN void err_sys(const char* msg)
 {
     printf("server error: %s\n", msg);
-    if (msg)
-        exit(EXIT_FAILURE);
+    exit(EXIT_FAILURE);
 }
 
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -84,22 +84,34 @@ typedef int SOCKET_T;
     #define CYASSL_THREAD __stdcall
 #endif
 
-#ifdef __GNUC__
-    #define NORETURN __attribute__((noreturn))
-#else
-    #define NORETURN
-#endif
-
-
 typedef struct {
     SOCKET_T clientFd;
 } thread_ctx_t;
 
 
-static INLINE NORETURN void err_sys(const char* msg)
+#ifdef __GNUC__
+    #define WS_NORETURN __attribute__((noreturn))
+#else
+    #define WS_NORETURN
+#endif
+
+
+static INLINE WS_NORETURN void err_sys(const char* msg)
 {
     printf("server error: %s\n", msg);
-    exit(EXIT_FAILURE);
+
+#ifndef __GNUC__
+    /* scan-build (which pretends to be gnuc) can get confused and think the
+     * msg pointer can be null even when hardcoded and then it won't exit,
+     * making null pointer checks above the err_sys() call useless.
+     * We could just always exit() but some compilers will complain about no
+     * possible return, with gcc we know the attribute to handle that with
+     * WS_NORETURN. */
+    if (msg)
+#endif
+    {
+        exit(EXIT_FAILURE);
+    }
 }
 
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -84,17 +84,22 @@ typedef int SOCKET_T;
     #define CYASSL_THREAD __stdcall
 #endif
 
+#ifdef __GNUC__
+    #define NORETURN __attribute__((noreturn))
+#else
+    #define NORETURN
+#endif
+
 
 typedef struct {
     SOCKET_T clientFd;
 } thread_ctx_t;
 
 
-static INLINE void err_sys(const char* msg)
+static INLINE NORETURN void err_sys(const char* msg)
 {
     printf("server error: %s\n", msg);
-    if (msg)
-        exit(EXIT_FAILURE);
+    exit(EXIT_FAILURE);
 }
 
 


### PR DESCRIPTION
Copied change to err_sys() from wolfSSL. Cleaned up a static analysis issue. Also added the attribute noreturn to the function since it doesn't actually return.