### PR TITLE
Revert Libool Config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,9 +8,6 @@ AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])
 
 : ${CFLAGS=""}
-# Test ar for the "U" option. Should be checked before the libtool macros.
-xxx_ar_flags=$(ar --help 2>&1)
-AS_CASE([$xxx_ar_flags],[*'use actual timestamps and uids/gids'*],[: ${AR_FLAGS="Ucru"}])
 
 AC_CANONICAL_HOST
 


### PR DESCRIPTION
Removed an initialization of AR_FLAGS and let the libtool version happen. This makes Ubuntu builds recreatable.