### PR TITLE
Fixes directory listing output in sftp.

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -6094,19 +6094,20 @@ WS_SFTPNAME* wolfSSH_SFTP_LS(WOLFSSH* ssh, char* dir)
                 if (names == NULL) {
                     if (ssh->error == WS_WANT_READ ||
                         ssh->error == WS_WANT_WRITE) {
-                        /* Error condition. Clean up previous names that we got
-                         * and return null to indicate error. */
+                        /* Clean up previous names that we got. */
                         wolfSSH_SFTPNAME_list_free(state->name);
                         state->name = NULL;
                         return NULL;
                     }
                     /* Got all the names. Leave the while loop and fall through
                      * because the handle should always be closed. */
-                } else {
+                }
+                else {
                     WS_SFTPNAME* runner = NULL;
                     /* Got more entries so we append them. */
-                    for(runner = state->name; runner->next != NULL;
-                        runner = runner->next);
+                    for (runner = state->name;
+                         runner->next != NULL;
+                         runner = runner->next);
                     runner->next = names;
                 }
             }

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -6017,6 +6017,7 @@ WS_SFTPNAME* wolfSSH_SFTP_LS(WOLFSSH* ssh, char* dir)
 {
     struct WS_SFTP_LS_STATE* state = NULL;
     WS_SFTPNAME* name = NULL;
+    WS_SFTPNAME* names = NULL;
 
     if (ssh == NULL || dir == NULL) {
         WLOG(WS_LOG_SFTP, "Bad argument passed in");
@@ -6078,7 +6079,6 @@ WS_SFTPNAME* wolfSSH_SFTP_LS(WOLFSSH* ssh, char* dir)
 
         case STATE_LS_READDIR:
             /* now read the dir */
-            WS_SFTPNAME* names = NULL;
             state->name = wolfSSH_SFTP_ReadDir(ssh, state->handle, state->sz);
             if (state->name == NULL) {
                 if (ssh->error == WS_WANT_READ || ssh->error == WS_WANT_WRITE) {
@@ -6111,7 +6111,6 @@ WS_SFTPNAME* wolfSSH_SFTP_LS(WOLFSSH* ssh, char* dir)
                     runner->next = names;
                 }
             }
-
             state->state = STATE_LS_CLOSE;
             NO_BREAK;
 


### PR DESCRIPTION
We were only only showing the output of the first message of a directory listing
which is wrong. A directory listing can be composed of several messages so we
must keep reading until there is no more to read.

Fixes ZD14587