### PR TITLE
Build Cleanup

### DIFF
--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1151,7 +1151,9 @@ THREAD_RETURN WOLFSSH_THREAD sftpclient_test(void* args)
         args.argv = argv;
         args.return_code = 0;
         args.user_auth = NULL;
-        args.sftp_cb   = NULL;
+        #ifdef WOLFSSH_SFTP
+            args.sftp_cb = NULL;
+        #endif
 
         WSTARTTCP();
 

--- a/ide/winvs/README.md
+++ b/ide/winvs/README.md
@@ -16,6 +16,14 @@ names:
         wolfssl\
 
 
+The file `wolfssh\ide\winvs\user_settings.h` contains the settings used to
+configure wolfSSL with the appropriate settings. This file must be copied
+from the directory `wolfssh\ide\winvs` to `wolfssl\IDE\WIN`. If you change
+one copy you must change both copies. The option `WOLFCRYPT_ONLY` disables
+the build of the wolfSSL files and only builds the wolfCrypt algorithms. To
+also keep wolfSSL, delete that option.
+
+
 User Macros
 -----------
 


### PR DESCRIPTION
1. Update the Windows build README.
2. Add a guard to the sftpclient.c so it builds without SFTP enabled.