### PR TITLE
Fix Error Code

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -281,6 +281,9 @@ const char* GetErrorString(int err)
         case WS_SSH_CTX_NULL_E:
             return "ssh ctx pointer was null";
 
+        case WS_CHANNEL_NOT_CONF:
+            return "channel open not confirmed";
+
         default:
             return "Unknown error code";
     }

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1520,7 +1520,7 @@ int wolfSSH_ChannelSend(WOLFSSH_CHANNEL* channel,
         bytesTxd = WS_BAD_ARGUMENT;
     else if (!channel->openConfirmed) {
         WLOG(WS_LOG_DEBUG, "Channel not confirmed yet.");
-        return -666;
+        bytesTxd = WS_CHANNEL_NOT_CONF;
     }
     else {
         WLOG(WS_LOG_DEBUG, "Sending data.");

--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -109,8 +109,9 @@ enum WS_ErrorCodes {
     WS_USER_AUTH_E          = -1068, /* User authentication error */
     WS_SSH_NULL_E           = -1069, /* SSH was null */
     WS_SSH_CTX_NULL_E       = -1070, /* SSH_CTX was null */
+    WS_CHANNEL_NOT_CONF     = -1071, /* Channel open not confirmed. */
 
-    WS_LAST_E               = -1070  /* Update this to indicate last error */
+    WS_LAST_E               = -1071  /* Update this to indicate last error */
 };
 
 


### PR DESCRIPTION
Fix the error code for sending data on a channel that hasn't confirmed open yet to be an error code rather than a dummy value.