### PR TITLE
Small Fixes

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -637,6 +637,9 @@ static int ssh_worker(thread_ctx_t* threadCtx)
         p_passwd = getpwnam((const char *)userName);
         if (p_passwd == NULL) {
             /* Not actually a user on the system. */
+            #ifdef SHELL_DEBUG
+                fprintf(stderr, "user %s does not exist\n", userName);
+            #endif
             return WS_FATAL_ERROR;
         }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -2303,7 +2303,7 @@ static INLINE enum wc_HashType HashForId(byte id)
 }
 
 
-#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
+#if !defined(WOLFSSH_NO_ECDSA) || !defined(WOLFSSH_NO_ECDH)
 static INLINE int wcPrimeForId(byte id)
 {
     switch (id) {
@@ -4744,7 +4744,7 @@ static int DoUserAuthFailure(WOLFSSH* ssh,
                         case ID_USERAUTH_PASSWORD:
                             authType |= WOLFSSH_USERAUTH_PASSWORD;
                             break;
-#if !defined(WOLFSSH_NO_RSA) && !defined(WOLFSSH_NO_ECDSA)
+#if !defined(WOLFSSH_NO_RSA) || !defined(WOLFSSH_NO_ECDSA)
                         case ID_USERAUTH_PUBLICKEY:
                             authType |= WOLFSSH_USERAUTH_PUBLICKEY;
                             break;
@@ -8511,7 +8511,7 @@ typedef struct WS_KeySignature {
 
 
 static const char cannedAuths[] =
-#if !defined(WOLFSSH_NO_RSA) && !defined(WOLFSSH_NO_ECDSA)
+#if !defined(WOLFSSH_NO_RSA) || !defined(WOLFSSH_NO_ECDSA)
     "publickey,"
 #endif
     "password,";


### PR DESCRIPTION
1. When the echoserver fails to log in a user, report their name in a debug print.
2. Fixed a few of the guard checks w.r.t. ECDSA enable in internal.c.