### PR TITLE
Detect if ECC needs RNG

### DIFF
--- a/wolfssh/settings.h
+++ b/wolfssh/settings.h
@@ -72,6 +72,15 @@ extern "C" {
     #error only SCP server side supported
 #endif
 
+/* Detect if ECC needs RNG */
+#if !defined(HAVE_WC_ECC_SET_RNG) && \
+    defined(ECC_TIMING_RESISTANT) && (!defined(HAVE_FIPS) || \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
+    !defined(HAVE_SELFTEST)
+    /* Enable use of wc_ecc_set_rng */
+    #define HAVE_WC_ECC_SET_RNG
+#endif    
+    
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The [ecc.c](https://github.com/wolfSSL/wolfssl/blob/c3e4c6b6bc77c4c3d96385563d6134c9e06821bd/wolfcrypt/src/ecc.c#L4389) needs to be supplied a random number for timing resistance features, otherwise we see `err = MISSING_RNG_E`. 

> The wolfSSH library already handles it if you build with `HAVE_WC_ECC_SET_RNG`

In my case, I was using the `WOLFSSL_ESPIDF` in [wolfssl/wolfcrypt/settings.h](https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/wolfcrypt/settings.h#L299) that defines `ECC_TIMING_RESISTANT` but the API is NOT in all wolfSSL versions. For example older FIPS. Thus, this patch.

credit @dgarske for pointing out this fix.