### PR TITLE
updates to auth callback

### DIFF
--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -442,6 +442,31 @@ static int wsUserAuth(byte authType,
 {
     int ret = WOLFSSH_USERAUTH_INVALID_AUTHTYPE;
 
+#ifdef DEBUG_WOLFSSH
+    /* inspect supported types from server */
+    printf("Server supports ");
+    if (authData->type & WOLFSSH_USERAUTH_PASSWORD) {
+        printf("password authentication");
+    }
+    if (authData->type & WOLFSSH_USERAUTH_PUBLICKEY) {
+        printf(" and public key authentication");
+    }
+    printf("\n");
+    printf("wolfSSH requesting to use type %d\n", authType);
+#endif
+
+    /* We know hansel has a key, wait for request of public key */
+    if (authData->type & WOLFSSH_USERAUTH_PUBLICKEY &&
+            authData->username != NULL &&
+            authData->usernameSz > 0 &&
+            XSTRNCMP((char*)authData->username, "hansel",
+                authData->usernameSz) == 0) {
+        if (authType == WOLFSSH_USERAUTH_PASSWORD) {
+            printf("rejecting password type with hansel in favor of pub key\n");
+            return WOLFSSH_USERAUTH_FAILURE;
+        }
+    }
+
     if (authType == WOLFSSH_USERAUTH_PASSWORD) {
         const char* defaultPassword = (const char*)ctx;
         word32 passwordSz;

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -750,11 +750,6 @@ int wolfSSH_connect(WOLFSSH* ssh)
                 if (DoReceive(ssh) < WS_SUCCESS) {
                     WLOG(WS_LOG_DEBUG, connectError,
                          "CLIENT_USERAUTH_SENT", ssh->error);
-                    if (ssh->error == WC_CHANGE_AUTH_E) {
-                        /* retry with supported auth type */
-                        ssh->error = WS_SUCCESS;
-                        continue;
-                    }
                     return WS_FATAL_ERROR;
                 }
             }

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -238,10 +238,9 @@ enum WS_FormatTypes {
 };
 
 
-enum WS_UserAuthTypes {
-    WOLFSSH_USERAUTH_PASSWORD,
-    WOLFSSH_USERAUTH_PUBLICKEY
-};
+/* bit map */
+#define WOLFSSH_USERAUTH_PASSWORD  0x01
+#define WOLFSSH_USERAUTH_PUBLICKEY 0x02
 
 enum WS_UserAuthResults
 {


### PR DESCRIPTION
This is altering the callback behavior for peer authentication some. It sets the WS_UserAuthData.type to be a bit map of all supported types before it is passed to the user callback. The first time the user callback is called a password is requested by wolfSSH, if the user returns a fail case from that then a public key is requested. This process of calling requesting type individually is to not break previous use cases for the authentication callback.