### PR TITLE
Fixes when compiling with an old version of GCC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,7 @@ CPPFLAGS="$CPPFLAGS -I${wcpath}/include"
 
 AC_CHECK_LIB([wolfssl],[wolfCrypt_Init],,[AC_MSG_ERROR([libwolfssl is required for ${PACKAGE}. It can be obtained from https://www.wolfssl.com/download.html/ .])])
 AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday inet_ntoa memset socket wc_ecc_set_rng])
+AC_CHECK_DECLS([[pread],[pwrite]],,[unistd.h])
 
 # DEBUG
 DEBUG_CFLAGS="-g -O0"

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AM_INIT_AUTOMAKE([1.11 -Wall -Werror -Wno-portability foreign tar-ustar subdir-o
 
 AC_ARG_PROGRAM
 AC_CONFIG_MACRO_DIR([m4])
-AC_CONFIG_HEADERS([src/config.h])
+AC_CONFIG_HEADERS([config.h])
 
 WOLFSSH_LIBRARY_VERSION=12:3:3
 #                       | | |

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -541,14 +541,17 @@ static THREAD_RET readInput(void* in)
         sz  = (word32)ret;
     #endif
         if (ret <= 0) {
-            err_sys("Error reading stdin");
+            fprintf(stderr, "Error reading stdin\n");
+            return THREAD_RET_SUCCESS;
         }
         /* lock SSH structure access */
         wc_LockMutex(&args->lock);
         ret = wolfSSH_stream_send(args->ssh, buf, sz);
         wc_UnLockMutex(&args->lock);
-        if (ret <= 0)
-            err_sys("Couldn't send data");
+        if (ret <= 0) {
+            fprintf(stderr, "Couldn't send data\n");
+            return THREAD_RET_SUCCESS;
+        }
     }
 #if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)
     wc_ecc_fp_free();  /* free per thread cache */

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -18,6 +18,10 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #define WOLFSSH_TEST_CLIENT
 
 #include <wolfssh/ssh.h>

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -18,12 +18,12 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define WOLFSSH_TEST_SERVER
-#define WOLFSSH_TEST_ECHOSERVER
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
+
+#define WOLFSSH_TEST_SERVER
+#define WOLFSSH_TEST_ECHOSERVER
 
 #ifdef WOLFSSL_USER_SETTINGS
     #include <wolfssl/wolfcrypt/settings.h>

--- a/examples/portfwd/portfwd.c
+++ b/examples/portfwd/portfwd.c
@@ -18,6 +18,10 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #define WOLFSSH_TEST_CLIENT
 #define WOLFSSH_TEST_SERVER
 

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -18,6 +18,10 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #define WOLFSSH_TEST_CLIENT
 
 #include <stdio.h>

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -235,7 +235,7 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
     word16 port = wolfSshPort;
     byte nonBlock = 0;
     enum copyDir dir = copyNone;
-    char ch;
+    int ch;
 
     ((func_args*)args)->return_code = 0;
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -18,6 +18,10 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #define WOLFSSH_TEST_SERVER
 #define WOLFSSH_TEST_THREADING
 

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -18,6 +18,10 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #define WOLFSSH_TEST_CLIENT
 
 #include <wolfssh/ssh.h>

--- a/src/port.c
+++ b/src/port.c
@@ -37,6 +37,13 @@
     #include <stdio.h>
 #endif
 
+/*
+Flags:
+  WOLFSSH_LOCAL_PREAD_PWRITE
+    Defined to use local implementations of pread() and pwrite(). Switched
+    on automatically if pread() or pwrite() aren't found by configure.
+*/
+
 
 #if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
 int wfopen(WFILE** f, const char* filename, const char* mode)
@@ -82,6 +89,16 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
 #endif
 }
 
+
+/* If either pread() or pwrite() are missing, use the local versions. */
+#if (defined(USE_OSE_API) || \
+     !defined(HAVE_DECL_PREAD) || (HAVE_DECL_PREAD == 0) || \
+     !defined(HAVE_DECL_PWRITE) || (HAVE_DECL_PWRITE == 0))
+    #undef WOLFSSH_LOCAL_PREAD_PWRITE
+    #define WOLFSSH_LOCAL_PREAD_PWRITE
+#endif
+
+
 #if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
     !defined(NO_WOLFSSH_SERVER)
 
@@ -90,7 +107,7 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
 
         /* This is current inline in the source. */
 
-    #elif defined(USE_OSE_API)
+    #elif defined(WOLFSSH_LOCAL_PREAD_PWRITE)
 
         int wPwrite(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)
@@ -104,7 +121,6 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
             return ret;
         }
 
-
         int wPread(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)
         {
@@ -117,7 +133,7 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
             return ret;
         }
 
