### PR TITLE
Null Agent

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4620,7 +4620,10 @@ static int DoChannelOpen(WOLFSSH* ssh,
         #ifdef WOLFSSH_AGENT
             case ID_CHANTYPE_AUTH_AGENT:
                 WLOG(WS_LOG_INFO, "agent = %p", ssh->agent);
-                ssh->agent->channel = peerChannelId;
+                if (ssh->agent != NULL)
+                    ssh->agent->channel = peerChannelId;
+                else
+                    ret = WS_AGENT_NULL_E;
                 break;
         #endif
             default:


### PR DESCRIPTION
Check that the agent was set in the SSH session before trying to set its channel ID. (ZD 11099)