### PR TITLE
DH Size Fix

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -437,6 +437,8 @@ static HandshakeInfo* HandshakeInfoNew(void* heap)
         newHs->macId = ID_NONE;
         newHs->blockSz = MIN_BLOCK_SZ;
         newHs->hashId = WC_HASH_TYPE_NONE;
+        newHs->eSz = sizeof newHs->e;
+        newHs->xSz = sizeof newHs->x;
 #ifndef WOLFSSH_NO_DH_GEX_SHA256
         newHs->dhGexMinSz = WOLFSSH_DEFAULT_GEXDH_MIN;
         newHs->dhGexPreferredSz = WOLFSSH_DEFAULT_GEXDH_PREFERRED;


### PR DESCRIPTION
When creating the handshake info, initialize the size of the e and x values to their sizes. To recreate issue:

    wolfSSL: ./configure CPPFLAGS="-DFP_MAX_BITS=6144"
    wolfSSH: ./configure CPPFLAGS="-DWOLFSSH_NO_ECDH"