### PR TITLE
SFTP port to MQX 4.2 (MQX/MFS/RTCS)

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8707,7 +8707,7 @@ int wolfSSH_oct2dec(WOLFSSH* ssh, byte* oct, word32 octSz)
     /* convert octal string to int without mp_read_radix() */
     ret = 0;
 
-    for (i = 0; i < WOLFSSH_MAX_OCTET_LEN; i++)
+    for (i = 0; i < octSz; i++)
     {
         if (oct[i] < '0' || oct[0] > '7') {
             ret = WS_BAD_ARGUMENT;

--- a/src/internal.c
+++ b/src/internal.c
@@ -593,10 +593,13 @@ int wolfSSH_ProcessBuffer(WOLFSSH_CTX* ctx,
                           const byte* in, word32 inSz,
                           int format, int type)
 {
-    int dynamicType;
-    void* heap;
+    int dynamicType = 0;
+    void* heap = NULL;
     byte* der;
     word32 derSz;
+
+    (void)dynamicType;
+    (void)heap;
 
     if (ctx == NULL || in == NULL || inSz == 0)
         return WS_BAD_ARGUMENT;
@@ -3098,7 +3101,7 @@ static int DoUnimplemented(WOLFSSH* ssh,
 static int DoDisconnect(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
 {
     word32 reason;
-    const char* reasonStr;
+    const char* reasonStr = NULL;
     word32 begin = *idx;
 
     (void)ssh;
@@ -3404,7 +3407,7 @@ static int DoUserAuthRequestRsa(WOLFSSH* ssh, WS_UserAuthData_PublicKey* pk,
                                   encDigestSz);
         sizeCompare = encDigestSz != (word32)checkDigestSz;
 
-        if ((compare | sizeCompare) == 0)
+        if ((compare == 0) && (sizeCompare == 0))
             ret = WS_SUCCESS;
         else
             ret = WS_RSA_E;
@@ -5197,7 +5200,6 @@ int DoReceive(WOLFSSH* ssh)
 
         return WS_SUCCESS;
     }
-    return WS_FATAL_ERROR;
 }
 
 

--- a/src/log.c
+++ b/src/log.c
@@ -35,10 +35,12 @@
 #include <wolfssh/error.h>
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <stdarg.h>
-#ifndef WOLFSSH_NO_TIMESTAMP
-    #include <time.h>
+#ifndef FREESCALE_MQX
+    #include <stdio.h>
+    #ifndef WOLFSSH_NO_TIMESTAMP
+        #include <time.h>
+    #endif
 #endif
 
 

--- a/src/port.c
+++ b/src/port.c
@@ -33,7 +33,7 @@
 
 
 #include <wolfssh/port.h>
-#ifndef USE_WINDOWS_API
+#if !defined(USE_WINDOWS_API) && !defined(FREESCALE_MQX)
     #include <stdio.h>
 #endif
 
@@ -85,7 +85,8 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
 #if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
     !defined(NO_WOLFSSH_SERVER)
 
-    #if defined(USE_WINDOWS_API) || defined(WOLFSSL_NUCLEUS)
+    #if defined(USE_WINDOWS_API) || defined(WOLFSSL_NUCLEUS) || \
+        defined(FREESCALE_MQX)
 
         /* This is current inline in the source. */
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -104,6 +104,8 @@ WOLFSSH* wolfSSH_new(WOLFSSH_CTX* ctx)
     WOLFSSH* ssh;
     void*    heap = NULL;
 
+    (void)heap;
+
     WLOG(WS_LOG_DEBUG, "Entering wolfSSH_new()");
 
     if (ctx)

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -171,6 +171,31 @@ WS_SOCKET_T wolfSSH_get_fd(const WOLFSSH* ssh)
 }
 
 
+int wolfSSH_SetFilesystemHandle(WOLFSSH* ssh, void* handle)
+{
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_SetFilesystemHandle()");
+
+    if (ssh) {
+        ssh->fs = handle;
+
+        return WS_SUCCESS;
+    }
+
+    return WS_BAD_ARGUMENT;
+}
+
+
+void* wolfSSH_GetFilesystemHandle(WOLFSSH* ssh)
+{
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_GetFilesystemHandle()");
+
+    if (ssh)
+        return ssh->fs;
+
+    return NULL;
+}
+
+
 int wolfSSH_SetHighwater(WOLFSSH* ssh, word32 highwater)
 {
     WLOG(WS_LOG_DEBUG, "Entering wolfSSH_SetHighwater()");
@@ -1611,7 +1636,7 @@ void wolfSSH_CheckReceivePending(WOLFSSH* ssh)
         return;
 
     inputBuffer = &ssh->channelList->inputBuffer;
-    WIOCTL(wolfSSH_get_fd(ssh), FIONREAD, &bytes);
+    WIOCTL(wolfSSH_get_fd(ssh), WFIONREAD, &bytes);
     while (bytes > 0) { /* there is something to read off the wire */
         if (inputBuffer->length - inputBuffer->idx > MAX_PACKET_SZ) {
             WLOG(WS_LOG_DEBUG, "Application data to be read");
@@ -1620,7 +1645,7 @@ void wolfSSH_CheckReceivePending(WOLFSSH* ssh)
         if (DoReceive(ssh) < 0) {
             WLOG(WS_LOG_ERROR, "Error trying to read potential window adjust");
         }
-        WIOCTL(wolfSSH_get_fd(ssh), FIONREAD, &bytes);
+        WIOCTL(wolfSSH_get_fd(ssh), WFIONREAD, &bytes);
     }
 }
 

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -1738,9 +1738,9 @@ int wsScpRecvCallback(WOLFSSH* ssh, int state, const char* basePath,
                 WSTRNCAT(abslut, "/", WOLFSSH_MAX_FILENAME);
                 WSTRNCAT(abslut, fileName, WOLFSSH_MAX_FILENAME);
                 clean_path(abslut);
-                if (WMKDIR(abslut, fileMode) != 0) {
+                if (WMKDIR(ssh->fs, abslut, fileMode) != 0) {
             #else
-                if (WMKDIR(fileName, fileMode) != 0) {
+                if (WMKDIR(ssh->fs, fileName, fileMode) != 0) {
             #endif
                     if (wolfSSH_LastError() != EEXIST) {
                         wolfSSH_SetScpErrorMsg(ssh, "error creating directory");
@@ -1891,7 +1891,7 @@ static ScpDir* ScpNewDir(const char* path, void* heap)
     }
 
     entry->next = NULL;
-    if (WOPENDIR(&entry->dir, path) != 0
+    if (WOPENDIR(NULL, heap, &entry->dir, path) != 0
         #ifndef WOLFSSL_NUCLEUS
             || entry->dir == NULL
         #endif

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -2110,7 +2110,7 @@ static int wolfSSH_SFTPNAME_readdir(WOLFSSH* ssh, WDIR* dir, WS_SFTPNAME* out,
     sz = (int)WSTRLEN(tmpName);
 
     /* remove /r/n that _io_mfs_dir_read() adds */
-    if (WSTRNCMP(tmpName + sz - 2, "\r\n", 2) == 0) {
+    if ((sz >= 2) && (WSTRNCMP(tmpName + sz - 2, "\r\n", 2) == 0)) {
         tmpName[sz - 2] = '\0';
         sz -= 2;
     }
@@ -3669,7 +3669,7 @@ int SFTP_GetAttributes(void* fs, const char* fileName, WS_SFTP_FILEATRB* atr,
     sz = (int)WSTRLEN(fileName);
 
     /* handle case of '<drive>:/.' */
-    if (WSTRNCMP(fileName + sz - 3, ":/.", 3) == 0) {
+    if ((sz >= 3) && (WSTRNCMP(fileName + sz - 3, ":/.", 3) == 0)) {
         atr->flags |= WOLFSSH_FILEATRB_PERM;
         atr->per |= 0x4000;
         return WS_SUCCESS;

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -5211,8 +5211,6 @@ static int wolfSSH_SFTP_GetHandle(WOLFSSH* ssh, byte* handle, word32* handleSz)
                 return WS_INPUT_CASE_E;
         }
     }
-
-    return WS_SUCCESS;
 }
 
 
@@ -5226,7 +5224,6 @@ WS_SFTPNAME* wolfSSH_SFTP_LS(WOLFSSH* ssh, char* dir)
 {
     struct WS_SFTP_LS_STATE* state = NULL;
     WS_SFTPNAME* name = NULL;
-    int ret;
 
     if (ssh == NULL || dir == NULL) {
         WLOG(WS_LOG_SFTP, "Bad argument passed in");
@@ -5305,7 +5302,7 @@ WS_SFTPNAME* wolfSSH_SFTP_LS(WOLFSSH* ssh, char* dir)
 
         case STATE_LS_CLOSE:
             /* close dir when finished */
-            if ((ret = wolfSSH_SFTP_Close(ssh, state->handle, state->sz))
+            if (wolfSSH_SFTP_Close(ssh, state->handle, state->sz)
                     != WS_SUCCESS) {
                 WLOG(WS_LOG_SFTP, "Error closing handle");
                 if (ssh->error != WS_WANT_READ && ssh->error != WS_WANT_WRITE) {
@@ -5544,8 +5541,6 @@ static int SFTP_STAT(WOLFSSH* ssh, char* dir, WS_SFTP_FILEATRB* atr, byte type)
                 return WS_INPUT_CASE_E;
         }
     }
-
-    return WS_SUCCESS;
 }
 
 
@@ -5836,8 +5831,6 @@ int wolfSSH_SFTP_Open(WOLFSSH* ssh, char* dir, word32 reason,
                 return WS_INPUT_CASE_E;
         }
     }
-
-    return WS_SUCCESS;
 }
 
 
@@ -6047,8 +6040,6 @@ int wolfSSH_SFTP_SendWritePacket(WOLFSSH* ssh, byte* handle, word32 handleSz,
                 return WS_FATAL_ERROR;
         }
     }
-
-    return WS_SUCCESS;
 }
 
 
@@ -6279,8 +6270,6 @@ int wolfSSH_SFTP_SendReadPacket(WOLFSSH* ssh, byte* handle, word32 handleSz,
                 return WS_FATAL_ERROR;
         }
     }
-
-    return WS_SUCCESS;
 }
 
 
@@ -6589,8 +6578,6 @@ int wolfSSH_SFTP_Close(WOLFSSH* ssh, byte* handle, word32 handleSz)
                 return WS_INPUT_CASE_E;
         }
     }
-
-    return WS_SUCCESS;
 }
 
 
@@ -6856,8 +6843,6 @@ int wolfSSH_SFTP_Rename(WOLFSSH* ssh, const char* old, const char* nw)
                 return WS_FATAL_ERROR;
         }
     }
-
-    return WS_SUCCESS;
 }
 
 
@@ -7414,8 +7399,6 @@ int wolfSSH_SFTP_Get(WOLFSSH* ssh, char* from,
                 return WS_INPUT_CASE_E;
         }
     }
-
-    return WS_SUCCESS;
 }
 
 
@@ -7613,8 +7596,6 @@ int wolfSSH_SFTP_Put(WOLFSSH* ssh, char* from, char* to, byte resume,
                 return WS_INPUT_CASE_E;
         }
     }
