### PR TITLE
Error Code Maintenance

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -71,7 +71,7 @@ const char* GetErrorString(int err)
     return "No wolfSSH strings available";
 #else
     switch (err) {
-        case WS_FATAL_ERROR:
+        case WS_ERROR:
             return "general function failure";
 
         case WS_BAD_ARGUMENT:
@@ -274,6 +274,12 @@ const char* GetErrorString(int err)
 
         case WS_USER_AUTH_E:
             return "User authentication error";
+
+        case WS_SSH_NULL_E:
+            return "ssh pointer was null";
+
+        case WS_SSH_CTX_NULL_E:
+            return "ssh ctx pointer was null";
 
         default:
             return "Unknown error code";

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -306,7 +306,7 @@ int wolfSSH_get_error(const WOLFSSH* ssh)
     if (ssh)
         return ssh->error;
 
-    return WS_BAD_ARGUMENT;
+    return WS_SSH_NULL_E;
 }
 
 
@@ -317,7 +317,7 @@ const char* wolfSSH_get_error_name(const WOLFSSH* ssh)
     if (ssh)
         return GetErrorString(ssh->error);
 
-    return NULL;
+    return GetErrorString(WS_SSH_NULL_E);
 }
 
 

--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -38,7 +38,8 @@ extern "C" {
 /* main public return values */
 enum WS_ErrorCodes {
     WS_SUCCESS              =  0,    /* function success */
-    WS_FATAL_ERROR          = -1001, /* general function failure */
+    WS_FATAL_ERROR          = -1001, /* name deprecated */
+    WS_ERROR                = -1001, /* general function failure */
     WS_BAD_ARGUMENT         = -1002, /* bad function argument */
     WS_MEMORY_E             = -1003, /* memory allocation failure */
     WS_BUFFER_E             = -1004, /* input/output buffer size error */
@@ -106,8 +107,10 @@ enum WS_ErrorCodes {
     WS_PUBKEY_REJECTED_E    = -1066, /* Server public key rejected */
     WS_EXTDATA              = -1067, /* Extended Data available to be read */
     WS_USER_AUTH_E          = -1068, /* User authentication error */
-    
-    WS_LAST_E               = -1068  /* Update this to indicate last error */
+    WS_SSH_NULL_E           = -1069, /* SSH was null */
+    WS_SSH_CTX_NULL_E       = -1070, /* SSH_CTX was null */
+
+    WS_LAST_E               = -1070  /* Update this to indicate last error */
 };
 
 


### PR DESCRIPTION
1. Add new error WS_ERROR to replace WS_FATAL_ERROR.
2. Added error WS_SSH_NULL_E and WS_SSH_CTX_NULL_E for the error to string functions for when ssh is actually NULL.