### PR TITLE
Error Code Unit Test

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -71,9 +71,6 @@ const char* GetErrorString(int err)
     return "No wolfSSH strings available";
 #else
     switch (err) {
-        case WS_SUCCESS:
-            return "function success";
-
         case WS_FATAL_ERROR:
             return "general function failure";
 
@@ -131,6 +128,9 @@ const char* GetErrorString(int err)
         case WS_BAD_FILE_E:
             return "bad file";
 
+        case WS_INVALID_ALGO_ID:
+            return "invalid algorithm id";
+
         case WS_DECRYPT_E:
             return "decrypt error";
 
@@ -141,7 +141,7 @@ const char* GetErrorString(int err)
             return "verify mac error";
 
         case WS_CREATE_MAC_E:
-            return "verify mac error";
+            return "create mac error";
 
         case WS_RESOURCE_E:
             return "insufficient resources for new channel";
@@ -160,6 +160,9 @@ const char* GetErrorString(int err)
 
         case WS_INVALID_STATE_E:
             return "invalid state";
+
+        case WS_EOF:
+            return "end of file";
 
         case WS_REKEYING:
             return "rekeying with peer";

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -241,6 +241,14 @@ const char* wolfSSH_get_error_name(const WOLFSSH* ssh)
 }
 
 
+const char* wolfSSH_ErrorToName(int err)
+{
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_ErrorToName()");
+
+    return GetErrorString(err);
+}
+
+
 const char acceptError[] = "accept error: %s, %d";
 const char acceptState[] = "accept state: %s";
 

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -379,9 +379,66 @@ static int test_RsaKeyGen(void)
 #endif
 
 
+/* Error Code And Message Test */
+
+static int test_Errors(void)
+{
+    const char* errStr;
+    const char* unknownStr = wolfSSH_ErrorToName(1);
+    int result = 0;
+
+#ifdef NO_WOLFSSH_STRINGS
+    /* Ensure a valid error code's string matches an invalid code's.
+     * The string is that error strings are not available.
+     */
+    errStr = wolfSSH_ErrorToName(WS_BAD_ARGUMENT);
+    if (errStr != unknownStr)
+        result = -104;
+#else
+    int i, j = 0;
+    /* Values that are not or no longer error codes. */
+    int missing[] = { WS_SUCCESS };
+
+    /* Check that all errors have a string and it's the same through the two
+     * APIs. Check that the values that are not errors map to the unknown
+     * string.  */
+    for (i = WS_SUCCESS; i >= WS_LAST_E; i--) {
+        errStr = wolfSSH_ErrorToName(i);
+
+        if (i != missing[j]) {
+            if (errStr == unknownStr) {
+                result = -105;
+                break;
+            }
+        }
+        else {
+            j++;
+            if (errStr != unknownStr) {
+                result = -106;
+                break;
+            }
+        }
+    }
+
+    /* Check if the next possible value has been given a string. */
+    if (result == 0) {
+        errStr = wolfSSH_ErrorToName(i);
+        if (errStr != unknownStr)
+            return -107;
+    }
+#endif
+
+    return result;
+}
+
+
 int main(void)
 {
     int testResult = 0, unitResult = 0;
+
+    unitResult = test_Errors();
+    printf("Errors: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));
+    testResult = testResult || unitResult;
 
     unitResult = test_KDF();
     printf("KDF: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));

--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -72,8 +72,10 @@ enum WS_ErrorCodes {
     WS_INVALID_PRIME_CURVE = -32,
     WS_ECC_E           = -33,
     WS_CHANOPEN_FAILED = -34,
-    WS_REKEYING        = -90,   /* Status: rekey in progress */
-    WS_CHANNEL_CLOSED  = -91    /* Status: channel closed */
+    WS_REKEYING        = -35,   /* Status: rekey in progress */
+    WS_CHANNEL_CLOSED  = -36,   /* Status: channel closed */
+
+    WS_LAST_E          = -36    /* Update this to indicate last error */
 };
 
 

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -78,6 +78,7 @@ WOLFSSH_API void* wolfSSH_GetHighwaterCtx(WOLFSSH*);
 
 WOLFSSH_API int wolfSSH_get_error(const WOLFSSH*);
 WOLFSSH_API const char* wolfSSH_get_error_name(const WOLFSSH*);
+WOLFSSH_API const char* wolfSSH_ErrorToName(int);
 
 /* I/O callbacks */
 typedef int (*WS_CallbackIORecv)(WOLFSSH*, void*, word32, void*);


### PR DESCRIPTION
1. Add a unit test to check all error codes have strings.
2. Add public function to return the error string for an error code.
3. Fill in the missing error strings.