### PR TITLE
Optional Builds

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -869,6 +869,10 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     if (username == NULL)
         err_sys("client requires a username parameter.");
 
+#ifdef NO_RSA
+    userEcc = 1;
+#endif
+
 #ifdef SINGLE_THREADED
     if (keepOpen)
         err_sys("Threading needed for terminal session\n");

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1602,6 +1602,12 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
     }
 #endif
 
+#ifdef NO_RSA
+    /* If wolfCrypt isn't built with RSA, force ECC on. */
+    userEcc = 1;
+    peerEcc = 1;
+#endif
+
     if (wolfSSH_Init() != WS_SUCCESS) {
         fprintf(stderr, "Couldn't initialize wolfSSH.\n");
         exit(EXIT_FAILURE);

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -660,6 +660,11 @@ THREAD_RETURN WOLFSSH_THREAD server_test(void* args)
     }
     myoptind = 0;      /* reset for test cases */
 
+#ifdef NO_RSA
+    /* If wolfCrypt isn't built with RSA, force ECC on. */
+    useEcc = 1;
+#endif
+
     if (wolfSSH_Init() != WS_SUCCESS) {
         fprintf(stderr, "Couldn't initialize wolfSSH.\n");
         exit(EXIT_FAILURE);

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1329,6 +1329,11 @@ THREAD_RETURN WOLFSSH_THREAD sftpclient_test(void* args)
     if (username == NULL)
         err_sys("client requires a username parameter.");
 
+#ifdef NO_RSA
+    userEcc = 1;
+    /* peerEcc = 1; */
+#endif
+
     if (autopilot != AUTOPILOT_OFF) {
         if (apLocal == NULL || apRemote == NULL) {
             err_sys("Options -G and -g require both -l and -r.");

--- a/src/agent.c
+++ b/src/agent.c
@@ -379,6 +379,7 @@ static int PostUnlock(WOLFSSH_AGENT_CTX* agent,
 }
 
 
+#ifndef NO_RSA
 static int PostAddRsaId(WOLFSSH_AGENT_CTX* agent,
         byte keyType, byte* key, word32 keySz,
         word32 nSz, word32 eSz, word32 dSz,
@@ -457,6 +458,7 @@ static int PostAddRsaId(WOLFSSH_AGENT_CTX* agent,
     WLOG_LEAVE(ret);
     return ret;
 }
+#endif
 
 
 static int PostAddEcdsaId(WOLFSSH_AGENT_CTX* agent,
@@ -667,6 +669,7 @@ static int PostSignRequest(WOLFSSH_AGENT_CTX* agent,
         int sigSz = sizeof(sig);
 
         if (cur->keyType == ID_SSH_RSA) {
+#ifndef NO_RSA
             WOLFSSH_AGENT_KEY_RSA* key;
             RsaKey rsa;
             byte encSig[MAX_ENCODED_SIG_SZ];
@@ -708,6 +711,7 @@ static int PostSignRequest(WOLFSSH_AGENT_CTX* agent,
             wc_FreeRsaKey(&rsa);
             if (ret != 0)
                 ret = WS_RSA_E;
+#endif
         }
         else if (cur->keyType == ID_ECDSA_SHA2_NISTP256) {
             WOLFSSH_AGENT_KEY_ECDSA* key;
@@ -942,6 +946,7 @@ static int DoAddIdentity(WOLFSSH_AGENT_CTX* agent,
 
         begin += sz;
         if (keyType == ID_SSH_RSA) {
+#ifndef NO_RSA
             byte* key;
             byte* scratch;
             word32 keySz, nSz, eSz, dSz, iqmpSz, pSz, qSz, commentSz;
@@ -983,6 +988,7 @@ static int DoAddIdentity(WOLFSSH_AGENT_CTX* agent,
                 ret = PostAddRsaId(agent, keyType, key, keySz,
                         nSz, eSz, dSz, iqmpSz, pSz, qSz, commentSz);
             }
+#endif
         }
         else if (keyType == ID_ECDSA_SHA2_NISTP256 ||
                 keyType == ID_ECDSA_SHA2_NISTP384 ||

--- a/src/keygen.c
+++ b/src/keygen.c
@@ -57,6 +57,8 @@
 int wolfSSH_MakeRsaKey(byte* out, word32 outSz,
                        word32 size, word32 e)
 {
+#ifndef NO_RSA
+
     int ret = WS_SUCCESS;
     WC_RNG rng;
 
@@ -105,6 +107,13 @@ int wolfSSH_MakeRsaKey(byte* out, word32 outSz,
 
     WLOG(WS_LOG_DEBUG, "Leaving wolfSSH_MakeRsaKey(), ret = %d", ret);
     return ret;
+#else
+    (void)out;
+    (void)outSz;
+    (void)size;
+    (void)e;
+    return WS_NOT_COMPILED;
+#endif
 }
 
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1441,7 +1441,9 @@ int wolfSSH_ReadKey_buffer(const byte* in, word32 inSz, int format,
     else if (format == WOLFSSH_FORMAT_ASN1) {
         byte* newKey;
         union {
-            RsaKey rsa;
+            #ifndef NO_RSA
+                RsaKey rsa;
+            #endif
             ecc_key ecc;
         } testKey;
         word32 scratch = 0;
@@ -1459,7 +1461,7 @@ int wolfSSH_ReadKey_buffer(const byte* in, word32 inSz, int format,
         }
         *outSz = inSz;
         WMEMCPY(newKey, in, inSz);
-
+#ifndef NO_RSA
         /* TODO: This is copied and modified from a function in src/internal.c.
            This and that code should be combined into a single function. */
         if (wc_InitRsaKey(&testKey.rsa, heap) < 0)
@@ -1474,6 +1476,7 @@ int wolfSSH_ReadKey_buffer(const byte* in, word32 inSz, int format,
             *outTypeSz = (word32)WSTRLEN((const char*)*outType);
         }
         else {
+#endif
             /* Couldn't decode as RSA testKey. Try decoding as ECC testKey. */
             scratch = 0;
             if (wc_ecc_init_ex(&testKey.ecc, heap, INVALID_DEVID) != 0)
@@ -1489,7 +1492,9 @@ int wolfSSH_ReadKey_buffer(const byte* in, word32 inSz, int format,
             }
             else
                 return WS_BAD_FILE_E;
+#ifndef NO_RSA
         }
+#endif
     }
     else
         ret = WS_ERROR;

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -722,8 +722,11 @@ int wolfSSH_connect(WOLFSSH* ssh)
                 return WS_FATAL_ERROR;
             }
 
-            if (ssh->handshake->kexId == ID_DH_GEX_SHA256)
+            if (ssh->handshake->kexId == ID_DH_GEX_SHA256) {
+#ifndef NO_DH
                 ssh->error = SendKexDhGexRequest(ssh);
+#endif
+            }
             else
                 ssh->error = SendKexDhInit(ssh);
             if (ssh->error < WS_SUCCESS) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -570,9 +570,10 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
     AssertNotNull(ctx->privateKey);
     AssertIntNE(0, ctx->privateKeySz);
     AssertIntEQ(ECC_SECP256R1, ctx->useEcc);
+
+#ifndef NO_RSA
     lastKey = ctx->privateKey;
     lastKeySz = ctx->privateKeySz;
-
     AssertIntEQ(WS_SUCCESS,
         wolfSSH_CTX_UsePrivateKey_buffer(ctx, rsaKey, rsaKeySz,
                                          TEST_GOOD_FORMAT_ASN1));
@@ -581,6 +582,10 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
     AssertIntEQ(0, ctx->useEcc);
     AssertIntEQ(0, (lastKey == ctx->privateKey));
     AssertIntNE(lastKeySz, ctx->privateKeySz);
+#else
+    (void)lastKey;
+    (void)lastKeySz;
+#endif
 
     wolfSSH_CTX_free(ctx);
     FreeBins(eccKey, rsaKey, NULL, NULL);

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -270,6 +270,7 @@ typedef struct HandshakeInfo {
     byte* kexInit;
     word32 kexInitSz;
 
+#ifndef NO_DH
     word32 dhGexMinSz;
     word32 dhGexPreferredSz;
     word32 dhGexMaxSz;
@@ -277,10 +278,13 @@ typedef struct HandshakeInfo {
     word32 primeGroupSz;
     byte* generator;
     word32 generatorSz;
+#endif
 
     byte useEcc;
     union {
+#ifndef NO_DH
         DhKey dh;
+#endif
         ecc_key ecc;
     } privKey;
 } HandshakeInfo;


### PR DESCRIPTION
If options are disabled in wolfCrypt, they shouldn't be used in wolfSSH. Currently covers DH and RSA.