-    #else /* USE_WINDOWS_API USE_OSE_API */
+    #else /* USE_WINDOWS_API WOLFSSH_LOCAL_PREAD_PWRITE */
 
         int wPwrite(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -954,7 +954,7 @@ static INLINE int SFTP_GetSz(byte* buf, word32* sz,
 
 #ifndef WOLFSSH_USER_FILESYSTEM
 static int SFTP_GetAttributes(void* fs, const char* fileName,
-        WS_SFTP_FILEATRB* atr, byte link, void* heap);
+        WS_SFTP_FILEATRB* atr, byte noFollow, void* heap);
 static int SFTP_GetAttributes_Handle(WOLFSSH* ssh, byte* handle, int handleSz,
         WS_SFTP_FILEATRB* atr);
 #endif
@@ -4098,7 +4098,7 @@ static word32 TimeTo32(word16 d, word16 t)
  * returns WS_SUCCESS on success
  */
 int SFTP_GetAttributes(void* fs, const char* fileName, WS_SFTP_FILEATRB* atr,
-        byte link, void* heap)
+        byte noFollow, void* heap)
 {
     DSTAT stats;
     int sz = (int)WSTRLEN(fileName);
@@ -4107,7 +4107,7 @@ int SFTP_GetAttributes(void* fs, const char* fileName, WS_SFTP_FILEATRB* atr,
     (void)heap;
     (void)fs;
 
-    if (link) {
+    if (noFollow) {
         ret = WLSTAT(fileName, &stats);
     }
     else {
@@ -4238,13 +4238,13 @@ int SFTP_GetAttributes_Handle(WOLFSSH* ssh, byte* handle, int handleSz,
  * returns WS_SUCCESS on success
  */
 int SFTP_GetAttributes(void* fs, const char* fileName, WS_SFTP_FILEATRB* atr,
-        byte link, void* heap)
+        byte noFollow, void* heap)
 {
     BOOL error;
     WIN32_FILE_ATTRIBUTE_DATA stats;
 
     WLOG(WS_LOG_SFTP, "Entering SFTP_GetAttributes()");
-    (void)link;
+    (void)noFollow;
     (void)fs;
 
     /* @TODO add proper Windows link support */
@@ -4283,7 +4283,7 @@ int SFTP_GetAttributes(void* fs, const char* fileName, WS_SFTP_FILEATRB* atr,
  * Fills out a WS_SFTP_FILEATRB structure
  * returns WS_SUCCESS on success */
 int SFTP_GetAttributes(void* fs, const char* fileName, WS_SFTP_FILEATRB* atr,
-                       byte link, void* heap)
+                       byte noFollow, void* heap)
 {
     int err, sz;
     MQX_FILE_PTR mfs_ptr;
@@ -4401,7 +4401,7 @@ int SFTP_GetAttributes_Handle(WOLFSSH* ssh, byte* handle, int handleSz,
 /* FatFs has its own structure for file attributes */
 
 static int SFTP_GetAttributes(void* fs, const char* fileName,
-        WS_SFTP_FILEATRB* atr, byte link, void* heap)
+        WS_SFTP_FILEATRB* atr, byte noFollow, void* heap)
 {
     FILINFO info;
     FRESULT ret;
@@ -4522,14 +4522,14 @@ static int SFTP_GetAttributes_Handle(WOLFSSH* ssh, byte* handle, int handleSz,
  * returns WS_SUCCESS on success
  */
 int SFTP_GetAttributes(void* fs, const char* fileName, WS_SFTP_FILEATRB* atr,
-        byte link, void* heap)
+        byte noFollow, void* heap)
 {
     WSTAT_T stats;
 
     (void)heap;
     (void)fs;
 
-    if (link) {
+    if (noFollow) {
         /* Note, for windows, we treat WSTAT and WLSTAT the same. */
         if (WLSTAT(fileName, &stats) != 0) {
             return WS_BAD_FILE_E;
@@ -4620,7 +4620,7 @@ int wolfSSH_SFTP_RecvFSTAT(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
 {
     WS_SFTP_FILEATRB atr;
     word32 handleSz;
-    word32 sz;
+    word32 sz = 0;
     byte*  handle;
     word32 idx = 0;
     int ret = WS_SUCCESS;

--- a/tests/api.c
+++ b/tests/api.c
@@ -18,6 +18,9 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <stdio.h>
 #include <wolfssh/ssh.h>

--- a/tests/sftp.c
+++ b/tests/sftp.c
@@ -18,6 +18,10 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include <stdio.h>
 #include <wolfssh/ssh.h>
 #include <wolfssh/wolfsftp.h>

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -18,6 +18,10 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #define WOLFSSH_TEST_CLIENT
 #define WOLFSSH_TEST_SERVER
 #define WOLFSSH_TEST_THREADING

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -18,6 +18,9 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <stdio.h>
 #include <wolfssh/ssh.h>


### PR DESCRIPTION
1. Add include config.h to the example and test tool sources. They use some of the types from wolfCrypt's types.h and aren't finding them available. Also moved config.h to the top level source directory.
2. In the version of the system I was building for, functions pread() and pwrite() weren't readily available. Added a DECL check to configure to find if they are in unistd.h, and if not use the home brewed wPread() and wPwrite().
3. Cleaned up a bunch of compiler warnings for things like possible use of uninitialized variables and shadowing global names.