### PR TITLE
Transfer Highwater Mark, Session Key Refactoring

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -91,6 +91,11 @@ typedef struct {
 } thread_ctx_t;
 
 
+#ifndef DEFAULT_HIGHWATER_MARK
+    #define DEFAULT_HIGHWATER_MARK 0
+#endif
+
+
 #ifdef __GNUC__
     #define WS_NORETURN __attribute__((noreturn))
 #else
@@ -586,11 +591,29 @@ static int wsUserAuth(uint8_t authType,
 }
 
 
+static int wsHighwater(uint8_t side, void* ctx)
+{
+    if (ctx) {
+        WOLFSSH* ssh = (WOLFSSH*)ctx;
+        uint32_t highwaterMark = wolfSSH_GetHighwater(ssh);
+
+        printf("HIGHWATER ALERT: (%u) %s\n", highwaterMark,
+                (side == WOLFSSH_HWSIDE_RECEIVE) ? "receive" : "transmit");
+        highwaterMark *= 2;
+        printf("  Doubling the highwater mark to %u.\n", highwaterMark);
+        wolfSSH_SetHighwater(ssh, highwaterMark);
+    }
+
+    return 0;
+}
+
+
 int main(void)
 {
     WOLFSSH_CTX* ctx = NULL;
     PwMapList pwMapList;
     SOCKET_T listenFd = 0;
+    uint32_t defaultHighwater = DEFAULT_HIGHWATER_MARK;
 
     #ifdef DEBUG_WOLFSSH
         wolfSSH_Debugging_ON();
@@ -609,6 +632,8 @@ int main(void)
 
     memset(&pwMapList, 0, sizeof(pwMapList));
     wolfSSH_SetUserAuth(ctx, wsUserAuth);
+    if (defaultHighwater > 0)
+        wolfSSH_SetHighwaterCb(ctx, defaultHighwater, wsHighwater);
 
     {
         uint8_t buf[SCRATCH_BUFFER_SIZE];
@@ -662,6 +687,9 @@ int main(void)
             exit(EXIT_FAILURE);
         }
         wolfSSH_SetUserAuthCtx(ssh, &pwMapList);
+        /* Use the session object for its own highwater callback ctx */
+        if (defaultHighwater > 0)
+            wolfSSH_SetHighwaterCtx(ssh, (void*)ssh);
 
         if (listen(listenFd, 5) != 0)
             err_sys("tcp listen failed");

--- a/src/internal.c
+++ b/src/internal.c
@@ -146,6 +146,138 @@ const char* GetErrorString(int err)
 }
 
 
