### PR TITLE
use int type for getting example args

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -195,7 +195,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     socklen_t clientAddrSz = sizeof(clientAddr);
     char rxBuf[80];
     int ret;
-    char ch;
+    int ch;
     word16 port = wolfSshPort;
     char* host = (char*)wolfSshIp;
     const char* username = NULL;

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -599,7 +599,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
     word32 threadCount = 0;
     int multipleConnections = 1;
     int useEcc = 0;
-    char ch;
+    int ch;
     word16 port = wolfSshPort;
     char* readyFile = NULL;
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -565,7 +565,7 @@ THREAD_RETURN WOLFSSH_THREAD server_test(void* args)
     word16 port = wolfSshPort;
     char multipleConnections = 0;
     char useEcc = 0;
-    char ch;
+    int  ch;
     char nonBlock = 0;
 
     int     argc = ((func_args*)args)->argc;

--- a/examples/wolffwd/wolffwd.c
+++ b/examples/wolffwd/wolffwd.c
@@ -217,7 +217,7 @@ THREAD_RETURN WOLFSSH_THREAD wolffwd_worker(void* args)
     fd_set errFds;
     int nFds;
     int ret;
-    char ch;
+    int ch;
     int appFdSet = 0;
     struct timeval to;
     WOLFSSH_CHANNEL* fwdChannel = NULL;

--- a/wolfsftp/client/sftpclient.c
+++ b/wolfsftp/client/sftpclient.c
@@ -788,7 +788,7 @@ THREAD_RETURN WOLFSSH_THREAD sftpclient_test(void* args)
     SOCKADDR_IN_T clientAddr;
     socklen_t clientAddrSz = sizeof(clientAddr);
     int ret;
-    char ch;
+    int ch;
     word16 port = wolfSshPort;
     char* host = (char*)wolfSshIp;
     const char* username = NULL;


### PR DESCRIPTION
On a raspberry pi the default for "char" type is unsigned. i.e. -1 = 255. This changes the type in the examples to "int" for catching a -1 return value.

Fix for issue https://github.com/wolfSSL/wolfssh/issues/124