### PR TITLE
add callback and example for no file system with SCP

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1076,7 +1076,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     if (userPrivateKey != NULL)
         free(userPrivateKey);
     if (ret != WS_SUCCESS)
-        err_sys("Closing stream failed. Connection could have been closed by peer");
+        err_sys("Closing client stream failed. Connection could have been closed by peer");
 
 #if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)
     wc_ecc_fp_free();  /* free per thread cache */

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -894,10 +894,15 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         if (ret != 0) err_sys("Couldn't load private key buffer.");
     }
     else {
+    #ifndef NO_FILESYSTEM
         ret = wolfSSH_ReadKey_file(privKeyName,
                 (byte**)&userPrivateKey, &userPrivateKeySz,
                 (const byte**)&userPrivateKeyType, &userPrivateKeyTypeSz,
                 &isPrivate, NULL);
+    #else
+        printf("file system not compiled in!\n");
+        ret = -1;
+    #endif
         if (ret != 0) err_sys("Couldn't load private key file.");
     }
 
@@ -922,6 +927,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         if (ret != 0) err_sys("Couldn't load public key buffer.");
     }
     else {
+    #ifndef NO_FILESYSTEM
         byte* p = userPublicKey;
         userPublicKeySz = sizeof(userPublicKey);
 
@@ -929,6 +935,10 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
                 &p, &userPublicKeySz,
                 (const byte**)&userPublicKeyType, &userPublicKeyTypeSz,
                 &isPrivate, NULL);
+    #else
+        printf("file system not compiled in!\n");
+        ret = -1;
+    #endif
         if (ret != 0) err_sys("Couldn't load public key file.");
     }
 

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1695,11 +1695,16 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
 
     /* if creating a ready file with port then override port to be 0 */
     if (readyFile != NULL) {
+    #ifdef NO_FILESYSTEM
+        fprintf(stderr, "cannot create readyFile with no file system.\r\n");
+        exit(EXIT_FAILURE);
+    #endif
         port = 0;
     }
     tcp_listen(&listenFd, &port, 1);
     /* write out port number listing to, to user set ready file */
     if (readyFile != NULL) {
+    #ifndef NO_FILESYSTEM
         WFILE* f = NULL;
         int    ret;
         ret = WFOPEN(&f, readyFile, "w");
@@ -1707,6 +1712,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
             fprintf(f, "%d\n", (int)port);
             WFCLOSE(f);
         }
+    #endif
     }
 
     do {

--- a/examples/portfwd/portfwd.c
+++ b/examples/portfwd/portfwd.c
@@ -435,7 +435,7 @@ THREAD_RETURN WOLFSSH_THREAD portfwd_worker(void* args)
 
     ret = wolfSSH_shutdown(ssh);
     if (ret != WS_SUCCESS)
-        err_sys("Closing stream failed.");
+        err_sys("Closing port forward stream failed.");
 
     WCLOSESOCKET(sshFd);
     WCLOSESOCKET(listenFd);

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -357,7 +357,7 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
     wolfSSH_free(ssh);
     wolfSSH_CTX_free(ctx);
     if (ret != WS_SUCCESS)
-        err_sys("Closing stream failed. Connection could have been closed by peer");
+        err_sys("Closing scp stream failed. Connection could have been closed by peer");
 
 #if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)
     wc_ecc_fp_free();  /* free per thread cache */

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -148,12 +148,12 @@ static THREAD_RETURN WOLFSSH_THREAD server_worker(void* vArgs)
 
 #if defined(WOLFSSH_SCP) && defined(NO_FILESYSTEM)
     ScpBuffer scpBufferRecv, scpBufferSend;
-    byte fileBuffer[1024];
+    byte fileBuffer[49000];
     byte fileTmp[] = "wolfSSH SCP buffer file";
 
     WMEMSET(&scpBufferRecv, 0, sizeof(ScpBuffer));
     scpBufferRecv.buffer   = fileBuffer;
-    scpBufferRecv.bufferSz = 1024;
+    scpBufferRecv.bufferSz = sizeof(fileBuffer);
     wolfSSH_SetScpRecvCtx(threadCtx->ssh, (void*)&scpBufferRecv);
 
     /* make buffer file to send if asked */

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -161,7 +161,7 @@ static THREAD_RETURN WOLFSSH_THREAD server_worker(void* vArgs)
     WMEMCPY(scpBufferSend.name, "test.txt", sizeof("test.txt"));
     scpBufferSend.nameSz   = WSTRLEN("test.txt");
     scpBufferSend.buffer   = fileTmp;
-    scpBufferSend.bufferSz = sizeof(fileTmp);
+    scpBufferSend.bufferSz = sizeof(fileBuffer);
     scpBufferSend.fileSz   = sizeof(fileTmp);
     scpBufferSend.mode     = 0x1A4;
     wolfSSH_SetScpSendCtx(threadCtx->ssh, (void*)&scpBufferSend);

--- a/src/internal.c
+++ b/src/internal.c
@@ -421,8 +421,7 @@ WOLFSSH_CTX* CtxInit(WOLFSSH_CTX* ctx, byte side, void* heap)
 #endif /* WOLFSSH_USER_IO */
     ctx->highwaterMark = DEFAULT_HIGHWATER_MARK;
     ctx->highwaterCb = wsHighwater;
-#if defined(WOLFSSH_SCP) && !defined(WOLFSSH_SCP_USER_CALLBACKS) && \
-    !defined(NO_FILESYSTEM)
+#if defined(WOLFSSH_SCP) && !defined(WOLFSSH_SCP_USER_CALLBACKS)
     ctx->scpRecvCb = wsScpRecvCallback;
     ctx->scpSendCb = wsScpSendCallback;
 #endif /* WOLFSSH_SCP */
@@ -8744,7 +8743,7 @@ int SendChannelRequest(WOLFSSH* ssh, byte* name, word32 nameSz)
 }
 
 