+WOLFSSH_CTX* CtxInit(WOLFSSH_CTX* ctx, void* heap)
+{
+    WLOG(WS_LOG_DEBUG, "Entering CtxInit()");
+
+    if (ctx == NULL)
+        return ctx;
+
+    WMEMSET(ctx, 0, sizeof(WOLFSSH_CTX));
+
+    if (heap)
+        ctx->heap = heap;
+
+#ifndef WOLFSSH_USER_IO
+    ctx->ioRecvCb = wsEmbedRecv;
+    ctx->ioSendCb = wsEmbedSend;
+#endif /* WOLFSSH_USER_IO */
+
+    return ctx;
+}
+
+
+void CtxResourceFree(WOLFSSH_CTX* ctx)
+{
+    WLOG(WS_LOG_DEBUG, "Entering CtxResourceFree()");
+
+    if (ctx->privateKey) {
+        ForceZero(ctx->privateKey, ctx->privateKeySz);
+        WFREE(ctx->privateKey, ctx->heap, DYNTYPE_KEY);
+    }
+    WFREE(ctx->cert, ctx->heap, DYNTYPE_CERT);
+    WFREE(ctx->caCert, ctx->heap, DYNTYPE_CA);
+}
+
+
+WOLFSSH* SshInit(WOLFSSH* ssh, WOLFSSH_CTX* ctx)
+{
+    HandshakeInfo* handshake = NULL;
+    RNG*           rng = NULL;
+    void*          heap;
+
+    WLOG(WS_LOG_DEBUG, "Entering SshInit()");
+
+    if (ssh == NULL || ctx == NULL)
+        return ssh;
+    heap = ctx->heap;
+
+    handshake = (HandshakeInfo*)WMALLOC(sizeof(HandshakeInfo),
+                                        heap, DYNTYPE_HS);
+    rng = (RNG*)WMALLOC(sizeof(RNG), heap, DYNTYPE_RNG);
+
+    if (handshake == NULL || rng == NULL || wc_InitRng(rng) != 0) {
+
+        WLOG(WS_LOG_DEBUG, "SshInit: Cannot allocate memory.\n");
+        WFREE(handshake, heap, DYNTYPE_HS);
+        WFREE(rng, heap, DYNTYPE_RNG);
+        wolfSSH_free(ssh);
+        return NULL;
+    }
+
+    WMEMSET(ssh, 0, sizeof(WOLFSSH));  /* default init to zeros */
+    WMEMSET(handshake, 0, sizeof(HandshakeInfo));
+
+    ssh->ctx         = ctx;
+    ssh->error       = WS_SUCCESS;
+    ssh->rfd         = -1;         /* set to invalid */
+    ssh->wfd         = -1;         /* set to invalid */
+    ssh->ioReadCtx   = &ssh->rfd;  /* prevent invalid access if not correctly */
+    ssh->ioWriteCtx  = &ssh->wfd;  /* set */
+    ssh->countHighwater = DEFAULT_COUNT_HIGHWATER;
+    ssh->acceptState = ACCEPT_BEGIN;
+    ssh->clientState = CLIENT_BEGIN;
+    ssh->nextChannel = DEFAULT_NEXT_CHANNEL;
+    ssh->blockSz     = MIN_BLOCK_SZ;
+    ssh->encryptId   = ID_NONE;
+    ssh->macId       = ID_NONE;
+    ssh->peerBlockSz = MIN_BLOCK_SZ;
+    ssh->rng         = rng;
+    ssh->kSz         = sizeof(ssh->k);
+    ssh->handshake   = handshake;
+    handshake->kexId = ID_NONE;
+    handshake->pubKeyId  = ID_NONE;
+    handshake->encryptId = ID_NONE;
+    handshake->macId = ID_NONE;
+    handshake->blockSz = MIN_BLOCK_SZ;
+
+    if (BufferInit(&ssh->inputBuffer, 0, ctx->heap) != WS_SUCCESS ||
+        BufferInit(&ssh->outputBuffer, 0, ctx->heap) != WS_SUCCESS ||
+        wc_InitSha(&ssh->handshake->hash) != 0) {
+
+        wolfSSH_free(ssh);
+        ssh = NULL;
+    }
+
+    return ssh;
+}
+
+
+void SshResourceFree(WOLFSSH* ssh, void* heap)
+{
+    /* when ssh holds resources, free here */
+    (void)heap;
+
+    WLOG(WS_LOG_DEBUG, "Entering sshResourceFree()");
+
+    ShrinkBuffer(&ssh->inputBuffer, 1);
+    ShrinkBuffer(&ssh->outputBuffer, 1);
+    ForceZero(ssh->k, ssh->kSz);
+    if (ssh->handshake) {
+        ForceZero(ssh->handshake, sizeof(HandshakeInfo));
+        WFREE(ssh->handshake, heap, DYNTYPE_HS);
+    }
+    ForceZero(&ssh->clientKeys, sizeof(Keys));
+    ForceZero(&ssh->serverKeys, sizeof(Keys));
+    if (ssh->rng) {
+        wc_FreeRng(ssh->rng);
+        WFREE(ssh->rng, heap, DYNTYPE_RNG);
+    }
+    if (ssh->userName) {
+        WFREE(ssh->userName, heap, DYNTYPE_STRING);
+    }
+    if (ssh->channelList) {
+        WOLFSSH_CHANNEL* cur = ssh->channelList;
+        WOLFSSH_CHANNEL* next;
+        while (cur) {
+            next = cur->next;
+            ChannelDelete(cur, heap);
+            cur = next;
+        }
+    }
+}
+
+
 typedef struct {
     uint8_t id;
     const char* name;

--- a/src/internal.c
+++ b/src/internal.c
@@ -2258,6 +2258,9 @@ static INLINE int Encrypt(WOLFSSH* ssh, uint8_t* cipher, const uint8_t* input,
     }
 
     ssh->txCount += sz;
+    if (ssh->countHighwater && ssh->txCount > ssh->countHighwater) {
+        WLOG(WS_LOG_DEBUG, "Transmit over high water mark");
+    }
 
     return ret;
 }
