### PR TITLE
Scan Build Fixes

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -746,6 +746,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
 
         ssh = wolfSSH_new(ctx);
         if (ssh == NULL) {
+            free(threadCtx);
             fprintf(stderr, "Couldn't allocate SSH data.\n");
             exit(EXIT_FAILURE);
         }

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -317,7 +317,7 @@ static int test_KDF(void)
     byte* h = NULL;
     byte* sId = NULL;
     byte* eKey = NULL;
-    word32 kSz, hSz, sIdSz, eKeySz;
+    word32 kSz = 0, hSz = 0, sIdSz = 0, eKeySz = 0;
     byte cKey[32]; /* Greater of SHA256_DIGEST_SIZE and AES_BLOCK_SIZE */
     /* sId - Session ID, eKey - Expected Key, cKey - Calculated Key */
 
@@ -347,6 +347,10 @@ static int test_KDF(void)
         }
 
         FreeBins(k, h, sId, eKey);
+        k = NULL;
+        h = NULL;
+        sId = NULL;
+        eKey = NULL;
 
         if (result != 0) break;
     }


### PR DESCRIPTION
1. In the echoserver, free the thread context before exiting app on error.
2. In the unit test, when checking the KDF, initialize the sizes to zero
and the pointers to NULL after freeing them.