### PR TITLE
free name list after done and fix clean_path

### DIFF
--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1232,6 +1232,7 @@ static int doAutopilot(int cmd, char* local, char* remote)
         }
     }
 
+    wolfSSH_SFTPNAME_list_free(name);
     return ret;
 }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -8681,7 +8681,7 @@ void clean_path(char* path)
     sz = (int)WSTRLEN(path);
 
     /* remove any /./ patterns */
-    for (i = 0; i < sz; i++) {
+    for (i = 1; i + 1 < sz; i++) {
         if (path[i] == '.' && path[i - 1] == WS_DELIM && path[i + 1] == WS_DELIM) {
             WMEMMOVE(path + i, path + i + 1, sz - i + 1);
             sz -= 1;
@@ -8830,6 +8830,7 @@ void DumpOctetString(const byte* input, word32 inputSz)
 int wolfSSH_oct2dec(WOLFSSH* ssh, byte* oct, word32 octSz)
 {
     int ret;
+    word32 i;
 
     if (octSz > WOLFSSH_MAX_OCTET_LEN || ssh == NULL || oct == NULL) {
         return WS_BAD_ARGUMENT;
@@ -8838,7 +8839,7 @@ int wolfSSH_oct2dec(WOLFSSH* ssh, byte* oct, word32 octSz)
     /* convert octal string to int without mp_read_radix() */
     ret = 0;
 
-    for (word32 i = 0; i < octSz; i++)
+    for (i = 0; i < octSz; i++)
     {
         if (oct[i] < '0' || oct[0] > '7') {
             ret = WS_BAD_ARGUMENT;


### PR DESCRIPTION
- if tests/api.test finds the file .DS_Store then the /./ check was reading over the buffer

- fix for sftp auto get/put test not free'ing the name list