### PR TITLE
Release 1.4.5

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,33 @@
+# wolfSSH v1.4.5 (August 31, 2020)
+
+## New Feature Additions
+
+- Added SSH-AGENT support to the echoserver and client
+- For testing purposes, add ability to have named users with authentication
+  type of "none"
+- Added support for building for EWARM
+- Echoserver can now spawn a shell and set up a pty with it
+- Added example to the SCP callback for file transfers without a filesystem
+
+## Fixes
+
+- Fixes for clean connection shutdown in the example.
+- Fixes for some issues with DH KEX discovered with fuzz testing
+- Fix for an OOB read around the RSA signature
+- Fix for building with wolfSSL v4.5.0 with respect to `wc_ecc_set_rng()`;
+  configure will detect the function's presence and work around it absence;
+  see note in internal.c regarding the flag `HAVE_WC_ECC_SET_RNG` if not
+  using configure
+
+## Improvements and Optimizations
+
+- Improved interoperability with winSCP
+- Improved interoperability with Dropbear
+- Example client can now authenticate with public keys
+
+
+--------------------------------
+
 # wolfSSH v1.4.4 (04/28/2020)
 
 ## New Feature Additions

--- a/README
+++ b/README
@@ -91,6 +91,14 @@ To use public key authentication use the command line:
 
 Where the *USER* can be `gretel` or `hansel`, and *TYPE* is `rsa` or `ecc`.
 
+Keep in mind, the echoserver has several fake accounts in its wsUserAuth
+callback function. (jack, jill, hansel, and gretel) When the shell support is
+enabled, those fake accounts will not work. They don't exist in the system's
+passwd file. The users will authenticate, but the server will err out because
+they don't exist in the system. You can add your own username to the password
+or public key list in the echoserver. That account will be logged into a shell
+started by the echoserver with the privileges of the user running echoserver.
+
 
 scp support
 -----------

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AC_ARG_PROGRAM
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([src/config.h])
 
-WOLFSSH_LIBRARY_VERSION=11:0:2
+WOLFSSH_LIBRARY_VERSION=12:0:3
 #                       | | |
 #                +------+ | +---+
 #                |        |     |

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -588,12 +588,12 @@ static int shell_worker(thread_ctx_t* threadCtx)
         memset((void *)&buf_rx, 0, sizeof(buf_rx));
         memset((void *)&buf_tx, 0, sizeof(buf_tx));
 
-        buf_rx.buf = malloc(SE_BUF_SIZE);
+        buf_rx.buf = (char*)malloc(SE_BUF_SIZE);
         if (buf_rx.buf == NULL) {
             return WS_FATAL_ERROR;
         }
 
-        buf_tx.buf = malloc(SE_BUF_SIZE);
+        buf_tx.buf = (char*)malloc(SE_BUF_SIZE);
         if (buf_tx.buf == NULL) {
             free(buf_rx.buf);
             return WS_FATAL_ERROR;
@@ -601,7 +601,7 @@ static int shell_worker(thread_ctx_t* threadCtx)
 
 #ifdef WOLFSSH_AGENT
         memset((void *)&agent_buf, 0, sizeof(agent_buf));
-        agent_buf.buf = malloc(SE_BUF_SIZE);
+        agent_buf.buf = (char*)malloc(SE_BUF_SIZE);
         if (agent_buf.buf == NULL) {
             free(buf_rx.buf);
             free(buf_tx.buf);

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -2058,7 +2058,8 @@ int ScpPushDir(ScpSendCtx* ctx, const char* path, void* heap)
     }
 
     /* append directory name to ctx->dirName */
-    WSTRNCPY(ctx->dirName, path, DEFAULT_SCP_FILE_NAME_SZ);
+    WSTRNCPY(ctx->dirName, path, DEFAULT_SCP_FILE_NAME_SZ-1);
+    ctx->dirName[DEFAULT_SCP_FILE_NAME_SZ-1] = '\0';
 
     return WS_SUCCESS;
 }


### PR DESCRIPTION
1. Update the readme, changelog, and configure.ac for the new version.
2. Cleanup some errors from building the code with a C++ compiler as a part of the test.