### PR TITLE
Fixes for SCP and SCP with Nucleus port

### DIFF
--- a/wolfssh/wolfscp.h
+++ b/wolfssh/wolfscp.h
@@ -64,6 +64,7 @@ extern "C" {
     #else
         int   fd; /* file descriptor, in the case of Nucleus fp points to fd */
         DSTAT s;
+        int   nextError;
     #endif
         WFILE* fp;                              /* file pointer */
         struct ScpDir* currentDir;              /* dir being copied, stack */


### PR DESCRIPTION
- fix for repeat call of scp with changed directory name (i.e. scp -r ./test jill@127.0.0.1:/test
- check on directory already existing for Nucleus port
- fixes for parsing scp command and nucleus port, parsing picking up part of file name as command (i.e scp ./file-test.txt jill@127.0.0.1:/)