@@ -2290,6 +2293,9 @@ static INLINE int Decrypt(WOLFSSH* ssh, uint8_t* plain, const uint8_t* input,
     }
 
     ssh->rxCount += sz;
+    if (ssh->countHighwater && ssh->rxCount > ssh->countHighwater) {
+        WLOG(WS_LOG_DEBUG, "Receive over high water mark");
+    }
 
     return ret;
 }

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -155,6 +155,7 @@ static WOLFSSH* SshInit(WOLFSSH* ssh, WOLFSSH_CTX* ctx)
     ssh->wfd         = -1;         /* set to invalid */
     ssh->ioReadCtx   = &ssh->rfd;  /* prevent invalid access if not correctly */
     ssh->ioWriteCtx  = &ssh->wfd;  /* set */
+    ssh->countHighwater = DEFAULT_COUNT_HIGHWATER;
     ssh->acceptState = ACCEPT_BEGIN;
     ssh->clientState = CLIENT_BEGIN;
     ssh->nextChannel = DEFAULT_NEXT_CHANNEL;
@@ -277,6 +278,31 @@ int wolfSSH_get_fd(const WOLFSSH* ssh)
 
     if (ssh)
         return ssh->rfd;
+
+    return WS_BAD_ARGUMENT;
+}
+
+
+int wolfSSH_set_highwater(WOLFSSH* ssh, uint32_t highwater)
+{
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_set_highwater()");
+
+    if (ssh) {
+        ssh->countHighwater = highwater;
+
+        return WS_SUCCESS;
+    }
+
+    return WS_BAD_ARGUMENT;
+}
+
+
+uint32_t wolfSSH_get_highwater(WOLFSSH* ssh)
+{
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_get_highwater()");
+
+    if (ssh)
+        return ssh->countHighwater;
 
     return WS_BAD_ARGUMENT;
 }

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -154,9 +154,9 @@ int wolfSSH_get_fd(const WOLFSSH* ssh)
 }
 
 
