### PR TITLE
doc: corrects `--disable-term` documentation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AC_ARG_ENABLE([fwd],
 
 # pseudo-terminal
 AC_ARG_ENABLE([term],
-    [AS_HELP_STRING([--disable-term],[Enable pseudo-terminal support (default: enabled)])],
+    [AS_HELP_STRING([--disable-term],[Disable pseudo-terminal support (default: enabled)])],
     [ENABLED_PTERM=$enableval],[ENABLED_PTERM=yes])
 
 # Enable All


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/24358465/86491998-d5d75c80-bd6c-11ea-930b-6b35ab863591.png)

## After

![image](https://user-images.githubusercontent.com/24358465/86492016-e8ea2c80-bd6c-11ea-98fe-6872c37a75f1.png)
