### PR TITLE
SCP Disconnect

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -868,10 +868,10 @@ int wolfSSH_shutdown(WOLFSSH* ssh)
         ret = SendChannelEof(ssh, ssh->channelList->peerChannel);
 
     if (ret == WS_SUCCESS)
-        ret = SendChannelClose(ssh, ssh->channelList->peerChannel);
+        ret = SendChannelExit(ssh, ssh->channelList->peerChannel, 0);
 
     if (ret == WS_SUCCESS)
-        ret = SendDisconnect(ssh, WOLFSSH_DISCONNECT_BY_APPLICATION);
+        ret = SendChannelClose(ssh, ssh->channelList->peerChannel);
 
     if (ssh != NULL && ssh->channelList == NULL) {
         WLOG(WS_LOG_DEBUG, "channel list was already removed");

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -85,7 +85,7 @@ int DoScpSink(WOLFSSH* ssh)
 
                 if ( (ret = ReceiveScpMessage(ssh)) < WS_SUCCESS) {
                     if (ret == WS_EOF) {
-                        ret = WS_SUCCESS;
+                        ret = wolfSSH_shutdown(ssh);
                         ssh->scpState = SCP_DONE;
                         break;
                     }


### PR DESCRIPTION
1. When receiving the EOF from the client, wolfSCP should be shutting down the connection.
2. When shutting down the connection, don't send Disconnect. Instead send channel exit, then follow with close. This tells the client that the program exited cleanly.