### PR TITLE
Channel Close

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -172,6 +172,9 @@ const char* GetErrorString(int err)
         case WS_CHANOPEN_FAILED:
             return "peer returned channel open failure";
 
+        case WS_CHANNEL_CLOSED:
+            return "channel closed";
+
         default:
             return "Unknown error code";
     }
@@ -3517,6 +3520,8 @@ static int DoChannelClose(WOLFSSH* ssh,
     if (ret == WS_SUCCESS)
         ret = ChannelRemove(ssh, channelId, FIND_SELF);
 
+	if (ret == WS_SUCCESS)
+		ret = WS_CHANNEL_CLOSED;
 
     WLOG(WS_LOG_DEBUG, "Leaving DoChannelClose(), ret = %d", ret);
     return ret;

--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -68,10 +68,11 @@ enum WS_ErrorCodes {
     WS_INVALID_USERNAME = -28,
     WS_CRYPTO_FAILED   = -29,   /* crypto action failed */
     WS_INVALID_STATE_E = -30,
-    WS_REKEYING        = -31,
     WS_INVALID_PRIME_CURVE = -32,
     WS_ECC_E           = -33,
-    WS_CHANOPEN_FAILED = -34
+    WS_CHANOPEN_FAILED = -34,
+    WS_REKEYING        = -90,   /* Status: rekey in progress */
+    WS_CHANNEL_CLOSED  = -91    /* Status: channel closed */
 };
 
 


### PR DESCRIPTION
1. Renumbered a few error codes.
2. Added an error code for stream reading when the channel is closed during the read action.