### PR TITLE
RSA OOB Read

### DIFF
--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -113,8 +113,9 @@ enum WS_ErrorCodes {
     WS_WINDOW_FULL          = -1073,
     WS_MISSING_CALLBACK     = -1074, /* Callback is missing */
     WS_DH_SIZE_E            = -1075, /* DH prime larger than expected */
+    WS_PUBKEY_SIG_MIN_E     = -1076, /* Signature too small */
 
-    WS_LAST_E               = -1075  /* Update this to indicate last error */
+    WS_LAST_E               = -1076  /* Update this to indicate last error */
 };
 
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -112,6 +112,7 @@ enum {
 #define MAX_INTEGRITY 2
 #define MAX_KEY_EXCHANGE 2
 #define MAX_PUBLIC_KEY 1
+#define MIN_RSA_SIG_SZ 2
 #define MAX_HMAC_SZ WC_SHA256_DIGEST_SIZE
 #define MIN_BLOCK_SZ 8
 #define COOKIE_SZ 16


### PR DESCRIPTION
Added a check of the length of the RSA signature before verifying it. The signature's length needs to be at least 2 bytes as the wolfCrypt padding check assumes it is at least 2 bytes long. (ZD10358) This was fixed in wolfCrypt, but the length should also be checked here since this is the source of the data.