### PR TITLE
ESP-IDF Build Cleanup

### DIFF
--- a/ide/Espressif/ESP-IDF/libs/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/libs/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # cmake for wolfssh
-# 
+#
 cmake_minimum_required(VERSION 3.5)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 
@@ -41,10 +41,9 @@ if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
 endif()
 
 set(COMPONENT_SRCEXCLUDE
-    "wolfcrypt/src/aes_asm.S"
-    "wolfcrypt/src/evp.c"
-    "wolfcrypt/src/misc.c"
-    "src/bio.c"
+    "./src/misc.c"
+    "../wolfssl/wolfcrypt/src/evp.c"
+    "../wolfssl/wolfcrypt/src/misc.c"
     )
 set(COMPONENT_PRIV_INCLUDEDIRS . ../wolfssl ../wolfssl/include)
 


### PR DESCRIPTION
1. Update the list of files to leave out of the build. They are from wolfCrypt and aren't needed. Also left out wolfSSH's version of misc.c as it is handled automatically.