### PR TITLE
Fix for NO_FILESYSTEM and WOLFSSH_NO_AES_GCM and !HAVE_ECC

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1123,14 +1123,14 @@ static int load_key(byte isEcc, byte* buf, word32 bufSz)
 #else
     /* using buffers instead */
     if (isEcc) {
-        if (sizeof_ecc_key_der_256 > bufSz) {
+        if ((word32)sizeof_ecc_key_der_256 > bufSz) {
             return 0;
         }
         WMEMCPY(buf, ecc_key_der_256, sizeof_ecc_key_der_256);
         sz = sizeof_ecc_key_der_256;
     }
     else {
-        if (sizeof_rsa_key_der_2048 > bufSz) {
+        if ((word32)sizeof_rsa_key_der_2048 > bufSz) {
             return 0;
         }
         WMEMCPY(buf, (byte*)rsa_key_der_2048, sizeof_rsa_key_der_2048);

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -313,14 +313,14 @@ static int load_key(byte isEcc, byte* buf, word32 bufSz)
 #else
     /* using buffers instead */
     if (isEcc) {
-        if (sizeof_ecc_key_der_256 > bufSz) {
+        if ((word32)sizeof_ecc_key_der_256 > bufSz) {
             return 0;
         }
         WMEMCPY(buf, ecc_key_der_256, sizeof_ecc_key_der_256);
         sz = sizeof_ecc_key_der_256;
     }
     else {
-        if (sizeof_rsa_key_der_2048 > bufSz) {
+        if ((word32)sizeof_rsa_key_der_2048 > bufSz) {
             return 0;
         }
         WMEMCPY(buf, rsa_key_der_2048, sizeof_rsa_key_der_2048);

--- a/src/internal.c
+++ b/src/internal.c
@@ -2281,6 +2281,7 @@ static INLINE enum wc_HashType HashForId(byte id)
 }
 
 
+#ifndef WOLFSSH_NO_ECDSA
 static INLINE int wcPrimeForId(byte id)
 {
     switch (id) {
@@ -2317,7 +2318,6 @@ static INLINE int wcPrimeForId(byte id)
     }
 }
 
-#ifndef WOLFSSH_NO_ECDSA
 static INLINE const char *PrimeNameForId(byte id)
 {
     switch (id) {
@@ -2337,7 +2337,7 @@ static INLINE const char *PrimeNameForId(byte id)
             return "unknown";
     }
 }
-#endif
+#endif /* WOLFSSH_NO_ECDSA */
 
 
 static INLINE byte AeadModeForId(byte id)
@@ -5884,6 +5884,7 @@ static INLINE int VerifyMac(WOLFSSH* ssh, const byte* in, word32 inSz,
 }
 
 
+#ifndef WOLFSSH_NO_AEAD
 static INLINE void AeadIncrementExpIv(byte* iv)
 {
     int i;
@@ -5896,7 +5897,6 @@ static INLINE void AeadIncrementExpIv(byte* iv)
 }
 
 
-#ifndef WOLFSSH_NO_AEAD
 static INLINE int EncryptAead(WOLFSSH* ssh, byte* cipher,
                               const byte* input, word16 sz,
                               byte* authTag, const byte* auth,
@@ -5968,7 +5968,7 @@ static INLINE int DecryptAead(WOLFSSH* ssh, byte* plain,
 
     return ret;
 }
-#endif
+#endif /* WOLFSSH_NO_AEAD */
 
 
 int DoReceive(WOLFSSH* ssh)
@@ -6432,7 +6432,7 @@ static const char cannedKeyAlgoClientNames[] =
 #endif
 
 static const char cannedKeyAlgoRsaNames[] = "ssh-rsa";
-#if !defined(WOLFSSH_NO_ECDSA)
+#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
 static const char cannedKeyAlgoEcc256Names[] = "ecdsa-sha2-nistp256";
 static const char cannedKeyAlgoEcc384Names[] = "ecdsa-sha2-nistp384";
 static const char cannedKeyAlgoEcc521Names[] = "ecdsa-sha2-nistp521";
@@ -7683,6 +7683,8 @@ int SendKexDhInit(WOLFSSH* ssh)
                                      privKey, primeId);
             if (ret == 0)
                 ret = wc_ecc_export_x963(privKey, e, &eSz);
+#else
+            ret = WS_INVALID_ALGO_ID;
 #endif /* !defined(WOLFSSH_NO_ECDH) */
         }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -2281,7 +2281,7 @@ static INLINE enum wc_HashType HashForId(byte id)
 }
 
 
-#ifndef WOLFSSH_NO_ECDSA
+#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
 static INLINE int wcPrimeForId(byte id)
 {
     switch (id) {
@@ -2310,11 +2310,7 @@ static INLINE int wcPrimeForId(byte id)
             return ECC_SECP521R1;
 #endif
         default:
-#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
             return ECC_CURVE_INVALID;
-#else
-            return -1;
-#endif
     }
 }
 
@@ -2875,10 +2871,14 @@ static int DoKexDhReply(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
     int ret = WS_SUCCESS;
     int tmpIdx = 0;
     struct wolfSSH_sigKeyBlock *sigKeyBlock_ptr = NULL;
+#ifndef WOLFSSH_NO_ECDH
     ecc_key *key_ptr = NULL;
+    #ifndef WOLFSSH_SMALL_STACK
+        ecc_key key_s;
+    #endif
+#endif
 #ifndef WOLFSSH_SMALL_STACK
     struct wolfSSH_sigKeyBlock s_sigKeyBlock;
-    ecc_key key_s;
 #endif
 
     WLOG(WS_LOG_DEBUG, "Entering DoKexDhReply()");
@@ -6665,7 +6665,9 @@ int SendKexDhReply(WOLFSSH* ssh)
 {
     int ret = WS_SUCCESS;
     byte *f_ptr = NULL, *sig_ptr = NULL;
+#ifndef WOLFSSH_NO_ECDH
     byte *r_ptr = NULL, *s_ptr = NULL;
+#endif
     byte scratchLen[LENGTH_SZ];
     word32 fSz = KEX_F_SIZE;
     word32 sigSz = KEX_SIG_SIZE;

--- a/src/internal.c
+++ b/src/internal.c
@@ -2309,7 +2309,11 @@ static INLINE int wcPrimeForId(byte id)
             return ECC_SECP521R1;
 #endif
         default:
+#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
             return ECC_CURVE_INVALID;
+#else
+            return -1;
+#endif
     }
 }
 
@@ -6428,9 +6432,11 @@ static const char cannedKeyAlgoClientNames[] =
 #endif
 
 static const char cannedKeyAlgoRsaNames[] = "ssh-rsa";
+#if !defined(WOLFSSH_NO_ECDSA)
 static const char cannedKeyAlgoEcc256Names[] = "ecdsa-sha2-nistp256";
 static const char cannedKeyAlgoEcc384Names[] = "ecdsa-sha2-nistp384";
 static const char cannedKeyAlgoEcc521Names[] = "ecdsa-sha2-nistp521";
+#endif
 
 static const char cannedKexAlgoNames[] =
 #if !defined(WOLFSSH_NO_ECDH_SHA2_NISTP521)
@@ -6470,12 +6476,14 @@ static const word32 cannedMacAlgoNamesSz = sizeof(cannedMacAlgoNames) - 2;
 static const word32 cannedKeyAlgoClientNamesSz =
                                            sizeof(cannedKeyAlgoClientNames) - 2;
 static const word32 cannedKeyAlgoRsaNamesSz = sizeof(cannedKeyAlgoRsaNames) - 1;
+#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
 static const word32 cannedKeyAlgoEcc256NamesSz =
                                            sizeof(cannedKeyAlgoEcc256Names) - 1;
 static const word32 cannedKeyAlgoEcc384NamesSz =
                                            sizeof(cannedKeyAlgoEcc384Names) - 1;
 static const word32 cannedKeyAlgoEcc521NamesSz =
                                            sizeof(cannedKeyAlgoEcc521Names) - 1;
+#endif
 static const word32 cannedKexAlgoNamesSz = sizeof(cannedKexAlgoNames) - 2;
 static const word32 cannedNoneNamesSz = sizeof(cannedNoneNames) - 1;
 
@@ -6509,6 +6517,7 @@ int SendKexInit(WOLFSSH* ssh)
     if (ret == WS_SUCCESS) {
         if (ssh->ctx->side == WOLFSSH_ENDPOINT_SERVER) {
             switch (ssh->ctx->useEcc) {
+#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
                 case ECC_SECP256R1:
                     cannedKeyAlgoNames = cannedKeyAlgoEcc256Names;
                     cannedKeyAlgoNamesSz = cannedKeyAlgoEcc256NamesSz;
@@ -6521,6 +6530,7 @@ int SendKexInit(WOLFSSH* ssh)
                     cannedKeyAlgoNames = cannedKeyAlgoEcc521Names;
                     cannedKeyAlgoNamesSz = cannedKeyAlgoEcc521NamesSz;
                     break;
+#endif
                 default:
                     cannedKeyAlgoNames = cannedKeyAlgoRsaNames;
                     cannedKeyAlgoNamesSz = cannedKeyAlgoRsaNamesSz;
@@ -7053,6 +7063,7 @@ int SendKexDhReply(WOLFSSH* ssh)
 #endif /* ! WOLFSSH_NO_DH */
             }
             else {
+#if !defined(WOLFSSH_NO_ECDH)
                 ecc_key pubKey;
                 ecc_key privKey;
                 int primeId;
@@ -7088,6 +7099,7 @@ int SendKexDhReply(WOLFSSH* ssh)
                                                ssh->k, &ssh->kSz);
                 wc_ecc_free(&privKey);
                 wc_ecc_free(&pubKey);
+#endif /* !defined(WOLFSSH_NO_ECDH) */
             }
         }
 
@@ -7651,6 +7663,7 @@ int SendKexDhInit(WOLFSSH* ssh)
 #endif
         }
         else {
+#if !defined(WOLFSSH_NO_ECDH)
             ecc_key* privKey = &ssh->handshake->privKey.ecc;
             int primeId = wcPrimeForId(ssh->handshake->kexId);
 
@@ -7670,6 +7683,7 @@ int SendKexDhInit(WOLFSSH* ssh)
                                      privKey, primeId);
             if (ret == 0)
                 ret = wc_ecc_export_x963(privKey, e, &eSz);
+#endif /* !defined(WOLFSSH_NO_ECDH) */
         }
 
         if (ret == 0)

--- a/tests/api.c
+++ b/tests/api.c
@@ -471,7 +471,7 @@ static const char serverKeyEccDer[] =
     "45747a834c61f33fad26cf22cda9a3bca561b47ce662d4c2f755439a31fb8011"
     "20b5124b24f578d7fd22ef4635f005586b5f63c8da1bc4f569";
 static const int serverKeyEccCurveId = ECC_SECP256R1;
-#elif defined(WOLFSSH_NO_ECDSA_SHA2_NISTP384)
+#elif !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP384)
 static const char serverKeyEccDer[] =
     "3081a402010104303eadd2bbbf05a7be3a3f7c28151289de5bb3644d7011761d"
     "b56f2a0362fba64f98e64ff986dc4fb8efdb2d6b8da57142a00706052b810400"
@@ -480,7 +480,7 @@ static const char serverKeyEccDer[] =
     "b4c6a4cf5e97bd7e51e975e3e9217261506eb9cf3c493d3eb88d467b5f27ebab"
     "2161c00066febd";
 static const int serverKeyEccCurveId = ECC_SECP384R1;
-#elif defined(WOLFSSH_NO_ECDSA_SHA2_NISTP521)
+#elif !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP521)
 static const char serverKeyEccDer[] =
     "3081dc0201010442004ca4d86428d9400e7b2df3912eb996c195895043af92e8"
     "6de70ae4df46f22a291a6bb2748aae82580df6c39f49b3ed82f1789ece1b657d"

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -463,7 +463,9 @@ typedef struct HandshakeInfo {
 #ifndef WOLFSSH_NO_DH
         DhKey dh;
 #endif
+#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
         ecc_key ecc;
+#endif
     } privKey;
 } HandshakeInfo;
 


### PR DESCRIPTION
This fixes compiler errors in wolfSSH when wolfSSL is configured with `./configure --enable-ssh --disable-filesystem --disable-aesgcm --disable-ecc`

This issue was reported in https://www.wolfssl.com/forums/topic1711-does-wolfssh-require-aesgcm-and-ecc-and-nofilesystem.html

This PR updates and closes #328.