### PR TITLE
Small Buffer wolfSCP

### DIFF
--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -622,7 +622,14 @@ int DoScpSource(WOLFSSH* ssh)
                 }
                 ssh->scpBufferedSz -= ret;
                 ret = WS_SUCCESS;
-                if (ssh->scpFileOffset < ssh->scpFileSz) {
+
+                if (ssh->scpBufferedSz > 0) {
+                    /* There is still file data in the buffer to send,
+                     * go ahead and try to send it by repeating this
+                     * state. */
+                    continue;
+                }
+                else if (ssh->scpFileOffset < ssh->scpFileSz) {
                     ssh->scpState = SCP_TRANSFER;
                     ssh->scpRequestType = WOLFSSH_SCP_CONTINUE_FILE_TRANSFER;
 


### PR DESCRIPTION
When using a small file buffer for SCP, there was a combination of file size and channel window size where SCP would read the remainder of the file, close it, send a small message because the peer's window was full, then try reading the file again. The change keeps trying to send if the file buffer still has data. (ZD #13808)