### PR TITLE
gcc-7 build fall through warning

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4732,7 +4732,8 @@ int DoReceive(WOLFSSH* ssh)
                         return ret;
                     }
                 }
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case PROCESS_PACKET_LENGTH:
                 if (ssh->inputBuffer.idx + UINT32_SZ > ssh->inputBuffer.bufferSz)
@@ -4745,7 +4746,8 @@ int DoReceive(WOLFSSH* ssh)
                     return WS_OVERFLOW_E;
 
                 ssh->processReplyState = PROCESS_PACKET_FINISH;
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case PROCESS_PACKET_FINISH:
                 readSz = ssh->curSz + LENGTH_SZ + peerMacSz;
@@ -4811,7 +4813,8 @@ int DoReceive(WOLFSSH* ssh)
                     }
                 }
                 ssh->processReplyState = PROCESS_PACKET;
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case PROCESS_PACKET:
                 ret = DoPacket(ssh);

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -275,7 +275,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_SERVER_VERSION_SENT;
                 WLOG(WS_LOG_DEBUG, acceptState, "SERVER_VERSION_SENT");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_SERVER_VERSION_SENT:
                 while (ssh->clientState < CLIENT_VERSION_DONE) {
@@ -287,7 +288,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_CLIENT_VERSION_DONE;
                 WLOG(WS_LOG_DEBUG, acceptState, "CLIENT_VERSION_DONE");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_CLIENT_VERSION_DONE:
                 if ( (ssh->error = SendKexInit(ssh)) < WS_SUCCESS) {
@@ -297,7 +299,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_SERVER_KEXINIT_SENT;
                 WLOG(WS_LOG_DEBUG, acceptState, "SERVER_KEXINIT_SENT");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_SERVER_KEXINIT_SENT:
                 while (ssh->isKeying) {
@@ -309,7 +312,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_KEYED;
                 WLOG(WS_LOG_DEBUG, acceptState, "KEYED");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_KEYED:
                 while (ssh->clientState < CLIENT_USERAUTH_REQUEST_DONE) {
@@ -321,7 +325,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_CLIENT_USERAUTH_REQUEST_DONE;
                 WLOG(WS_LOG_DEBUG, acceptState, "CLIENT_USERAUTH_REQUEST_DONE");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_CLIENT_USERAUTH_REQUEST_DONE:
                 if ( (ssh->error = SendServiceAccept(ssh,
@@ -333,7 +338,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 ssh->acceptState = ACCEPT_SERVER_USERAUTH_ACCEPT_SENT;
                 WLOG(WS_LOG_DEBUG, acceptState,
                      "ACCEPT_SERVER_USERAUTH_ACCEPT_SENT");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_SERVER_USERAUTH_ACCEPT_SENT:
                 while (ssh->clientState < CLIENT_USERAUTH_DONE) {
@@ -345,7 +351,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_CLIENT_USERAUTH_DONE;
                 WLOG(WS_LOG_DEBUG, acceptState, "CLIENT_USERAUTH_DONE");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_CLIENT_USERAUTH_DONE:
                 if ( (ssh->error = SendUserAuthSuccess(ssh)) < WS_SUCCESS) {
@@ -355,7 +362,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_SERVER_USERAUTH_SENT;
                 WLOG(WS_LOG_DEBUG, acceptState, "SERVER_USERAUTH_SENT");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_SERVER_USERAUTH_SENT:
                 while (ssh->clientState < CLIENT_CHANNEL_OPEN_DONE) {
@@ -367,7 +375,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_CLIENT_CHANNEL_REQUEST_DONE;
                 WLOG(WS_LOG_DEBUG, acceptState, "CLIENT_CHANNEL_REQUEST_DONE");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_CLIENT_CHANNEL_REQUEST_DONE:
                 if ( (ssh->error = SendChannelOpenConf(ssh)) < WS_SUCCESS) {
@@ -377,7 +386,8 @@ int wolfSSH_accept(WOLFSSH* ssh)
                 }
                 ssh->acceptState = ACCEPT_SERVER_CHANNEL_ACCEPT_SENT;
                 WLOG(WS_LOG_DEBUG, acceptState, "SERVER_CHANNEL_ACCEPT_SENT");
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
 
             case ACCEPT_SERVER_CHANNEL_ACCEPT_SENT:
                 while (ssh->clientState < CLIENT_DONE) {
@@ -445,7 +455,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_CLIENT_VERSION_SENT;
             WLOG(WS_LOG_DEBUG, connectState, "CLIENT_VERSION_SENT");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_CLIENT_VERSION_SENT:
             while (ssh->serverState < SERVER_VERSION_DONE) {
@@ -457,7 +468,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_SERVER_VERSION_DONE;
             WLOG(WS_LOG_DEBUG, connectState, "SERVER_VERSION_DONE");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_SERVER_VERSION_DONE:
             if ( (ssh->error = SendKexInit(ssh)) < WS_SUCCESS) {
@@ -467,7 +479,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_CLIENT_KEXINIT_SENT;
             WLOG(WS_LOG_DEBUG, connectState, "CLIENT_KEXINIT_SENT");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_CLIENT_KEXINIT_SENT:
             while (ssh->serverState < SERVER_KEXINIT_DONE) {
@@ -479,7 +492,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_SERVER_KEXINIT_DONE;
             WLOG(WS_LOG_DEBUG, connectState, "SERVER_KEXINIT_DONE");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_SERVER_KEXINIT_DONE:
             if (ssh->handshake->kexId == ID_DH_GEX_SHA256)
@@ -493,7 +507,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_CLIENT_KEXDH_INIT_SENT;
             WLOG(WS_LOG_DEBUG, connectState, "CLIENT_KEXDH_INIT_SENT");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_CLIENT_KEXDH_INIT_SENT:
             while (ssh->isKeying) {
@@ -505,7 +520,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_KEYED;
             WLOG(WS_LOG_DEBUG, connectState, "KEYED");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_KEYED:
             if ( (ssh->error = SendServiceRequest(ssh, ID_SERVICE_USERAUTH)) <
@@ -515,7 +531,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_CLIENT_USERAUTH_REQUEST_SENT;
             WLOG(WS_LOG_DEBUG, connectState, "CLIENT_USERAUTH_REQUEST_SENT");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_CLIENT_USERAUTH_REQUEST_SENT:
             while (ssh->serverState < SERVER_USERAUTH_REQUEST_DONE) {
@@ -527,7 +544,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_SERVER_USERAUTH_REQUEST_DONE;
             WLOG(WS_LOG_DEBUG, connectState, "SERVER_USERAUTH_REQUEST_DONE");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_SERVER_USERAUTH_REQUEST_DONE:
             if ( (ssh->error = SendUserAuthRequest(ssh, ID_NONE)) <
@@ -538,7 +556,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_CLIENT_USERAUTH_SENT;
             WLOG(WS_LOG_DEBUG, connectState, "CLIENT_USERAUTH_SENT");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_CLIENT_USERAUTH_SENT:
             while (ssh->serverState < SERVER_USERAUTH_ACCEPT_DONE) {
@@ -550,7 +569,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             }
             ssh->connectState = CONNECT_SERVER_USERAUTH_ACCEPT_DONE;
             WLOG(WS_LOG_DEBUG, connectState, "SERVER_USERAUTH_ACCEPT_DONE");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_SERVER_USERAUTH_ACCEPT_DONE:
             {
@@ -577,7 +597,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             ssh->connectState = CONNECT_CLIENT_CHANNEL_OPEN_SESSION_SENT;
             WLOG(WS_LOG_DEBUG, connectState,
                  "CLIENT_CHANNEL_OPEN_SESSION_SENT");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_CLIENT_CHANNEL_OPEN_SESSION_SENT:
             while (ssh->serverState < SERVER_CHANNEL_OPEN_DONE) {
@@ -590,7 +611,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             ssh->connectState = CONNECT_SERVER_CHANNEL_OPEN_SESSION_DONE;
             WLOG(WS_LOG_DEBUG, connectState,
                  "SERVER_CHANNEL_OPEN_SESSION_DONE");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_SERVER_CHANNEL_OPEN_SESSION_DONE:
             if ( (ssh->error = SendChannelRequest(ssh, ssh->channelName,
@@ -602,7 +624,8 @@ int wolfSSH_connect(WOLFSSH* ssh)
             ssh->connectState = CONNECT_CLIENT_CHANNEL_REQUEST_SENT;
             WLOG(WS_LOG_DEBUG, connectState,
                  "CLIENT_CHANNEL_REQUEST_SENT");
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case CONNECT_CLIENT_CHANNEL_REQUEST_SENT:
             while (ssh->serverState < SERVER_DONE) {

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -1241,7 +1241,8 @@ int ReceiveScpMessage(WOLFSSH* ssh)
 
     switch (buf[0]) {
         case 'C':
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case 'D':
             if (buf[0] == 'C') {
@@ -1349,7 +1350,8 @@ int SendScpConfirmation(WOLFSSH* ssh)
 
         case WS_SCP_CONTINUE:
             /* default to ok confirmation */
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         default:
             msg[0] = SCP_CONFIRM_OK;
@@ -1400,9 +1402,11 @@ int ReceiveScpConfirmation(WOLFSSH* ssh)
             case SCP_CONFIRM_OK:
                 break;
             case SCP_CONFIRM_ERR:
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
             case SCP_CONFIRM_FATAL:
-                FALL_THROUGH /* no break */
+                FALL_THROUGH;
+                /* no break */
             default:
                 WLOG(WS_LOG_ERROR,
                      "scp error: peer sent error confirmation (code: %d)",

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -202,7 +202,8 @@ int wolfSSH_SFTP_accept(WOLFSSH* ssh)
                 return WS_FATAL_ERROR;
             }
             ssh->connectState = SFTP_RECV;
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case SFTP_RECV:
             if ((ssh->error = SFTP_ServerSendInit(ssh)) != WS_SUCCESS) {
@@ -2540,7 +2541,8 @@ int wolfSSH_SFTP_connect(WOLFSSH* ssh)
                 return WS_FATAL_ERROR;
             }
             ssh->connectState = SFTP_RECV;
-            FALL_THROUGH /* no break */
+            FALL_THROUGH;
+            /* no break */
 
         case SFTP_RECV:
             if ((ssh->error = SFTP_ClientRecvInit(ssh)) != WS_SUCCESS) {

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -473,9 +473,9 @@ extern "C" {
 
 
 /* GCC 7 has new switch() fall-through detection */
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(FALL_THROUGH)
     #if ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
-        #define FALL_THROUGH __attribute__ ((fallthrough));
+        #define FALL_THROUGH __attribute__ ((fallthrough))
     #endif
 #endif
 #ifndef FALL_THROUGH


### PR DESCRIPTION
changes "FALL_THROUGH" to be "FALL_THROUGH;" matching wolfSSL and checks if FALL_THROUGH is already defined in gcc-7 case.