### PR TITLE
Add AES-GCM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Copyright (C) 2014-2017 wolfSSL Inc.
 # All right reserved.
 
-AC_INIT([wolfssh], [1.1.0], [http://wolfssl.com], [wolfssh])
+AC_INIT([wolfssh], [1.2.0], [http://wolfssl.com], [wolfssh])
 AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -17,7 +17,7 @@ AC_ARG_PROGRAM
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([src/config.h])
 
-WOLFSSH_LIBRARY_VERSION=3:0:2
+WOLFSSH_LIBRARY_VERSION=3:1:2
 #                       | | |
 #                +------+ | +---+
 #                |        |     |

--- a/src/internal.c
+++ b/src/internal.c
@@ -382,8 +382,6 @@ static const NameIdPair NameIdMap[] = {
 
     /* Encryption IDs */
     { ID_AES128_CBC, "aes128-cbc" },
-    { ID_AES128_CTR, "aes128-ctr" },
-    { ID_AES128_GCM_WOLF, "aes128-gcm@wolfssl.com" },
 
     /* Integrity IDs */
     { ID_HMAC_SHA1, "hmac-sha1" },
@@ -1109,7 +1107,6 @@ static INLINE uint8_t BlockSzForId(uint8_t id)
 {
     switch (id) {
         case ID_AES128_CBC:
-        case ID_AES128_CTR:
             return AES_BLOCK_SIZE;
         default:
             return 0;
@@ -1141,7 +1138,6 @@ static INLINE uint8_t KeySzForId(uint8_t id)
         case ID_HMAC_SHA2_256:
             return SHA256_DIGEST_SIZE;
         case ID_AES128_CBC:
-        case ID_AES128_CTR:
             return AES_BLOCK_SIZE;
         default:
             return 0;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -62,8 +62,6 @@ enum {
 
     /* Encryption IDs */
     ID_AES128_CBC,
-    ID_AES128_CTR,
-    ID_AES128_GCM_WOLF,
 
     /* Integrity IDs */
     ID_HMAC_SHA1,

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -62,6 +62,7 @@ enum {
 
     /* Encryption IDs */
     ID_AES128_CBC,
+    ID_AES128_GCM,
 
     /* Integrity IDs */
     ID_HMAC_SHA1,
@@ -103,6 +104,9 @@ enum {
 #define UINT32_SZ        4
 #define SSH_PROTO_SZ     7    /* "SSH-2.0" */
 #define SSH_PROTO_EOL_SZ 2    /* Just the CRLF */
+#define AEAD_IMP_IV_SZ   4
+#define AEAD_EXP_IV_SZ   8
+#define AEAD_NONCE_SZ    (AEAD_IMP_IV_SZ+AEAD_EXP_IV_SZ)
 #ifndef DEFAULT_HIGHWATER_MARK
     #define DEFAULT_HIGHWATER_MARK ((1024 * 1024 * 1024) - (32 * 1024))
 #endif
@@ -179,6 +183,7 @@ typedef struct HandshakeInfo {
     uint8_t        macId;
     uint8_t        hashId;
     uint8_t        kexPacketFollows;
+    uint8_t        aeadMode;
 
     uint8_t        blockSz;
     uint8_t        macSz;
@@ -229,10 +234,12 @@ struct WOLFSSH {
     uint8_t        encryptId;
     uint8_t        macId;
     uint8_t        macSz;
+    uint8_t        aeadMode;
     uint8_t        peerBlockSz;
     uint8_t        peerEncryptId;
     uint8_t        peerMacId;
     uint8_t        peerMacSz;
+    uint8_t        peerAeadMode;
 
     Ciphers        encryptCipher;
     Ciphers        decryptCipher;

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -133,7 +133,6 @@ WOLFSSH_API int wolfSSH_stream_read(WOLFSSH*, uint8_t*, uint32_t);
 WOLFSSH_API int wolfSSH_stream_send(WOLFSSH*, uint8_t*, uint32_t);
 WOLFSSH_API int wolfSSH_channel_read(WOLFSSH_CHANNEL*, uint8_t*, uint32_t);
 WOLFSSH_API int wolfSSH_channel_send(WOLFSSH_CHANNEL*, uint8_t*, uint32_t);
-WOLFSSH_API int wolfSSH_worker(WOLFSSH*);
 WOLFSSH_API int wolfSSH_TriggerKeyExchange(WOLFSSH*);
 
 WOLFSSH_API void wolfSSH_GetStats(WOLFSSH*,

--- a/wolfssh/version.h
+++ b/wolfssh/version.h
@@ -33,8 +33,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFSSH_VERSION_STRING "1.1.0"
-#define LIBWOLFSSH_VERSION_HEX 0x01001000
+#define LIBWOLFSSH_VERSION_STRING "1.2.0"
+#define LIBWOLFSSH_VERSION_HEX 0x01002000
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added support for using aes128-gcm as the data cipher and MAC. Used the OpenSSH-style implementation rather than the RFC 5647 implementation. They are the same after the KEX. During KEX, OpenSSH-style implicitly assumes the required MAC rather than negotiating the required MAC.

Also, added option to the echoserver so that it can run with a single incoming connection or with multiple incoming connections. Single connection to assist with memory testing.