### PR TITLE
ECC Update for wolfSSL v4.5.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,11 +52,11 @@ AC_CHECK_SIZEOF([long])
 AC_CHECK_SIZEOF([off_t])
 
 # Check headers/libs
-AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday inet_ntoa memset socket])
 AC_CHECK_HEADERS([sys/select.h sys/time.h pty.h util.h termios.h])
 AC_CHECK_LIB([network],[socket])
 AC_CHECK_LIB([util],[forkpty])
 AC_CHECK_LIB([wolfssl],[wolfCrypt_Init],,[AC_MSG_ERROR([libwolfssl is required for ${PACKAGE}. It can be obtained from https://www.wolfssl.com/download.html/ .])])
+AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday inet_ntoa memset socket wc_ecc_set_rng])
 
 # DEBUG
 DEBUG_CFLAGS="-g -O0"

--- a/src/internal.c
+++ b/src/internal.c
@@ -48,6 +48,16 @@
 #endif
 
 
+/*
+Flags:
+  HAVE_WC_ECC_SET_RNG
+    Set by configure if wc_ecc_set_rng() discovered in wolfCrypt.  Disables
+    use of the function if the flag isn't set. If using wolfCrypt v4.5.0 or
+    later, and not building with configure, set this flag.
+    default: off
+*/
+
+
 static const char sshProtoIdStr[] = "SSH-2.0-wolfSSHv"
                                     LIBWOLFSSH_VERSION_STRING
                                     "\r\n";

--- a/src/internal.c
+++ b/src/internal.c
@@ -2766,6 +2766,10 @@ static int DoKexDhReply(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
 
             ret = wc_ecc_init_ex(&sigKeyBlock.sk.ecc.key, ssh->ctx->heap,
                                  INVALID_DEVID);
+#ifdef HAVE_WC_ECC_SET_RNG
+            if (ret == WS_SUCCESS)
+                ret = wc_ecc_set_rng(&sigKeyBlock.sk.ecc.key, ssh->rng);
+#endif
             if (ret != 0)
                 ret = WS_ECC_E;
             else
@@ -2814,6 +2818,10 @@ static int DoKexDhReply(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
             else {
                 ecc_key key;
                 ret = wc_ecc_init(&key);
+#ifdef HAVE_WC_ECC_SET_RNG
+            if (ret == WS_SUCCESS)
+                ret = wc_ecc_set_rng(&key, ssh->rng);
+#endif
                 if (ret == 0)
                     ret = wc_ecc_import_x963(f, fSz, &key);
                 if (ret == 0)
@@ -6400,6 +6408,10 @@ int SendKexDhReply(WOLFSSH* ssh)
                 if (ret == 0)
                     ret = wc_ecc_init_ex(&privKey, ssh->ctx->heap,
                                          INVALID_DEVID);
+#ifdef HAVE_WC_ECC_SET_RNG
+                if (ret == 0)
+                    ret = wc_ecc_set_rng(&privKey, ssh->rng);
+#endif
 
                 if (ret == 0)
                     ret = wc_ecc_import_x963_ex(ssh->handshake->e,
@@ -6908,7 +6920,10 @@ int SendKexDhInit(WOLFSSH* ssh)
             if (ret == 0)
                 ret = wc_ecc_init_ex(privKey, ssh->ctx->heap,
                                      INVALID_DEVID);
-
+#ifdef HAVE_WC_ECC_SET_RNG
+            if (ret == 0)
+                ret = wc_ecc_set_rng(privKey, ssh->rng);
+#endif
             if (ret == 0)
                 ret = wc_ecc_make_key_ex(ssh->rng,
                                      wc_ecc_get_curve_size_from_id(primeId),


### PR DESCRIPTION
wolfSSL v4.5.0 introduced a new function, `wc_ecc_set_rng()`, which is present when ECC_TIMING_RESISTANCE is enabled. Added a check to the configure script for that function, and disable calls to the function if it isn't present. This allows wolfSSH to build against older versions of wolfSSL.