### PR TITLE
In NameToId, prevent any reliance on null-termination of string.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -943,7 +943,7 @@ byte NameToId(const char* name, word32 nameSz)
 
     for (i = 0; i < (sizeof(NameIdMap)/sizeof(NameIdPair)); i++) {
         if (nameSz == WSTRLEN(NameIdMap[i].name) &&
-            WSTRNCMP(name, NameIdMap[i].name, nameSz) == 0) {
+            XMEMCMP(name, NameIdMap[i].name, nameSz) == 0) {
 
             id = NameIdMap[i].id;
             break;


### PR DESCRIPTION
When fuzzing this, I noticed that AddressSanitizer will perform a ```strlen()``` on the arguments to ```WSTRNCMP```, which leads to an out-of-bounds read notification, as ```name``` is not null-terminated.

This might be seen as an invalid assumption on the part of AddressSanitizer, however despite the fact that ```strncmp``` allows setting a max. length parameter, it might assume the parameters to be null-terminated anyway. The specification of ```strncmp``` is ambiguous on this matter as far as I can tell; it takes two ```const char*``` arguments (which implies null-termination), but makes no mention of an explicit requirement for null-termination. In this light, the current use of ```WSTRNCMP``` might be undefined behavior.

Either way, this PR is required to make fuzzing without false positives possible. ```XMEMCMP``` is adequate here because the length of both arguments is established so any out-of-bounds access is guaranteed not to occur.