### PR TITLE
remove hard tabs in DoChannelClose()

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3626,8 +3626,8 @@ static int DoChannelClose(WOLFSSH* ssh,
     if (ret == WS_SUCCESS)
         ret = ChannelRemove(ssh, channelId, FIND_SELF);
 
-	if (ret == WS_SUCCESS)
-		ret = WS_CHANNEL_CLOSED;
+    if (ret == WS_SUCCESS)
+        ret = WS_CHANNEL_CLOSED;
 
     WLOG(WS_LOG_DEBUG, "Leaving DoChannelClose(), ret = %d", ret);
     return ret;


### PR DESCRIPTION
GCC 7.2.0 complains about hard tab here, this PR fixes.

```
src/internal.c: In function ‘DoChannelClose’:
src/internal.c:3668:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
     if (ret == WS_SUCCESS)
     ^~
src/internal.c:3671:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (ret == WS_SUCCESS)
  ^~

```