-
-    return ret;
 }
 
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -300,6 +300,7 @@ struct WOLFSSH {
     void* globalReqCtx;    /* Global Request CB context */
     void* reqSuccessCtx;   /* Global Request Sucess CB context */
     void* reqFailureCtx;   /* Global Request Failure CB context */
+    void* fs;              /* File system handle */
     word32 curSz;
     word32 seq;
     word32 peerSeq;

--- a/wolfssh/settings.h
+++ b/wolfssh/settings.h
@@ -56,6 +56,17 @@ extern "C" {
     #endif
 #endif
 
+#ifdef FREESCALE_MQX
+    #define NO_STDIO_FILESYSTEM
+    #ifndef WOLFSSH_STOREHANDLE
+        #define WOLFSSH_STOREHANDLE
+    #endif
+
+    #ifdef WOLFSSH_SCP
+        #error wolfSSH SCP not ported to MQX yet
+    #endif
+#endif
+
 #if defined(WOLFSSH_SCP) && defined(NO_WOLFSSH_SERVER)
     #error only SCP server side supported
 #endif

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -67,6 +67,9 @@ WOLFSSH_API int wolfSSH_worker(WOLFSSH*, word32*);
 WOLFSSH_API int wolfSSH_set_fd(WOLFSSH*, WS_SOCKET_T);
 WOLFSSH_API WS_SOCKET_T wolfSSH_get_fd(const WOLFSSH*);
 
+WOLFSSH_API int wolfSSH_SetFilesystemHandle(WOLFSSH*, void*);
+WOLFSSH_API void* wolfSSH_GetFilesystemHandle(WOLFSSH*);
+
 /* data high water mark functions */
 WOLFSSH_API int wolfSSH_SetHighwater(WOLFSSH*, word32);
 WOLFSSH_API word32 wolfSSH_GetHighwater(WOLFSSH*);


### PR DESCRIPTION
This PR adds a port of wolfSSH and SFTP (client and server) to Freescale/NXP MQX 4.2 (Classic).  The compiler used for this port was IAR-EWARM 7.50.2.  Changes include:

- MQX 4.2 SFTP port
- Fix to loop bound on wolfSSH_oct2dec()
- Fix IAR-EWARM compiler warnings

MQX file system operations require that the file system handle be available in addition to the file handle or file name.  To assist in this, a new API has been added that applications running on MQX will need to use to set the general file system handle:

```
wolfSSH_SetFilesystemHandle()
```

NOTE: SCP has not been ported to MQX.