### PR TITLE
SFTP Channel Receive Fix

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1156,6 +1156,9 @@ static int sftp_worker(thread_ctx_t* threadCtx)
         if (error == WS_WANT_READ || error == WS_WANT_WRITE)
             ret = WS_WANT_READ;
 
+        if (error == WS_CHAN_RXD)
+            ret = WS_CHAN_RXD;
+
         if (ret == WS_FATAL_ERROR && error == 0) {
             WOLFSSH_CHANNEL* channel =
                 wolfSSH_ChannelNext(threadCtx->ssh, NULL);

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -1463,6 +1463,7 @@ int wolfSSH_SFTP_read(WOLFSSH* ssh)
                             if (ssh->error != WS_WANT_READ &&
                                     ssh->error != WS_WANT_WRITE &&
                                     ssh->error != WS_REKEYING &&
+                                    ssh->error != WS_CHAN_RXD &&
                                     ssh->error != WS_WINDOW_FULL)
                                 wolfSSH_SFTP_ClearState(ssh, STATE_ID_RECV);
                             return WS_FATAL_ERROR;


### PR DESCRIPTION
1. The echoserver's sftp_worker() was treating the WS_CHAN_RXD status as an error and failing out. Updated to clear the error status.
2. wolfSSH_SFTP_read() was also treating WS_CHAN_RXD status as an error and terminating the transfer. Update to treat like the other status.