### PR TITLE
Memory

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -393,10 +393,17 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     char**  argv = ((func_args*)args)->argv;
     ((func_args*)args)->return_code = 0;
 
-    while ((ch = mygetopt(argc, argv, "?NP:h:p:u:xc:Rt")) != -1) {
+    while ((ch = mygetopt(argc, argv, "?NP:h:p:u:xc:Rtz")) != -1) {
         switch (ch) {
             case 'h':
                 host = myoptarg;
+                break;
+
+            case 'z':
+            #ifdef WOLFSSH_SHOW_SIZES
+                wolfSSH_ShowSizes();
+                exit(EXIT_SUCCESS);
+            #endif
                 break;
 
             case 'p':

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1521,3 +1521,26 @@ void wolfSSH_CheckReceivePending(WOLFSSH* ssh)
         WIOCTL(wolfSSH_get_fd(ssh), FIONREAD, &bytes);
     }
 }
+
+
+#ifdef WOLFSSH_SHOW_SIZES
+
+void wolfSSH_ShowSizes(void)
+{
+    fprintf(stderr, "wolfSSH struct sizes:\n");
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WOLFSSH_CTX",
+            (word32)sizeof(struct WOLFSSH_CTX));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WOLFSSH",
+            (word32)sizeof(struct WOLFSSH));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "HandshakeInfo",
+            (word32)sizeof(struct HandshakeInfo));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WOLFSSH_CHANNEL",
+            (word32)sizeof(struct WOLFSSH_CHANNEL));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "Buffer",
+            (word32)sizeof(struct Buffer));
+    #ifdef WOLFSSH_SFTP
+        wolfSSH_SFTP_ShowSizes();
+    #endif
+}
+
+#endif /* WOLFSSH_SHOW_SIZES */

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -7384,4 +7384,52 @@ int wolfSSH_SFTP_free(WOLFSSH* ssh)
     return WS_SUCCESS;
 }
 
+
+#ifdef WOLFSSH_SHOW_SIZES
+
+void wolfSSH_SFTP_ShowSizes(void)
+{
+    fprintf(stderr, "wolfSFTP struct sizes:\n");
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_CHMOD_STATE",
+            (word32)sizeof(struct WS_SFTP_CHMOD_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_SETATR_STATE",
+            (word32)sizeof(struct WS_SFTP_SETATR_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_LSTAT_STATE",
+            (word32)sizeof(struct WS_SFTP_LSTAT_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_OPEN_STATE",
+            (word32)sizeof(struct WS_SFTP_OPEN_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_NAME_STATE",
+            (word32)sizeof(struct WS_SFTP_NAME_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_SEND_STATE",
+            (word32)sizeof(struct WS_SFTP_SEND_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_READDIR_STATE",
+            (word32)sizeof(struct WS_SFTP_READDIR_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_RM_STATE",
+            (word32)sizeof(struct WS_SFTP_RM_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_MKDIR_STATE",
+            (word32)sizeof(struct WS_SFTP_MKDIR_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_RMDIR_STATE",
+            (word32)sizeof(struct WS_SFTP_RMDIR_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_RECV_STATE",
+            (word32)sizeof(struct WS_SFTP_RECV_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_LS_STATE",
+            (word32)sizeof(struct WS_SFTP_LS_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_GET_STATE",
+            (word32)sizeof(struct WS_SFTP_GET_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_PUT_STATE",
+            (word32)sizeof(struct WS_SFTP_PUT_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_SEND_READ_STATE",
+            (word32)sizeof(struct WS_SFTP_SEND_READ_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_SEND_WRITE_STATE",
+            (word32)sizeof(struct WS_SFTP_SEND_WRITE_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_CLOSE_STATE",
+            (word32)sizeof(struct WS_SFTP_CLOSE_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_GET_HANDLE_STATE",
+            (word32)sizeof(struct WS_SFTP_GET_HANDLE_STATE));
+    fprintf(stderr, "  sizeof(struct %s) = %u\n", "WS_SFTP_RENAME_STATE",
+            (word32)sizeof(struct WS_SFTP_RENAME_STATE));
+}
+
+#endif /* WOLFSSH_SHOW_SIZES */
+
 #endif /* WOLFSSH_SFTP */

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -251,6 +251,9 @@ enum WS_DisconnectReasonCodes {
 };
 
 
+WOLFSSH_API void wolfSSH_ShowSizes(void);
+
+
 #ifndef WOLFSSH_MAX_FILENAME
     #define WOLFSSH_MAX_FILENAME 256
 #endif

--- a/wolfssh/wolfsftp.h
+++ b/wolfssh/wolfsftp.h
@@ -236,6 +236,7 @@ WOLFSSL_LOCAL int wolfSSH_SFTP_free(WOLFSSH* ssh);
 WOLFSSL_LOCAL int SFTP_AddHandleNode(WOLFSSH* ssh, byte* handle, word32 handleSz, char* name);
 WOLFSSL_LOCAL int SFTP_RemoveHandleNode(WOLFSSH* ssh, byte* handle, word32 handleSz);
 
+WOLFSSH_LOCAL void wolfSSH_SFTP_ShowSizes(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. Added an option to the echo server, z, to print out the sizes of several structures. The option is disabled at build by default.
2. Fixed a bug where getting a file listing with LS would fail when the window size was set to 2048 bytes. Had to add a false non-blocking would-block return when handling the directory listing from the peer.