-int wolfSSH_set_highwater(WOLFSSH* ssh, uint32_t highwater)
+int wolfSSH_SetHighwater(WOLFSSH* ssh, uint32_t highwater)
 {
-    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_set_highwater()");
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_SetHighwater()");
 
     if (ssh) {
         ssh->countHighwater = highwater;
@@ -168,14 +168,46 @@ int wolfSSH_set_highwater(WOLFSSH* ssh, uint32_t highwater)
 }
 
 
-uint32_t wolfSSH_get_highwater(WOLFSSH* ssh)
+uint32_t wolfSSH_GetHighwater(WOLFSSH* ssh)
 {
-    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_get_highwater()");
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_GetHighwater()");
 
     if (ssh)
         return ssh->countHighwater;
 
-    return WS_BAD_ARGUMENT;
+    return 0;
+}
+
+
+void wolfSSH_SetHighwaterCb(WOLFSSH_CTX* ctx, uint32_t highwater,
+                            WS_CallbackHighwater cb)
+{
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_SetHighwaterCb()");
+
+    if (ctx) {
+        ctx->countHighwater = highwater;
+        ctx->highwaterCb = cb;
+    }
+}
+
+
+void wolfSSH_SetHighwaterCtx(WOLFSSH* ssh, void* ctx)
+{
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_SetHighwaterCtx()");
+
+    if (ssh)
+        ssh->highwaterCtx = ctx;
+}
+
+
+void* wolfSSH_GetHighwaterCtx(WOLFSSH* ssh)
+{
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_GetHighwaterCtx()");
+
+    if (ssh)
+        return ssh->highwaterCtx;
+
+    return NULL;
 }
 
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -139,6 +139,7 @@ struct WOLFSSH_CTX {
     WS_CallbackIORecv   ioRecvCb;    /* I/O Receive Callback */
     WS_CallbackIOSend   ioSendCb;    /* I/O Send Callback */
     WS_CallbackUserAuth userAuthCb;  /* User Authentication Callback */
+    WS_CallbackHighwater highwaterCb; /* Data Highwater Mark Callback */
 
     uint8_t*            cert;        /* Owned by CTX */
     uint32_t            certSz;
@@ -146,6 +147,7 @@ struct WOLFSSH_CTX {
     uint32_t            caCertSz;
     uint8_t*            privateKey;  /* Owned by CTX */
     uint32_t            privateKeySz;
+    uint32_t            countHighwater;
 };
 
 
@@ -195,6 +197,7 @@ struct WOLFSSH {
     uint32_t       txCount;
     uint32_t       rxCount;
     uint32_t       countHighwater;
+    void*          highwaterCtx;
     uint32_t       curSz;
     uint32_t       seq;
     uint32_t       peerSeq;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -154,6 +154,16 @@ typedef struct Ciphers {
 } Ciphers;
 
 
+typedef struct Keys {
+    uint8_t        iv[AES_BLOCK_SIZE];
+    uint8_t        ivSz;
+    uint8_t        encKey[AES_BLOCK_SIZE];
+    uint8_t        encKeySz;
+    uint8_t        macKey[MAX_HMAC_SZ];
+    uint8_t        macKeySz;
+} Keys;
+
+
 typedef struct HandshakeInfo {
     uint8_t        kexId;
     uint8_t        pubKeyId;
@@ -164,6 +174,8 @@ typedef struct HandshakeInfo {
     uint8_t        blockSz;
     uint8_t        macSz;
 
+    Keys           clientKeys;
+    Keys           serverKeys;
     Sha            hash;
     uint8_t        e[257]; /* May have a leading zero, for unsigned. */
     uint32_t       eSz;
@@ -223,19 +235,8 @@ struct WOLFSSH {
     uint8_t        sessionId[SHA_DIGEST_SIZE];
     uint32_t       sessionIdSz;
 
-    uint8_t        ivClient[AES_BLOCK_SIZE];
-    uint8_t        ivClientSz;
-    uint8_t        ivServer[AES_BLOCK_SIZE];
-    uint8_t        ivServerSz;
-    uint8_t        encKeyClient[AES_BLOCK_SIZE];
-    uint8_t        encKeyClientSz;
-    uint8_t        encKeyServer[AES_BLOCK_SIZE];
-    uint8_t        encKeyServerSz;
-    uint8_t        macKeyClient[MAX_HMAC_SZ];
-    uint8_t        macKeyClientSz;
-    uint8_t        macKeyServer[MAX_HMAC_SZ];
-    uint8_t        macKeyServerSz;
-
+    Keys           clientKeys;
+    Keys           serverKeys;
     HandshakeInfo* handshake;
 
     void*          userAuthCtx;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -101,6 +101,7 @@ enum {
 #define MSG_ID_SZ        1
 #define SHA1_96_SZ       12
 #define UINT32_SZ        4
+#define DEFAULT_COUNT_HIGHWATER (1024 * 1024 * 1024)
 #define DEFAULT_WINDOW_SZ     (1024 * 1024)
 #define DEFAULT_MAX_PACKET_SZ (16 * 1024)
 #define DEFAULT_NEXT_CHANNEL  13013

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -262,6 +262,11 @@ struct WOLFSSH_CHANNEL {
 };
 
 
+WOLFSSL_LOCAL WOLFSSH_CTX* CtxInit(WOLFSSH_CTX*, void*);
+WOLFSSL_LOCAL void CtxResourceFree(WOLFSSH_CTX*);
+WOLFSSH_LOCAL WOLFSSH* SshInit(WOLFSSH*, WOLFSSH_CTX*);
+WOLFSSL_LOCAL void SshResourceFree(WOLFSSH*, void*);
+
 WOLFSSH_LOCAL WOLFSSH_CHANNEL* ChannelNew(WOLFSSH*, uint8_t, uint32_t,
                                           uint32_t, uint32_t);
 WOLFSSH_LOCAL void ChannelDelete(WOLFSSH_CHANNEL*, void*);

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -59,8 +59,16 @@ WOLFSSH_API void     wolfSSH_free(WOLFSSH*);
 WOLFSSH_API int  wolfSSH_set_fd(WOLFSSH*, int);
 WOLFSSH_API int  wolfSSH_get_fd(const WOLFSSH*);
 
-WOLFSSH_API int wolfSSH_set_highwater(WOLFSSH*, uint32_t);
-WOLFSSH_API uint32_t wolfSSH_get_highwater(WOLFSSH*);
+/* data high water mark functions */
+WOLFSSH_API int wolfSSH_SetHighwater(WOLFSSH*, uint32_t);
+WOLFSSH_API uint32_t wolfSSH_GetHighwater(WOLFSSH*);
+
+typedef int (*WS_CallbackHighwater)(uint8_t, void*);
+WOLFSSH_API void wolfSSH_SetHighwaterCb(WOLFSSH_CTX*, uint32_t,
+                                        WS_CallbackHighwater);
+WOLFSSH_API void wolfSSH_SetHighwaterCtx(WOLFSSH*, void*);
+WOLFSSH_API void* wolfSSH_GetHighwaterCtx(WOLFSSH*);
+
 
 WOLFSSH_API int wolfSSH_get_error(const WOLFSSH*);
 WOLFSSH_API const char* wolfSSH_get_error_name(const WOLFSSH*);
@@ -133,6 +141,13 @@ WOLFSSH_API int wolfSSH_worker(WOLFSSH*);
 WOLFSSH_API int wolfSSH_KDF(uint8_t, uint8_t, uint8_t*, uint32_t,
                 const uint8_t*, uint32_t, const uint8_t*, uint32_t,
                 const uint8_t*, uint32_t);
+
+
+enum WS_HighwaterSide {
+    WOLFSSH_HWSIDE_TRANSMIT,
+    WOLFSSH_HWSIDE_RECEIVE
+};
+
 
 enum WS_EndpointTypes {
     WOLFSSH_ENDPOINT_SERVER,

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -59,6 +59,9 @@ WOLFSSH_API void     wolfSSH_free(WOLFSSH*);
 WOLFSSH_API int  wolfSSH_set_fd(WOLFSSH*, int);
 WOLFSSH_API int  wolfSSH_get_fd(const WOLFSSH*);
 
+WOLFSSH_API int wolfSSH_set_highwater(WOLFSSH*, uint32_t);
+WOLFSSH_API uint32_t wolfSSH_get_highwater(WOLFSSH*);
+
 WOLFSSH_API int wolfSSH_get_error(const WOLFSSH*);
 WOLFSSH_API const char* wolfSSH_get_error_name(const WOLFSSH*);
 


### PR DESCRIPTION
1. Add in tracking of the number of bytes encrypted and decrypted. Trigger a callback function if the highwater mark is reached in either direction.
2. Refactor the session key storage and use to make re-keying easier to implement.
3. Moved the context and session init and resource free functions from ssh.c to internal.c.