### PR TITLE
Fix configuration WOLFSSH_NO_DH

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6556,7 +6556,7 @@ int SendKexDhReply(WOLFSSH* ssh)
 {
     int ret = WS_SUCCESS;
     byte *f_ptr = NULL, *sig_ptr = NULL;
-    byte *y_ptr = NULL, *r_ptr = NULL, *s_ptr = NULL;
+    byte *r_ptr = NULL, *s_ptr = NULL;
     byte scratchLen[LENGTH_SZ];
     word32 fSz = KEX_F_SIZE;
     word32 sigSz = KEX_SIG_SIZE;
@@ -6571,6 +6571,7 @@ int SendKexDhReply(WOLFSSH* ssh)
     byte msgId = MSGID_KEXDH_REPLY;
     enum wc_HashType enmhashId;
 #ifndef WOLFSSH_NO_DH
+    byte *y_ptr = NULL;
     const byte* primeGroup = NULL;
     word32 primeGroupSz = 0;
     const byte* generator = NULL;
@@ -7242,8 +7243,10 @@ int SendKexDhReply(WOLFSSH* ssh)
         WFREE(f_ptr, ssh->ctx->heap, DYNTYPE_BUFFER);
     if (sig_ptr)
         WFREE(sig_ptr, ssh->ctx->heap, DYNTYPE_BUFFER);
+#ifndef WOLFSSH_NO_DH
     if (y_ptr)
         WFREE(r_ptr, ssh->ctx->heap, DYNTYPE_PRIVKEY);
+#endif
     if (r_ptr)
         WFREE(r_ptr, ssh->ctx->heap, DYNTYPE_BUFFER);
     if (s_ptr)

--- a/src/internal.c
+++ b/src/internal.c
@@ -6575,8 +6575,8 @@ int SendKexDhReply(WOLFSSH* ssh)
     word32 primeGroupSz = 0;
     const byte* generator = NULL;
     word32 generatorSz = 0;
-    struct wolfSSH_sigKeyBlockFull *sigKeyBlock_ptr;
 #endif
+    struct wolfSSH_sigKeyBlockFull *sigKeyBlock_ptr;
 #ifdef WOLFSSH_SMALL_STACK
     sigKeyBlock_ptr = WMALLOC(sizeof(struct wolfSSH_sigKeyBlockFull),
             ssh->ctx->heap, DYNTYPE_PRIVKEY);


### PR DESCRIPTION
Fixed broken configuration when compiling with `WOLFSSH_NO_DH`

This regression was introduced by PR #327 