### PR TITLE
Automake Include Maintenance

### DIFF
--- a/examples/client/include.am
+++ b/examples/client/include.am
@@ -9,5 +9,4 @@ examples_client_client_LDADD        = src/libwolfssh.la
 examples_client_client_DEPENDENCIES = src/libwolfssh.la
 endif
 
-dist_example_DATA+= examples/client/client.c
 DISTCLEANFILES+= examples/client/.libs/client

--- a/examples/echoserver/include.am
+++ b/examples/echoserver/include.am
@@ -9,5 +9,4 @@ examples_echoserver_echoserver_LDADD        = src/libwolfssh.la
 examples_echoserver_echoserver_DEPENDENCIES = src/libwolfssh.la
 endif
 
-dist_example_DATA+= examples/echoserver/echoserver.c
 DISTCLEANFILES+= examples/echoserver/.libs/echoserver

--- a/examples/server/include.am
+++ b/examples/server/include.am
@@ -9,7 +9,4 @@ examples_server_server_LDADD        = src/libwolfssh.la
 examples_server_server_DEPENDENCIES = src/libwolfssh.la
 endif
 
-dist_example_DATA+= examples/server/server.c
 DISTCLEANFILES+= examples/server/.libs/server
-
-EXTRA_DIST+= examples/server/server.c

--- a/examples/sftpclient/include.am
+++ b/examples/sftpclient/include.am
@@ -9,5 +9,4 @@ examples_sftpclient_wolfsftp_LDADD        = src/libwolfssh.la
 examples_sftpclient_wolfsftp_DEPENDENCIES = src/libwolfssh.la
 endif
 
-dist_example_DATA+= examples/sftpclient/sftpclient.c
 DISTCLEANFILES+= examples/sftpclient/.libs/wolfsftp


### PR DESCRIPTION
Remove redundant items from the automake includes. They were including files already included.