### PR TITLE
Enable All for Configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,13 +81,6 @@ AC_ARG_ENABLE([inline],
     [AS_HELP_STRING([--disable-inline],[Enable inline functions (default: enabled)])],
     [ENABLED_INLINE=$enableval],[ENABLED_INLINE=yes])
 
-if test "$ENABLED_INLINE" = "no"
-then
-    AM_CPPFLAGS="$AM_CPPFLAGS -DNO_INLINE"
-fi
-
-AM_CONDITIONAL([BUILD_INLINE], [test "x$ENABLED_INLINE" = "xyes"])
-
 # Key Generation
 AC_ARG_ENABLE([keygen],
     [AS_HELP_STRING([--enable-keygen],[Enable key generation (default: disabled)])],
@@ -108,6 +101,20 @@ AC_ARG_ENABLE([fwd],
     [AS_HELP_STRING([--enable-fwd],[Enable TCP/IP Forwarding support (default: disabled)])],
     [ENABLED_FWD=$enableval],[ENABLED_FWD=no])
 
+# Enable All
+AC_ARG_ENABLE([all],
+    [AS_HELP_STRING([--enable-all],[Enable all wolfSSH features (default: disabled)])],
+    [ENABLED_ALL=$enableval],[ENABLED_ALL=no])
+
+# Distro build
+AC_ARG_ENABLE([distro],
+    [AS_HELP_STRING([--enable-distro],[Enable wolfSSH distro build (default: disabled)])],
+    [ENABLED_DISTRO=$enableval],[ENABLED_DISTRO=no])
+
+AS_IF([test "x$ENABLED_DISTRO" = "xyes"],
+      [ENABLED_ALL=yes; enable_shared=yes; enable_static=yes])
+AS_IF([test "x$ENABLED_ALL" = "xyes"],
+      [ENABLED_KEYGEN=yes; ENABLED_SCP=yes; ENABLED_SFTP=yes; ENABLED_FWD=yes])
 AS_IF([test "x$ENABLED_INLINE" = "xno"],
       [AM_CPPFLAGS="$AM_CPPFLAGS -DNO_INLINE"])
 AS_IF([test "x$ENABLED_KEYGEN" = "xyes"],
@@ -172,4 +179,4 @@ echo "   * keygen:                    $ENABLED_KEYGEN"
 echo "   * scp:                       $ENABLED_SCP"
 echo "   * sftp:                      $ENABLED_SFTP"
 echo "   * TCP/IP Forwarding:         $ENABLED_FWD"
-
+echo "   * Inline Code:               $ENABLED_INLINE"

--- a/scripts/commit-tests.sh
+++ b/scripts/commit-tests.sh
@@ -1,24 +1,42 @@
 #!/bin/sh
 
-#commit-tests.sh
-
+# commit-tests.sh
 
 # make sure current config is ok
-echo -e "\n\nTesting current config...\n\n"
-make clean; make -j 8 check;
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nCurrent config make test failed" && exit 1
+echo "Testing current config..."
+if ! make clean check
+then
+    echo "Current config make test failed"
+    exit 1
+fi
 
 
 # make sure basic config is ok
-echo -e "\n\nTesting basic config too...\n\n"
-./configure;
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nBasic config ./configure failed" && exit 1
+echo "Testing basic config..."
+if ! ./configure
+then
+    echo "Basic config ./configure failed"
+    exit 1
+fi
 
-make -j 8 check;
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nBasic config make test failed" && exit 1
+if ! make check
+then
+    echo "Basic config make test failed"
+    exit 1
+fi
 
+# make sure the all enabled config is ok
+echo "Testing enabled all config..."
+if ! ./configure --enable-all
+then
+    echo "Enabled all config ./configure failed"
+    exit 1
+fi
+
+if ! make check
+then
+    echo "Enabled all config make test failed"
+    exit 1
+fi
 
 exit 0


### PR DESCRIPTION
1. Add enable options for "all" and "distro". all enables all options.
distro enables all and turns on both shared and static library builds.
2. Updated the commit-tests script to perform a check on enable-all as well.
3. Made a few syntactical changes to commit-tests.