### PR TITLE
Fixes for cross compiling with FIPS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # All right reserved.
 
 AC_COPYRIGHT([Copyright (C) 2014-2020 wolfSSL Inc.])
-AC_INIT([wolfssh],[1.4.8],[support@wolfssl.com],[wolfssh],[https://www.wolfssl.com])
+AC_INIT([wolfssh],[1.4.9],[support@wolfssl.com],[wolfssh],[https://www.wolfssl.com])
 AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -18,7 +18,7 @@ AC_ARG_PROGRAM
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 
-WOLFSSH_LIBRARY_VERSION=12:3:3
+WOLFSSH_LIBRARY_VERSION=12:3:4
 #                       | | |
 #                +------+ | +---+
 #                |        |     |
@@ -72,15 +72,15 @@ AC_ARG_WITH(wolfssl,
     if test "x$withval" != "xno" ; then
       if test -d "${withval}/lib" && test -d "${withval}/include"; then
         wcpath=${withval}
+
+        LDFLAGS="$LDFLAGS -L${wcpath}/lib"
+        CPPFLAGS="$CPPFLAGS -I${wcpath}/include"
       else
         AC_MSG_ERROR([wolfSSL path error (${withval}): missing lib and include])
       fi
     fi
   ]
 )
-
-LDFLAGS="$LDFLAGS -L${wcpath}/lib"
-CPPFLAGS="$CPPFLAGS -I${wcpath}/include"
 
 AC_CHECK_LIB([wolfssl],[wolfCrypt_Init],,[AC_MSG_ERROR([libwolfssl is required for ${PACKAGE}. It can be obtained from https://www.wolfssl.com/download.html/ .])])
 AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday inet_ntoa memset socket wc_ecc_set_rng])

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -791,17 +791,19 @@ static int ssh_worker(thread_ctx_t* threadCtx)
                                             shellChannelId,
                                             threadCtx->channelBuffer, cnt_r);
                                     if (cnt_r > 0) {
-                                        ChildRunning = !process_bytes(threadCtx,
+                                        int doStop = process_bytes(threadCtx,
                                                 threadCtx->channelBuffer,
                                                 cnt_r);
+                                        ChildRunning = !doStop;
                                     }
                                 }
                             #else
                             cnt_w = wolfSSH_ChannelIdSend(ssh, shellChannelId,
                                     threadCtx->channelBuffer, cnt_r);
                             if (cnt_r > 0) {
-                                ChildRunning = !process_bytes(threadCtx,
+                                int doStop = process_bytes(threadCtx,
                                         threadCtx->channelBuffer, cnt_r);
+                                ChildRunning = !doStop;
                             }
                             #endif
                             if (cnt_w <= 0)
@@ -879,7 +881,8 @@ static int ssh_worker(thread_ctx_t* threadCtx)
                     cnt_r = (int)read(childFd,
                             threadCtx->shellBuffer,
                             sizeof threadCtx->shellBuffer);
-                    if (cnt_r < 0) {
+                    /* This read will return 0 on EOF */
+                    if (cnt_r <= 0) {
                         int err = errno;
                         if (err != EAGAIN) {
                             #ifdef SHELL_DEBUG

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -854,7 +854,7 @@ int wolfSSH_connect(WOLFSSH* ssh)
             WLOG(WS_LOG_DEBUG, connectState,
                     "CLIENT_CHANNEL_AGENT_REQUEST_SENT");
             ssh->connectState = CONNECT_CLIENT_CHANNEL_AGENT_REQUEST_SENT;
-            FALL_THROUGH;
+            NO_BREAK;
 
         case CONNECT_CLIENT_CHANNEL_AGENT_REQUEST_SENT:
         #if defined(WOLFSSH_TERM) && !defined(NO_FILESYSTEM)

--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -632,15 +632,15 @@ static INLINE void tcp_set_nonblocking(WS_SOCKET_T* sockfd)
 
 
 #ifdef WOLFSSL_NUCLEUS
-	#define WFD_SET_TYPE FD_SET
-	#define WFD_SET NU_FD_Set
-	#define WFD_ZERO NU_FD_Init
-	#define WFD_ISSET NU_FD_Check
+    #define WFD_SET_TYPE FD_SET
+    #define WFD_SET NU_FD_Set
+    #define WFD_ZERO NU_FD_Init
+    #define WFD_ISSET NU_FD_Check
 #else
-	#define WFD_SET_TYPE fd_set
-	#define WFD_SET FD_SET
-	#define WFD_ZERO FD_ZERO
-	#define WFD_ISSET FD_ISSET
+    #define WFD_SET_TYPE fd_set
+    #define WFD_SET FD_SET
+    #define WFD_ZERO FD_ZERO
+    #define WFD_ISSET FD_ISSET
 #endif
 
 /* returns 1 or greater when something is ready to be read */
@@ -890,5 +890,38 @@ static INLINE void ThreadDetach(THREAD_TYPE thread)
 
 #endif /* WOLFSSH_TEST_THREADING */
 
-#endif /* _WOLFSSH_TEST_H_ */
+#ifdef TEST_IPV6
+static INLINE void build_addr_ipv6(struct sockaddr_in6* addr, const char* peer,
+                              word16 port)
+{
+    memset(addr, 0, sizeof(struct sockaddr_in6));
 
+    addr->sin6_family = AF_INET6;
+    addr->sin6_port = htons(port);
+    if ((size_t)peer == INADDR_ANY)
+        addr->sin6_addr = in6addr_any;
+    else {
+        struct addrinfo  hints;
+        struct addrinfo* answer = NULL;
+        int    ret;
+        char   strPort[80];
+
+        memset(&hints, 0, sizeof(hints));
+        hints.ai_family   = AF_INET6;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_protocol = IPPROTO_TCP;
+
+        WSNPRINTF(strPort, sizeof(strPort), "%d", port);
+        strPort[79] = '\0';
+
+        ret = getaddrinfo(peer, strPort, &hints, &answer);
+        if (ret < 0 || answer == NULL)
+            err_sys("getaddrinfo failed");
+
+        memcpy(addr, answer->ai_addr, answer->ai_addrlen);
+        freeaddrinfo(answer);
+    }
+}
+#endif /* TEST_IPV6 */
+
+#endif /* _WOLFSSH_TEST_H_ */

--- a/wolfssh/version.h
+++ b/wolfssh/version.h
@@ -35,8 +35,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFSSH_VERSION_STRING "1.4.8"
-#define LIBWOLFSSH_VERSION_HEX 0x01004008
+#define LIBWOLFSSH_VERSION_STRING "1.4.9"
+#define LIBWOLFSSH_VERSION_HEX 0x01004009
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* Fixes for cross-compiling (don't force library path references).
* Fix for FIPS 140-3 on ECC private key use.
* Fix for IPv6 with scpclient.
* Wrong macro for fall through.
* Add support for flushing file IO using `WOLFSCP_FLUSH`.
* Whitespace cleanups.