### PR TITLE
exit channel in echoserver before sending disconnect

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -401,8 +401,20 @@ static THREAD_RETURN WOLFSSH_THREAD server_worker(void* vArgs)
 
     switch (ret) {
         case WS_SCP_COMPLETE:
-            printf("scp file transfer completed\n");
-            ret = 0;
+            {
+                byte buf[1];
+                printf("scp file transfer completed\n");
+                if (wolfSSH_stream_exit(threadCtx->ssh, 0) != WS_SUCCESS) {
+                    fprintf(stderr, "Error with SSH stream exit.\n");
+                }
+                /* Peer MUST send back a SSH_MSG_CHANNEL_CLOSE unless already
+                 * sent*/
+                ret = wolfSSH_stream_read(threadCtx->ssh, buf, 1);
+                if (ret != WS_EOF) {
+                    fprintf(stderr, "Was expecting EOF\n");
+                }
+                ret = 0;
+            }
             break;
 
         case WS_SFTP_COMPLETE:
@@ -442,13 +454,9 @@ static THREAD_RETURN WOLFSSH_THREAD server_worker(void* vArgs)
 
     if (error != WS_SOCKET_ERROR_E && error != WS_FATAL_ERROR)
     {
-        if (wolfSSH_stream_exit(threadCtx->ssh, 0) != WS_SUCCESS) {
-            fprintf(stderr, "Error with SSH stream exit.\n");
-        }
         if (wolfSSH_shutdown(threadCtx->ssh) != WS_SUCCESS) {
             fprintf(stderr, "Error with SSH shutdown.\n");
         }
-
     }
 
     WCLOSESOCKET(threadCtx->fd);

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -442,9 +442,13 @@ static THREAD_RETURN WOLFSSH_THREAD server_worker(void* vArgs)
 
     if (error != WS_SOCKET_ERROR_E && error != WS_FATAL_ERROR)
     {
+        if (wolfSSH_stream_exit(threadCtx->ssh, 0) != WS_SUCCESS) {
+            fprintf(stderr, "Error with SSH stream exit.\n");
+        }
         if (wolfSSH_shutdown(threadCtx->ssh) != WS_SUCCESS) {
             fprintf(stderr, "Error with SSH shutdown.\n");
         }
+
     }
 
     WCLOSESOCKET(threadCtx->fd);

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -878,7 +878,7 @@ int wolfSSH_shutdown(WOLFSSH* ssh)
     if (ret == WS_SUCCESS)
         ret = SendDisconnect(ssh, WOLFSSH_DISCONNECT_BY_APPLICATION);
 
-    if (ssh->channelList == NULL) {
+    if (ssh != NULL && ssh->channelList == NULL) {
         WLOG(WS_LOG_DEBUG, "channel list was already removed");
         ret = WS_SUCCESS;
     }

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -878,6 +878,11 @@ int wolfSSH_shutdown(WOLFSSH* ssh)
     if (ret == WS_SUCCESS)
         ret = SendDisconnect(ssh, WOLFSSH_DISCONNECT_BY_APPLICATION);
 
+    if (ssh->channelList == NULL) {
+        WLOG(WS_LOG_DEBUG, "channel list was already removed");
+        ret = WS_SUCCESS;
+    }
+
     WLOG(WS_LOG_DEBUG, "Leaving wolfSSH_shutdown(), ret = %d", ret);
     return ret;
 }


### PR DESCRIPTION
ZD 9884

Fix for when testing scp against echoserver. This change makes the return value of scp client from OpenSSH return 0 on a successful transfer.