### PR TITLE
Auth Type None

### DIFF
--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -242,6 +242,7 @@ enum WS_FormatTypes {
 /* bit map */
 #define WOLFSSH_USERAUTH_PASSWORD  0x01
 #define WOLFSSH_USERAUTH_PUBLICKEY 0x02
+#define WOLFSSH_USERAUTH_NONE      0x04
 
 enum WS_UserAuthResults
 {

--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -49,6 +49,8 @@
     #include <selectLib.h>
     #include <sys/types.h>
     #include <netinet/in.h>
+    #include <netinet/tcp.h>
+    #include <ipcom_sock.h>
     #include <fcntl.h>
     #include <sys/time.h>
     #include <netdb.h>
@@ -376,7 +378,7 @@ static INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
             NU_HOSTENT h;
             entry = &h;
             NU_Get_Host_By_Name((char*)peer, entry);
-            #else
+        #else
             struct hostent* entry = gethostbyname(peer);
         #endif
 


### PR DESCRIPTION
1. Added a compile time option to allow None as an authentication type, mainly for testing.
2. Added a couple updates for VxWorks builds.