-#ifdef WOLFSSH_TERM
+#if defined(WOLFSSH_TERM) && !defined(NO_FILESYSTEM)
 
 #if !defined(USE_WINDOWS_API) && !defined(MICROCHIP_PIC32) && \
     !defined(NO_TERMIOS)

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -872,7 +872,7 @@ int wolfSSH_connect(WOLFSSH* ssh)
             FALL_THROUGH;
 
         case CONNECT_CLIENT_CHANNEL_AGENT_REQUEST_SENT:
-        #ifdef WOLFSSH_TERM
+        #if defined(WOLFSSH_TERM) && !defined(NO_FILESYSTEM)
             if (ssh->sendTerminalRequest) {
                 if ( (ssh->error = SendChannelTerminalRequest(ssh))
                         < WS_SUCCESS) {

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -2537,6 +2537,15 @@ int wsScpRecvCallback(WOLFSSH* ssh, int state, const char* basePath,
             /* read file, or file part */
             sz = (bufSz < recvBuffer->bufferSz - recvBuffer->idx) ?
                 bufSz : recvBuffer->bufferSz - recvBuffer->idx;
+
+            if (recvBuffer->idx >= recvBuffer->bufferSz) {
+                wolfSSH_SetScpErrorMsg(ssh,
+                        "buffer is not large enough for file");
+                WLOG(WS_LOG_DEBUG, scpState, "SCP buffer too small for file");
+                ret = WS_SCP_ABORT;
+                break;
+            }
+
             WMEMCPY(recvBuffer->buffer + recvBuffer->idx, buf, sz);
             recvBuffer->idx    += sz;
             recvBuffer->fileSz += sz;

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -1045,8 +1045,8 @@ static int ScpCheckForRename(WOLFSSH* ssh, int cmdSz)
     }
 #else
     /* allow placing file at base address ':/' */
-    if (sz == 1 && buf[0] == WS_DELIM) {
-        idx--;
+    if (WSTRLEN(buf) == 1 && buf[0] == WS_DELIM) {
+        idx--; /* no delimiter at base */
     }
 #endif
     if (idx > cmdSz || idx > sz) {
@@ -2598,7 +2598,7 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
 
         case WOLFSSH_SCP_SINGLE_FILE_REQUEST:
             if (sendBuffer->buffer == NULL) {
-                wolfSSH_SetScpErrorMsg(ssh, "no buffer to send");
+                WLOG(WS_LOG_DEBUG, scpState, "no buffer to send");
                 ret = WS_SCP_ABORT;
                 break;
             }
@@ -2614,7 +2614,7 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
             }
 
             if (WSTRLEN(fileName) != sendBuffer->nameSz ||
-                WMEMCMP(sendBuffer->name, fileName, fileNameSz) != 0) {
+                WMEMCMP(sendBuffer->name, fileName, sendBuffer->nameSz) != 0) {
                 wolfSSH_SetScpErrorMsg(ssh, "file name did not match");
                 ret = WS_SCP_ABORT;
                 break;
@@ -2672,7 +2672,7 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
             break;
 
         default:
-            wolfSSH_SetScpErrorMsg(ssh, "bad state");
+            WLOG(WS_LOG_DEBUG, scpState, "bad state");
             ret = WS_SCP_ABORT;
     }
     (void)fileOffset;

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -2512,7 +2512,13 @@ int wsScpRecvCallback(WOLFSSH* ssh, int state, const char* basePath,
 
         case WOLFSSH_SCP_NEW_FILE:
             /* create file */
-            WMEMCPY(recvBuffer->name, fileName, WSTRLEN(fileName));
+            sz = (int)WSTRLEN(fileName);
+            if (sz >= DEFAULT_SCP_FILE_NAME_SZ) {
+                wolfSSH_SetScpErrorMsg(ssh, "file name is too large");
+                ret = WS_SCP_ABORT;
+                break;
+            }
+            WMEMCPY(recvBuffer->name, fileName, sz);
             recvBuffer->mTime = mTime;
             recvBuffer->mode = fileMode;
             break;
@@ -2632,7 +2638,7 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
 
     return ret;
 }
-#endif /* NO_FILESYSTME */
+#endif /* NO_FILESYSTEM */
 #endif /* WOLFSSH_SCP_USER_CALLBACKS */
 
 #endif /* WOLFSSH_SCP */

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -47,13 +47,11 @@
     #include "src/misc.c"
 #endif
 
-#if defined(NO_FILESYSTEM) && !defined(WOLFSSH_SCP_USER_CALLBACKS)
-    #error "scp with no filesystem requires user callbacks"
-#endif
-
+#ifndef NO_FILESYSTEM
 static int ScpFileIsDir(ScpSendCtx* ctx);
 static int ScpPushDir(ScpSendCtx* ctx, const char* path, void* heap);
 static int ScpPopDir(ScpSendCtx* ctx, void* heap);
+#endif
 
 const char scpError[] = "scp error: %s, %d";
 const char scpState[] = "scp state: %s";
@@ -1091,20 +1089,26 @@ static int ScpCheckForRename(WOLFSSH* ssh, int cmdSz)
  * returns WS_SUCCESS on success */
 static int ParseBasePathHelper(WOLFSSH* ssh, int cmdSz)
 {
-    ScpSendCtx ctx;
     int ret;
 
-    WMEMSET(&ctx, 0, sizeof(ScpSendCtx));
     ret = ScpCheckForRename(ssh, cmdSz);
-    if (ScpPushDir(&ctx, ssh->scpBasePath, ssh->ctx->heap) != WS_SUCCESS) {
-        WLOG(WS_LOG_DEBUG, "scp : issue opening base dir");
-    }
-    else {
-        ret = ScpPopDir(&ctx, ssh->ctx->heap);
-        if (ret == WS_SCP_DIR_STACK_EMPTY_E) {
-            ret = WS_SUCCESS; /* is ok to empty the directory stack here */
+
+#ifndef NO_FILESYSTEM
+    {
+        ScpSendCtx ctx;
+
+        WMEMSET(&ctx, 0, sizeof(ScpSendCtx));
+        if (ScpPushDir(&ctx, ssh->scpBasePath, ssh->ctx->heap) != WS_SUCCESS) {
+            WLOG(WS_LOG_DEBUG, "scp : issue opening base dir");
+        }
+        else {
+            ret = ScpPopDir(&ctx, ssh->ctx->heap);
+            if (ret == WS_SCP_DIR_STACK_EMPTY_E) {
+                ret = WS_SUCCESS; /* is ok to empty the directory stack here */
+            }
         }
     }
+#endif /* NO_FILESYSTEM */
 
     /* default case of directory */
     return ret;
@@ -1608,7 +1612,43 @@ int wolfSSH_SCP_from(WOLFSSH* ssh, const char* src, const char* dst)
 }
 
 
-#if !defined(WOLFSSH_SCP_USER_CALLBACKS) && !defined(NO_FILESYSTEM)
+#if !defined(WOLFSSH_SCP_USER_CALLBACKS)
+
+/* Extract file name from full path, store in fileName.
+ * Return WS_SUCCESS on success, negative upon error */
+static int ExtractFileName(const char* filePath, char* fileName,
+                           word32 fileNameSz)
+{
+    int ret = WS_SUCCESS;
+    word32 fileLen;
+    int idx = 0, pathLen, separator = -1;
+
+    if (filePath == NULL || fileName == NULL)
+        return WS_BAD_ARGUMENT;
+
+    pathLen = (int)WSTRLEN(filePath);
+
+    /* find last separator */
+    while (idx < pathLen) {
+        if (filePath[idx] == '/' || filePath[idx] == '\\')
+            separator = idx;
+        idx++;
+    }
+
+    if (separator < 0)
+        return WS_BAD_ARGUMENT;
+
+    fileLen = pathLen - separator - 1;
+    if (fileLen + 1 > fileNameSz)
+        return WS_SCP_PATH_LEN_E;
+
+    WMEMCPY(fileName, filePath + separator + 1, fileLen);
+    fileName[fileLen] = '\0';
+
+    return ret;
+}
+
+#if !defined(NO_FILESYSTEM)
 
 /* for porting to systems without errno */
 static INLINE int wolfSSH_LastError(void)
@@ -1879,40 +1919,6 @@ int wsScpRecvCallback(WOLFSSH* ssh, int state, const char* basePath,
 
     (void)totalFileSz;
     (void)fileOffset;
-    return ret;
-}
-
-/* Extract file name from full path, store in fileName.
- * Return WS_SUCCESS on success, negative upon error */
-static int ExtractFileName(const char* filePath, char* fileName,
-                           word32 fileNameSz)
-{
-    int ret = WS_SUCCESS;
-    word32 fileLen;
-    int idx = 0, pathLen, separator = -1;
-
-    if (filePath == NULL || fileName == NULL)
-        return WS_BAD_ARGUMENT;
-
-    pathLen = (int)WSTRLEN(filePath);
-
-    /* find last separator */
-    while (idx < pathLen) {
-        if (filePath[idx] == '/' || filePath[idx] == '\\')
-            separator = idx;
-        idx++;
-    }
-
-    if (separator < 0)
-        return WS_BAD_ARGUMENT;
-
-    fileLen = pathLen - separator - 1;
-    if (fileLen + 1 > fileNameSz)
-        return WS_SCP_PATH_LEN_E;
-
-    WMEMCPY(fileName, filePath + separator + 1, fileLen);
-    fileName[fileLen] = '\0';
-
     return ret;
 }
 
@@ -2481,6 +2487,152 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
     return ret;
 }
 
+#else
+
+/* single file transfer with no filesystem */
+int wsScpRecvCallback(WOLFSSH* ssh, int state, const char* basePath,
+        const char* fileName, int fileMode, word64 mTime, word64 aTime,
+        word32 totalFileSz, byte* buf, word32 bufSz, word32 fileOffset,
+        void* ctx)
+{
+    ScpBuffer* recvBuffer;
+    int ret = WS_SCP_CONTINUE;
+    int sz;
+
+    if (ctx == NULL) {
+        wolfSSH_SetScpErrorMsg(ssh, "SCP receive ctx not set");
+        return WS_SCP_ABORT;
+    }
+    recvBuffer = (ScpBuffer*)ctx;
+
+    switch (state) {
+
+        case WOLFSSH_SCP_NEW_REQUEST:
+            break;
+
+        case WOLFSSH_SCP_NEW_FILE:
+            /* create file */
+            WMEMCPY(recvBuffer->name, fileName, WSTRLEN(fileName));
+            recvBuffer->mTime = mTime;
+            recvBuffer->mode = fileMode;
+            break;
+
+        case WOLFSSH_SCP_FILE_PART:
+            /* read file, or file part */
+            sz = (bufSz < recvBuffer->bufferSz - recvBuffer->idx) ?
+                bufSz : recvBuffer->bufferSz - recvBuffer->idx;
+            WMEMCPY(recvBuffer->buffer + recvBuffer->idx, buf, sz);
+            recvBuffer->fileSz += sz;
+            break;
+
+        case WOLFSSH_SCP_FILE_DONE:
+            recvBuffer->idx   = 0; /* rewind when done */
+            recvBuffer->mTime = 0; /* @TODO set time if wanted */
+            break;
+
+        case WOLFSSH_SCP_NEW_DIR:
+        case WOLFSSH_SCP_END_DIR:
+            wolfSSH_SetScpErrorMsg(ssh,
+                    "creating a new directory not supported");
+            ret = WS_SCP_ABORT;
+            break;
+
+        default:
+            wolfSSH_SetScpErrorMsg(ssh, "invalid scp command request");
+            ret = WS_SCP_ABORT;
+    }
+
+    (void)totalFileSz;
+    (void)fileOffset;
+    (void)aTime;
+    (void)basePath;
+    return ret;
+}
+
+
+/* callback for single file transfer with no file system */
+int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
+        char* fileName, word32 fileNameSz, word64* mTime, word64* aTime,
+        int* fileMode, word32 fileOffset, word32* totalFileSz, byte* buf,
+        word32 bufSz, void* ctx)
+{
+    ScpBuffer* sendBuffer= NULL;
+    int ret = WS_SUCCESS;
+
+    if (ctx == NULL) {
+        wolfSSH_SetScpErrorMsg(ssh, "no ctx sent to hold file info");
+        return WS_SCP_ABORT;
+    }
+    sendBuffer = (ScpBuffer*)ctx;
+
+    switch (state) {
+        case WOLFSSH_SCP_NEW_REQUEST:
+            break;
+
+        case WOLFSSH_SCP_SINGLE_FILE_REQUEST:
+            if (sendBuffer->buffer == NULL) {
+                wolfSSH_SetScpErrorMsg(ssh, "no buffer to send");
+                ret = WS_SCP_ABORT;
+                break;
+            }
+
+            *totalFileSz = sendBuffer->bufferSz;
+            *mTime = sendBuffer->mTime;
+            *aTime = sendBuffer->mTime;
+            *fileMode = sendBuffer->mode;
+            ret = ExtractFileName(peerRequest, fileName, fileNameSz);
+            if (WSTRLEN(fileName) != sendBuffer->nameSz ||
+                WMEMCMP(sendBuffer->name, fileName, fileNameSz) != 0) {
+                wolfSSH_SetScpErrorMsg(ssh, "file name did not match");
+                ret = WS_SCP_ABORT;
+                break;
+            }
+
+            /* copy over buffer info */
+            if (sendBuffer->idx >= sendBuffer->bufferSz) {
+                ret = WS_SCP_ABORT;
+                break;
+            }
+            ret = (bufSz < (sendBuffer->bufferSz - sendBuffer->idx))?
+                bufSz : sendBuffer->bufferSz - sendBuffer->idx;
+            WMEMCPY(buf, sendBuffer->buffer + sendBuffer->idx, ret);
+            sendBuffer->idx += ret;
+
+            break;
+
+        case WOLFSSH_SCP_RECURSIVE_REQUEST:
+            wolfSSH_SetScpErrorMsg(ssh,
+                    "recursive request without filesystem not supported");
+            ret = WS_SCP_ABORT;
+            break;
+
+        case WOLFSSH_SCP_CONTINUE_FILE_TRANSFER:
+            /* copy over buffer info */
+            if (sendBuffer->idx >= sendBuffer->bufferSz) {
+                ret = WS_SCP_ABORT;
+                break;
+            }
+            ret = (bufSz < (sendBuffer->bufferSz - sendBuffer->idx))?
+                bufSz : sendBuffer->bufferSz - sendBuffer->idx;
+            if (ret > 0) {
+                WMEMCPY(buf, sendBuffer->buffer + sendBuffer->idx, ret);
+                sendBuffer->idx += ret;
+            }
+            if (ret == 0) { /* handle case of EOF */
+                ret = WS_EOF;
+            }
+
+            break;
+
+        default:
+            wolfSSH_SetScpErrorMsg(ssh, "bad state");
+            ret = WS_SCP_ABORT;
+    }
+    (void)fileOffset;
+
+    return ret;
+}
+#endif /* NO_FILESYSTME */
 #endif /* WOLFSSH_SCP_USER_CALLBACKS */
 
 #endif /* WOLFSSH_SCP */

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -2613,18 +2613,18 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
                 ret = WS_SCP_ABORT;
                 break;
             }
-            *totalFileSz = sendBuffer->bufferSz;
+            *totalFileSz = sendBuffer->fileSz;
             *mTime = sendBuffer->mTime;
             *aTime = sendBuffer->mTime;
             *fileMode = sendBuffer->mode;
 
             /* copy over buffer info */
-            if (sendBuffer->idx >= sendBuffer->bufferSz) {
+            ret = (bufSz < (sendBuffer->fileSz - sendBuffer->idx))?
+                bufSz : sendBuffer->fileSz - sendBuffer->idx;
+            if (sendBuffer->idx  + ret >= sendBuffer->bufferSz) {
                 ret = WS_SCP_ABORT;
                 break;
             }
-            ret = (bufSz < (sendBuffer->bufferSz - sendBuffer->idx))?
-                bufSz : sendBuffer->bufferSz - sendBuffer->idx;
             WMEMCPY(buf, sendBuffer->buffer + sendBuffer->idx, ret);
             sendBuffer->idx += ret;
 
@@ -2642,9 +2642,13 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
                 ret = WS_SCP_ABORT;
                 break;
             }
-            ret = (bufSz < (sendBuffer->bufferSz - sendBuffer->idx))?
-                bufSz : sendBuffer->bufferSz - sendBuffer->idx;
+            ret = (bufSz < (sendBuffer->fileSz - sendBuffer->idx))?
+                bufSz : sendBuffer->fileSz - sendBuffer->idx;
             if (ret > 0) {
+                if (sendBuffer->idx  + ret >= sendBuffer->bufferSz) {
+                    ret = WS_SCP_ABORT;
+                    break;
+                }
                 WMEMCPY(buf, sendBuffer->buffer + sendBuffer->idx, ret);
                 sendBuffer->idx += ret;
             }

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -1043,6 +1043,11 @@ static int ScpCheckForRename(WOLFSSH* ssh, int cmdSz)
     if (idx == 4) { /* case of 4 for drive letter plus ":\" + 1 */
         idx--;
     }
+#else
+    /* allow placing file at base address ':/' */
+    if (sz == 1 && buf[0] == WS_DELIM) {
+        idx--;
+    }
 #endif
     if (idx > cmdSz || idx > sz) {
         return WS_BUFFER_E;
@@ -1057,7 +1062,7 @@ static int ScpCheckForRename(WOLFSSH* ssh, int cmdSz)
         ssh->scpFileName = (char*)WMALLOC(sz + 1, ssh->ctx->heap,
             DYNTYPE_STRING);
         if (ssh->scpFileName == NULL) {
-            WLOG(WS_LOG_DEBUG, scpError, "memory error creaating file name",
+            WLOG(WS_LOG_DEBUG, scpError, "memory error creating file name",
                     WS_MEMORY_E);
             ssh->scpBasePath = NULL;
             return WS_MEMORY_E;
@@ -2533,6 +2538,7 @@ int wsScpRecvCallback(WOLFSSH* ssh, int state, const char* basePath,
             sz = (bufSz < recvBuffer->bufferSz - recvBuffer->idx) ?
                 bufSz : recvBuffer->bufferSz - recvBuffer->idx;
             WMEMCPY(recvBuffer->buffer + recvBuffer->idx, buf, sz);
+            recvBuffer->idx    += sz;
             recvBuffer->fileSz += sz;
             if (recvBuffer->status) {
                 if (recvBuffer->status(ssh, recvBuffer->name,

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -70,8 +70,9 @@ extern "C" {
     #endif
 #endif /* !WOLFSSH_HANDLE */
 
-#ifndef NO_FILESYSTEM
-#ifdef WOLFSSL_NUCLEUS
+#ifdef NO_FILESYSTEM
+    #define WS_DELIM '/'
+#elif defined(WOLFSSL_NUCLEUS)
     #include "storage/nu_storage.h"
 
     #define WFILE int
@@ -276,7 +277,6 @@ extern "C" {
         #endif
     #endif
 #endif
-#endif /* NO_FILESYSTEM */
 
 /* setup string handling */
 #ifndef WSTRING_USER
@@ -369,7 +369,7 @@ extern "C" {
 #endif
 
 #if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
-        !defined(NO_WOLFSSH_SERVER)
+        !defined(NO_WOLFSSH_SERVER) && !defined(NO_FILESYSTEM)
 
     #ifndef SIZEOF_OFF_T
         /* if not using autoconf then make a guess on off_t size based on sizeof

--- a/wolfssh/wolfscp.h
+++ b/wolfssh/wolfscp.h
@@ -52,6 +52,21 @@ extern "C" {
     #define DEFAULT_SCP_BUFFER_SZ DEFAULT_MAX_PACKET_SZ
 #endif
 
+enum WS_ScpFileStates {
+    /* sink */
+    WOLFSSH_SCP_NEW_REQUEST = 0,
+    WOLFSSH_SCP_NEW_FILE,
+    WOLFSSH_SCP_FILE_PART,
+    WOLFSSH_SCP_FILE_DONE,
+    WOLFSSH_SCP_NEW_DIR,
+    WOLFSSH_SCP_END_DIR,
+    /* source */
+    WOLFSSH_SCP_SINGLE_FILE_REQUEST,
+    WOLFSSH_SCP_RECURSIVE_REQUEST,
+    WOLFSSH_SCP_CONTINUE_FILE_TRANSFER
+};
+
+
 #if !defined(WOLFSSH_SCP_USER_CALLBACKS)
 #if !defined(NO_FILESYSTEM)
     #include <time.h>
@@ -80,7 +95,8 @@ extern "C" {
     } ScpDir;
 #else
     /* Use a buffer for built in no filesystem send/recv */
-    typedef struct ScpBuffer {
+    typedef struct ScpBuffer ScpBuffer;
+    struct ScpBuffer {
         char   name[DEFAULT_SCP_FILE_NAME_SZ];
         byte*  buffer;
         word64 mTime;
@@ -89,23 +105,10 @@ extern "C" {
         word32 idx;      /* current index into "buffer" */
         word32 nameSz;
         int   mode;
-    } ScpBuffer;
+        int (*status)(WOLFSSH* ssh, const char* fileName, enum WS_ScpFileStates state, ScpBuffer* file);
+    };
 #endif /* NO_FILESYSTEM */
 #endif /* WOLFSSH_SCP_USER_CALLBACKS */
-
-enum WS_ScpFileStates {
-    /* sink */
-    WOLFSSH_SCP_NEW_REQUEST = 0,
-    WOLFSSH_SCP_NEW_FILE,
-    WOLFSSH_SCP_FILE_PART,
-    WOLFSSH_SCP_FILE_DONE,
-    WOLFSSH_SCP_NEW_DIR,
-    WOLFSSH_SCP_END_DIR,
-    /* source */
-    WOLFSSH_SCP_SINGLE_FILE_REQUEST,
-    WOLFSSH_SCP_RECURSIVE_REQUEST,
-    WOLFSSH_SCP_CONTINUE_FILE_TRANSFER
-};
 
 typedef int (*WS_CallbackScpRecv)(WOLFSSH*, int, const char*, const char*,
                                   int, word64, word64, word32, byte*, word32,

--- a/wolfssh/wolfscp.h
+++ b/wolfssh/wolfscp.h
@@ -52,7 +52,8 @@ extern "C" {
     #define DEFAULT_SCP_BUFFER_SZ DEFAULT_MAX_PACKET_SZ
 #endif
 
-#if !defined(WOLFSSH_SCP_USER_CALLBACKS) && !defined(NO_FILESYSTEM)
+#if !defined(WOLFSSH_SCP_USER_CALLBACKS)
+#if !defined(NO_FILESYSTEM)
     #include <time.h>
     #ifdef HAVE_SYS_TIME_H
         #include <sys/time.h>
@@ -77,7 +78,19 @@ extern "C" {
         WDIR dir;                            /* dir pointer, from opendir() */
         struct ScpDir* next;                 /* previous directory in stack */
     } ScpDir;
-
+#else
+    /* Use a buffer for built in no filesystem send/recv */
+    typedef struct ScpBuffer {
+        char   name[DEFAULT_SCP_FILE_NAME_SZ];
+        byte*  buffer;
+        word64 mTime;
+        word32 bufferSz; /* size of "buffer" */
+        word32 fileSz;   /* size of file in "buffer" */
+        word32 idx;      /* current index into "buffer" */
+        word32 nameSz;
+        int   mode;
+    } ScpBuffer;
+#endif /* NO_FILESYSTEM */
 #endif /* WOLFSSH_SCP_USER_CALLBACKS */
 
 enum WS_ScpFileStates {


### PR DESCRIPTION
To test, compile wolfssl with --disable-filesystem, then compile wolfSSH with --enable-scp.

Run the example server: ./examples/server/server and send a file (will take up to 1024 bytes of the file) or try and get the file test.txt from the server.