### PR TITLE
fixes for scan-build warnings

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -589,8 +589,6 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
         byte buf[SCRATCH_BUFFER_SZ];
         word32 bufSz;
 
-        bufName = useEcc ? "./keys/server-key-ecc.der" :
-                           "./keys/server-key-rsa.der" ;
         bufSz = load_key(useEcc, buf, SCRATCH_BUFFER_SZ);
         if (bufSz == 0) {
             fprintf(stderr, "Couldn't load key file.\n");

--- a/src/internal.c
+++ b/src/internal.c
@@ -3350,7 +3350,6 @@ static int DoUserAuthSuccess(WOLFSSH* ssh,
 
 static int DoUserAuthBanner(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
 {
-    word32 begin;
     char banner[80];
     word32 bannerSz = sizeof(banner);
     int ret = WS_SUCCESS;
@@ -3360,16 +3359,13 @@ static int DoUserAuthBanner(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
     if (ssh == NULL || buf == NULL || len == 0 || idx == NULL)
         ret = WS_BAD_ARGUMENT;
 
-    if (ret == WS_SUCCESS) {
-        begin = *idx;
+    if (ret == WS_SUCCESS)
         ret = GetString(banner, &bannerSz, buf, len, idx);
-    }
 
     if (ret == WS_SUCCESS)
         ret = GetUint32(&bannerSz, buf, len, idx);
 
     if (ret == WS_SUCCESS) {
-        begin += bannerSz;
         if (ssh->ctx->showBanner) {
             WLOG(WS_LOG_INFO, "%s", banner);
         }

--- a/src/internal.c
+++ b/src/internal.c
@@ -2104,7 +2104,7 @@ static int DoKexDhReply(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
     }
 
     /* If using DH-GEX include the GEX specific values. */
-    if (ssh->handshake->kexId == ID_DH_GEX_SHA256) {
+    if (ret == WS_SUCCESS && ssh->handshake->kexId == ID_DH_GEX_SHA256) {
         byte primeGroupPad = 0, generatorPad = 0;
 
         /* Hash in the client's requested minimum key size. */
@@ -4715,12 +4715,14 @@ int SendKexInit(WOLFSSH* ssh)
     if (ssh == NULL)
         ret = WS_BAD_ARGUMENT;
 
-    ssh->isKeying = 1;
-    if (ssh->handshake == NULL) {
-        ssh->handshake = HandshakeInfoNew(ssh->ctx->heap);
+    if (ret == WS_SUCCESS) {
+        ssh->isKeying = 1;
         if (ssh->handshake == NULL) {
-            WLOG(WS_LOG_DEBUG, "Couldn't allocate handshake info");
-            ret = WS_MEMORY_E;
+            ssh->handshake = HandshakeInfoNew(ssh->ctx->heap);
+            if (ssh->handshake == NULL) {
+                WLOG(WS_LOG_DEBUG, "Couldn't allocate handshake info");
+                ret = WS_MEMORY_E;
+            }
         }
     }
 
@@ -6443,7 +6445,7 @@ int SendChannelEow(WOLFSSH* ssh, word32 peerChannelId)
     if (ssh == NULL)
         ret = WS_BAD_ARGUMENT;
 
-    if (!ssh->clientOpenSSH) {
+    if (ret == WS_SUCCESS && !ssh->clientOpenSSH) {
         WLOG(WS_LOG_DEBUG, "Leaving SendChannelEow(), not OpenSSH");
         return ret;
     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -4011,7 +4011,6 @@ static int DoPacket(WOLFSSH* ssh)
         case MSGID_CHANNEL_EOF:
             WLOG(WS_LOG_DEBUG, "Decoding MSGID_CHANNEL_EOF");
             ret = DoChannelEof(ssh, buf + idx, payloadSz, &payloadIdx);
-            ret = WS_SUCCESS;
             break;
 
         case MSGID_CHANNEL_CLOSE:


### PR DESCRIPTION
Fixes for scan-build warnings that showed up with:

```
$ clang --version
Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin13.4.0
Thread model: posix
```