### PR TITLE
fix get-put test so it will run on Linux and Cygwin

### DIFF
--- a/scripts/get-put.test
+++ b/scripts/get-put.test
@@ -53,11 +53,7 @@ do_trap() {
 trap do_trap INT TERM
 
 
-if ! ./examples/echoserver/echoserver -d "$(pwd)" -R "$READY_FILE" &
-then
-    echo "Echoserver was unable to start."
-    exit 1
-fi
+./examples/echoserver/echoserver -d "$(pwd)" -R "$READY_FILE" >/dev/null 2>&1 &
 
 SERVER_PID=$!
 wait_for_server


### PR DESCRIPTION
At the script's startup, the existence of the echo server is checked. Its successful startup is checked by waiting for the ready file. The previous version worked on macOS, but not Cygwin or Ubuntu. This works on all three.