### PR TITLE
Fixes for Cygwin build

### DIFF
--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -607,10 +607,14 @@ extern "C" {
 #elif defined(USE_WINDOWS_API)
     #define WIOCTL ioctlsocket
 #else
+    #if defined(__CYGWIN__) && !defined(FIONREAD)
+        /* Cygwin defines FIONREAD in socket.h instead of ioctl.h */
+        #include <sys/socket.h>
+    #endif
     #include <sys/ioctl.h>
     #define WIOCTL ioctl
 #endif
-#endif
+#endif /* WIOCTL */
 
 
 #if defined(USE_WINDOWS_API)

--- a/wolfssh/visibility.h
+++ b/wolfssh/visibility.h
@@ -40,25 +40,25 @@ extern "C" {
 */
 
 #if defined(BUILDING_WOLFSSH)
-    #if defined(HAVE_VISIBILITY) && HAVE_VISIBILITY
-        #define WOLFSSH_API   __attribute__ ((visibility("default")))
-        #define WOLFSSH_LOCAL __attribute__ ((visibility("hidden")))
-    #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x550)
-        #define WOLFSSH_API   __global  
-        #define WOLFSSH_LOCAL __hidden
-    #elif defined(_MSC_VER)
+    #if defined(_MSC_VER) || defined(__CYGWIN__)
         #ifdef WOLFSSH_DLL
             #define WOLFSSH_API extern __declspec(dllexport)
         #else
             #define WOLFSSH_API
         #endif
         #define WOLFSSH_LOCAL
+    #elif defined(HAVE_VISIBILITY) && HAVE_VISIBILITY
+        #define WOLFSSH_API   __attribute__ ((visibility("default")))
+        #define WOLFSSH_LOCAL __attribute__ ((visibility("hidden")))
+    #elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x550)
+        #define WOLFSSH_API   __global
+        #define WOLFSSH_LOCAL __hidden
     #else
         #define WOLFSSH_API
         #define WOLFSSH_LOCAL
     #endif /* HAVE_VISIBILITY */
 #else /* BUILDING_WOLFSSH */
-    #if defined(_MSC_VER)
+    #if defined(_MSC_VER) || defined(__CYGWIN__)
         #ifdef WOLFSSH_DLL
             #define WOLFSSH_API extern __declspec(dllimport)
         #else


### PR DESCRIPTION
This PR fixes two issues with building wolfSSH on Cygwin:

1.  FIONREAD was undefined, Cygwin defines it in <sys/socket.h> instead of <sys/ioctl.h>

2.  Visibility warnings.  Added a check for \_\_CYGWIN\_\_ in visibility.h and rearranged slightly.  These were fixed in wolfSSL proper with https://github.com/wolfSSL/wolfssl/pull/2253