### PR TITLE
Logging

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -82,7 +82,7 @@ void wolfSSH_SetLoggingCb(wolfSSH_LoggingCb logF)
 }
 
 
-INLINE int wolfSSH_LogEnabled(void)
+int wolfSSH_LogEnabled(void)
 {
 #ifdef DEBUG_WOLFSSH
     return logEnable;


### PR DESCRIPTION
Removed the `INLINE` tag from the accessor `wolfSSH_LogEnabled()`, it was causing trouble under Windows.