### PR TITLE
Refactor Packet Assembly

### DIFF
--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -298,7 +298,6 @@ struct WOLFSSH {
     word32 seq;
     word32 peerSeq;
     word32 packetStartIdx; /* Current send packet start index */
-    byte paddingSz;        /* Current send packet padding size */
     byte acceptState;
     byte connectState;
     byte clientState;


### PR DESCRIPTION
1. PreparePacket() is to be given an estimated payloadSz, not the actual
payloadSz. The payloadSz should be larger or equal to the actual.
2. BuildPacket() calculates the actual payloadSz based on the position
of idx and value of idx stored before PreparePacket() returns. The size
of the padding is also calculated at this point.

Currently, everything going into a packet needs to be calculated ahead
of time and saved locally until the output buffer is prepared. This
requires saving RSA and ECDSA signatures in large buffers to be copied
later. Now such things can be calculated directly into the output buffer
without the temporary storage and copy.