### PR TITLE
fix spacing on certs_test.h license header

### DIFF
--- a/wolfssh/certs_test.h
+++ b/wolfssh/certs_test.h
@@ -1,22 +1,22 @@
 /* certs_test.h
-*
-* Copyright (C) 2014-2018 wolfSSL Inc.
-*
-* This file is part of wolfSSH.
-*
-* wolfSSH is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 3 of the License, or
-* (at your option) any later version.
-*
-* wolfSSH is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *
+ * Copyright (C) 2014-2018 wolfSSL Inc.
+ *
+ * This file is part of wolfSSH.
+ *
+ * wolfSSH is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef WOLFSSL_CERTS_TEST_H
 #define WOLFSSL_CERTS_TEST_H


### PR DESCRIPTION
This PR fixes the license header spacing on wolfssh/certs_test.h so that our license replacement script picks it up correctly.