### PR TITLE
make loading user created keys into the examples easier

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -179,8 +179,10 @@ static void ShowUsage(void)
 
 
 static byte userPassword[256];
-static byte userPublicKey[512];
+static byte userPublicKeyBuf[512];
+static byte* userPublicKey = userPublicKeyBuf;
 static const byte* userPublicKeyType = NULL;
+static const char* pubKeyName = NULL;
 static byte userPrivateKeyBuf[1191]; /* Size equal to hanselPrivateRsaSz. */
 static byte* userPrivateKey = userPrivateKeyBuf;
 static const byte* userPrivateKeyType = NULL;
@@ -377,16 +379,20 @@ static int wsUserAuth(byte authType,
     printf("wolfSSH requesting to use type %d\n", authType);
 #endif
 
-    /* We know hansel has a key, wait for request of public key */
+    /* Wait for request of public key on names known to have one */
     if ((authData->type & WOLFSSH_USERAUTH_PUBLICKEY) &&
             authData->username != NULL &&
-            authData->usernameSz > 0 &&
-            (XSTRNCMP((char*)authData->username, "hansel",
-                authData->usernameSz) == 0)) {
-        if (authType == WOLFSSH_USERAUTH_PASSWORD) {
-            printf("rejecting password type with %s in favor of pub key\n",
+            authData->usernameSz > 0) {
+
+        /* in the case that the name is hansel or in the case that the user
+         * passed in a public key file, use public key auth */
+        if ((XSTRNCMP((char*)authData->username, "hansel",
+                authData->usernameSz) == 0) || pubKeyName != NULL) {
+            if (authType == WOLFSSH_USERAUTH_PASSWORD) {
+                printf("rejecting password type with %s in favor of pub key\n",
                     (char*)authData->username);
-            return WOLFSSH_USERAUTH_FAILURE;
+                return WOLFSSH_USERAUTH_FAILURE;
+            }
         }
     }
 
@@ -809,7 +815,6 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     const char* password = NULL;
     const char* cmd      = NULL;
     const char* privKeyName = NULL;
-    const char* pubKeyName = NULL;
     byte imExit = 0;
     byte nonBlock = 0;
     byte keepOpen = 0;
@@ -945,6 +950,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     }
     else {
     #ifndef NO_FILESYSTEM
+        userPrivateKey = NULL; /* create new buffer based on parsed input */
         ret = wolfSSH_ReadKey_file(privKeyName,
                 (byte**)&userPrivateKey, &userPrivateKeySz,
                 (const byte**)&userPrivateKeyType, &userPrivateKeyTypeSz,
@@ -958,7 +964,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
 
     if (pubKeyName == NULL) {
         byte* p = userPublicKey;
-        userPublicKeySz = sizeof(userPublicKey);
+        userPublicKeySz = sizeof(userPublicKeyBuf);
 
         if (userEcc) {
         #ifdef HAVE_ECC
@@ -981,11 +987,9 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     }
     else {
     #ifndef NO_FILESYSTEM
-        byte* p = userPublicKey;
-        userPublicKeySz = sizeof(userPublicKey);
-
+        userPublicKey = NULL; /* create new buffer based on parsed input */
         ret = wolfSSH_ReadKey_file(pubKeyName,
-                &p, &userPublicKeySz,
+                &userPublicKey, &userPublicKeySz,
                 (const byte**)&userPublicKeyType, &userPublicKeyTypeSz,
                 &isPrivate, NULL);
     #else
@@ -1143,6 +1147,13 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     if (ret != WS_SUCCESS)
         err_sys("Closing client stream failed. Connection could have been closed by peer");
 
+    if (pubKeyName != NULL && userPublicKey != NULL) {
+        WFREE(userPublicKey, NULL, DYNTYPE_PRIVKEY);
+    }
+
+    if (privKeyName != NULL && userPrivateKey != NULL) {
+        WFREE(userPrivateKey, NULL, DYNTYPE_PRIVKEY);
+    }
 #if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)
     wc_ecc_fp_free();  /* free per thread cache */
 #endif

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1335,6 +1335,7 @@ static int LoadPublicKeyBuffer(byte* buf, word32 bufSz, PwMapList* list)
 {
     char* str = (char*)buf;
     char* delimiter;
+    char* end = (char*)buf + bufSz;
     byte* publicKey64;
     word32 publicKey64Sz;
     byte* username;
@@ -1351,12 +1352,14 @@ static int LoadPublicKeyBuffer(byte* buf, word32 bufSz, PwMapList* list)
     if (buf == NULL || bufSz == 0)
         return 0;
 
-    while (*str != 0) {
+    while (str < end && *str != 0) {
         /* Skip the public key type. This example will always be ssh-rsa. */
         delimiter = strchr(str, ' ');
         if (delimiter == NULL) {
             return -1;
         }
+        if (str >= end)
+            break;
         str = delimiter + 1;
         delimiter = strchr(str, ' ');
         if (delimiter == NULL) {
@@ -1365,6 +1368,8 @@ static int LoadPublicKeyBuffer(byte* buf, word32 bufSz, PwMapList* list)
         publicKey64 = (byte*)str;
         *delimiter = 0;
         publicKey64Sz = (word32)(delimiter - str);
+        if (str >= end)
+            break;
         str = delimiter + 1;
         delimiter = strchr(str, '\n');
         if (delimiter == NULL) {


### PR DESCRIPTION
Loading and using created keys can now be done with:

```
ssh-keygen -t rsa -b 4096 -m PEM -f test.key
<convert test.key to DER format test.key.der>
./examples/echoserver/echoserver -j test.key.pub
./examples/client/client -i test.key.der -j test.key.pub -u <username from test.key.pub>
```