### PR TITLE
Fuzz Test Fix

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -52,15 +52,6 @@ static const char sshProtoIdStr[] = "SSH-2.0-wolfSSHv"
                                     LIBWOLFSSH_VERSION_STRING
                                     "\r\n";
 static const char OpenSSH[] = "SSH-2.0-OpenSSH";
-#ifndef WOLFSSH_DEFAULT_GEXDH_MIN
-    #define WOLFSSH_DEFAULT_GEXDH_MIN 1024
-#endif
-#ifndef WOLFSSH_DEFAULT_GEXDH_PREFERRED
-    #define WOLFSSH_DEFAULT_GEXDH_PREFERRED 3072
-#endif
-#ifndef WOLFSSH_DEFAULT_GEXDH_MAX
-    #define WOLFSSH_DEFAULT_GEXDH_MAX 8192
-#endif
 
 
 const char* GetErrorString(int err)
@@ -289,6 +280,9 @@ const char* GetErrorString(int err)
 
         case WS_MISSING_CALLBACK:
             return "missing a callback function";
+
+        case WS_DH_SIZE_E:
+            return "DH prime group size larger than expected";
 
         default:
             return "Unknown error code";
@@ -3046,6 +3040,8 @@ static int DoKexDhGexGroup(WOLFSSH* ssh,
     if (ret == WS_SUCCESS) {
         begin = *idx;
         ret = GetMpint(&primeGroupSz, &primeGroup, buf, len, &begin);
+        if (ret == WS_SUCCESS && primeGroupSz > (MAX_KEX_KEY_SZ + 1))
+            ret = WS_DH_SIZE_E;
     }
 
     if (ret == WS_SUCCESS)

--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -112,8 +112,9 @@ enum WS_ErrorCodes {
     WS_CHANGE_AUTH_E        = -1072, /* Changing auth type attempt */
     WS_WINDOW_FULL          = -1073,
     WS_MISSING_CALLBACK     = -1074, /* Callback is missing */
+    WS_DH_SIZE_E            = -1075, /* DH prime larger than expected */
 
-    WS_LAST_E               = -1074  /* Update this to indicate last error */
+    WS_LAST_E               = -1075  /* Update this to indicate last error */
 };
 
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -142,9 +142,18 @@ enum {
     /* This is from RFC 4253 section 6.1. */
     #define MAX_PACKET_SZ 35000
 #endif
+#ifndef WOLFSSH_DEFAULT_GEXDH_MIN
+    #define WOLFSSH_DEFAULT_GEXDH_MIN 1024
+#endif
+#ifndef WOLFSSH_DEFAULT_GEXDH_PREFERRED
+    #define WOLFSSH_DEFAULT_GEXDH_PREFERRED 3072
+#endif
+#ifndef WOLFSSH_DEFAULT_GEXDH_MAX
+    #define WOLFSSH_DEFAULT_GEXDH_MAX 8192
+#endif
 #ifndef MAX_KEX_KEY_SZ
-    /* This is based on the 3072-bit DH key that is the preferred size. */
-    #define MAX_KEX_KEY_SZ (3072 / 8)
+    /* This is based on the 8192-bit DH key that is the max size. */
+    #define MAX_KEX_KEY_SZ (WOLFSSH_DEFAULT_GEXDH_MAX / 8)
 #endif
 
 WOLFSSH_LOCAL byte NameToId(const char*, word32);


### PR DESCRIPTION
Fixed an issue where a too large GEX prime group size would cause problems generating the shared secret.
1. Moved the #defines for setting the default DH min/preferred/max values to internal.h.
2. Based the DH e value on the DH max size.
3. Check that the received prime group size is not greater than the max.