### PR TITLE
Improve detection of ECC RNG requirement

### DIFF
--- a/wolfssh/settings.h
+++ b/wolfssh/settings.h
@@ -72,6 +72,15 @@ extern "C" {
     #error only SCP server side supported
 #endif
 
+/* Detect if ECC needs RNG */
+#if !defined(HAVE_WC_ECC_SET_RNG) && \
+    defined(ECC_TIMING_RESISTANT) && (!defined(HAVE_FIPS) || \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2))) && \
+    !defined(HAVE_SELFTEST)
+    /* Enable use of wc_ecc_set_rng */
+    #define HAVE_WC_ECC_SET_RNG
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Improve detection of ECC RNG requirement when building without `./configure`. For reference this normally comes from the `configure.ac` here https://github.com/wolfSSL/wolfssh/blob/master/configure.ac#L126, however when building without configure this causes an issue with all ECC signing. If the ECC RNG is not set with `wc_ecc_set_rng` then it will result in an ECC signing error `MISSING_RNG_E`.