### PR TITLE
wolfSSHd Wildcard Config Includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ examples/scpclient/wolfscp
 
 # applications
 apps/wolfsshd/wolfsshd
+apps/wolfsshd/test/test_configuration
 
 # test output
 tests/*.test

--- a/apps/wolfsshd/configuration.c
+++ b/apps/wolfsshd/configuration.c
@@ -59,7 +59,7 @@ struct WOLFSSHD_CONFIG {
     char* authKeysFile;
     long  loginTimer;
     word16 port;
-    byte usePrivilegeSeparation;
+    byte usePrivilegeSeparation:2;
     byte passwordAuth:1;
     byte pubKeyAuth:1;
     byte permitRootLogin:1;
@@ -445,7 +445,7 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value)
     /* Ignore trailing whitespace */
     ptr = value + WSTRLEN(value) - 1;
     while (ptr != value) {
-        if (!WISSPACE(*ptr)) {
+        if (WISSPACE(*ptr)) {
             ptr--;
         }
         else {
@@ -474,7 +474,8 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value)
 
     /* Use wildcard */
     if (found) {
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || \
+    (defined(__APPLE__) && defined(__MACH__))
         int ret;
         struct dirent *dir;
         DIR *d;

--- a/apps/wolfsshd/include.am
+++ b/apps/wolfsshd/include.am
@@ -15,7 +15,7 @@ apps_wolfsshd_test_test_configuration_SOURCES = apps/wolfsshd/test/test_configur
                                                 apps/wolfsshd/auth.c
 apps_wolfsshd_test_test_configuration_LDADD        = src/libwolfssh.la
 apps_wolfsshd_test_test_configuration_DEPENDENCIES = src/libwolfssh.la
-apps_wolfsshd_test_test_configuration_CPPFLAGS     = -DWOLFSSH_SSHD -DWOLFSSHD_UNIT_TEST -Iapps/wolfsshd/
+apps_wolfsshd_test_test_configuration_CPPFLAGS     = $(AM_CPPFLAGS) -DWOLFSSH_SSHD -DWOLFSSHD_UNIT_TEST -Iapps/wolfsshd/
 
 DISTCLEANFILES+= apps/wolfsshd/.libs/wolfsshd \
                  apps/wolfsshd/test/.libs/test_configuration

--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -26,6 +26,76 @@ void Log(const char *const fmt, ...)
     va_end(vlist);
 }
 
+static void CleanupWildcardTest(void)
+{
+    WDIR dir;
+    struct dirent* d;
+    char filepath[MAX_PATH*2]; /* d_name is max_path long */
+
+    if (!WOPENDIR(NULL, NULL, &dir, "./sshd_config.d/")) {
+        while ((d = WREADDIR(&dir)) != NULL) {
+            if (d->d_type != DT_DIR) {
+                WSNPRINTF(filepath, sizeof filepath, "%s%s",
+                        "./sshd_config.d/", d->d_name);
+                WREMOVE(0, filepath);
+            }
+        }
+        WCLOSEDIR(&dir);
+        WRMDIR(0, "./sshd_config.d/");
+    }
+}
+
+static int SetupWildcardTest(void)
+{
+    WFILE* f;
+    const byte fileIds[] = { 0, 1, 50, 59, 99 };
+    word32 fileIdsSz = (word32)(sizeof(fileIds) / sizeof(byte));
+    word32 i;
+    int ret;
+    char filepath[MAX_PATH];
+
+    ret = WMKDIR(0, "./sshd_config.d/", 0755);
+
+    if (ret == 0) {
+        for (i = 0; i < fileIdsSz; i++) {
+            if (fileIds[i] != 0) {
+                WSNPRINTF(filepath, sizeof filepath, "%s%02u-test.conf",
+                        "./sshd_config.d/", fileIds[i]);
+            }
+            else {
+                WSNPRINTF(filepath, sizeof filepath, "%stest.bad",
+                        "./sshd_config.d/");
+            }
+
+            WFOPEN(&f, filepath, "w");
+            if (f) {
+                word32 sz, wr;
+                char contents[20];
+                WSNPRINTF(contents, sizeof contents, "LoginGraceTime %02u",
+                        fileIds[i]);
+                sz = (word32)WSTRLEN(contents);
+                wr = (word32)WFWRITE(contents, sizeof(char), sz, f);
+                WFCLOSE(f);
+                if (sz != wr) {
+                    Log("Couldn't write the contents of file %s\n", filepath);
+                    ret = -1;
+                    break;
+                }
+            }
+            else {
+                Log("Couldn't create the file %s\n", filepath);
+                ret = -1;
+                break;
+            }
+        }
+    }
+    else {
+        Log("Couldn't make the test config directory\n");
+    }
+
+    return ret;
+}
+
 typedef int (*TEST_FUNC)(void);
 typedef struct {
     const char *name;
@@ -110,6 +180,13 @@ static int test_ParseConfigLine(void)
         {"Password auth no", "PasswordAuthentication no", 0},
         {"Password auth yes", "PasswordAuthentication yes", 0},
         {"Password auth invalid", "PasswordAuthentication wolfsshd", 1},
+
+        /* Include files tests. */
+        {"Include file bad", "Include sshd_config.d/test.bad", 1},
+        {"Include file exists", "Include sshd_config.d/01-test.conf", 0},
+        {"Include file DNE", "Include sshd_config.d/test-dne.conf", 1},
+        {"Include wildcard exists", "Include sshd_config.d/*.conf", 0},
+        {"Include wildcard NDE", "Include sshd_config.d/*.dne", 0},
     };
     const int numVectors = (int)(sizeof(vectors) / sizeof(*vectors));
 
@@ -153,12 +230,20 @@ int main(int argc, char** argv)
     (void)argc;
     (void)argv;
 
+    CleanupWildcardTest();
+    ret = SetupWildcardTest();
+    if (ret != 0) {
+        return 1;
+    }
+
     for (i = 0; i < TEST_CASE_CNT; ++i) {
         ret = RunTest(&testCases[i]);
         if (ret != WS_SUCCESS) {
             break;
         }
     }
+
+    CleanupWildcardTest();
 
     return ret;
 }

--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -78,19 +78,20 @@ static int SetupWildcardTest(void)
                 WFCLOSE(f);
                 if (sz != wr) {
                     Log("Couldn't write the contents of file %s\n", filepath);
-                    ret = -1;
+                    ret = WS_FATAL_ERROR;
                     break;
                 }
             }
             else {
                 Log("Couldn't create the file %s\n", filepath);
-                ret = -1;
+                ret = WS_FATAL_ERROR;
                 break;
             }
         }
     }
     else {
         Log("Couldn't make the test config directory\n");
+        ret = WS_FATAL_ERROR;
     }
 
     return ret;
@@ -213,6 +214,7 @@ static int test_ParseConfigLine(void)
                 break;
             }
         }
+        wolfSSHD_ConfigFree(conf);
     }
 
     return ret;
@@ -232,14 +234,13 @@ int main(int argc, char** argv)
 
     CleanupWildcardTest();
     ret = SetupWildcardTest();
-    if (ret != 0) {
-        return 1;
-    }
 
-    for (i = 0; i < TEST_CASE_CNT; ++i) {
-        ret = RunTest(&testCases[i]);
-        if (ret != WS_SUCCESS) {
-            break;
+    if (ret == 0) {
+        for (i = 0; i < TEST_CASE_CNT; ++i) {
+            ret = RunTest(&testCases[i]);
+            if (ret != WS_SUCCESS) {
+                break;
+            }
         }
     }
 

--- a/examples/portfwd/portfwd.c
+++ b/examples/portfwd/portfwd.c
@@ -267,6 +267,8 @@ THREAD_RETURN WOLFSSH_THREAD portfwd_worker(void* args)
                 break;
 
             case 'f':
+                if (myoptarg == NULL)
+                    err_sys("null argument found");
                 fwdFromPort = (word16)atoi(myoptarg);
                 break;
 
@@ -281,6 +283,8 @@ THREAD_RETURN WOLFSSH_THREAD portfwd_worker(void* args)
                 break;
 
             case 't':
+                if (myoptarg == NULL)
+                    err_sys("null argument found");
                 fwdToPort = (word16)atoi(myoptarg);
                 break;
 

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -1217,8 +1217,9 @@ extern "C" {
 
     /* returns 0 on success */
     #define WOPENDIR(fs,h,c,d)  ((*(c) = opendir((d))) == NULL)
-    #define WCLOSEDIR(d) closedir(*(d))
-    #define WREADDIR(d)  readdir(*(d))
+    #define WCLOSEDIR(d)  closedir(*(d))
+    #define WREADDIR(d)   readdir(*(d))
+    #define WREWINDDIR(d) rewinddir(*(d))
 #endif /* NO_WOLFSSH_DIR */
 #endif
 #endif /* WOLFSSH_SFTP or WOLFSSH_SCP */

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -340,7 +340,8 @@ extern "C" {
         #define WCHMOD(fs,f,m)   _chmod((f),(m))
     #endif
 
-    #if (defined(WOLFSSH_SCP) || defined(WOLFSSH_SFTP)) && \
+    #if (defined(WOLFSSH_SCP) || \
+            defined(WOLFSSH_SFTP) || defined(WOLFSSH_SSHD)) && \
         !defined(WOLFSSH_SCP_USER_CALLBACKS)
 
         #ifdef USE_WINDOWS_API
@@ -474,8 +475,9 @@ extern "C" {
     #define WLOCALTIME(c,r) (localtime_r((c),(r))!=NULL)
 #endif
 
-#if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
-        !defined(NO_WOLFSSH_SERVER) && !defined(NO_FILESYSTEM)
+#if (defined(WOLFSSH_SFTP) || \
+        defined(WOLFSSH_SCP) || defined(WOLFSSH_SSHD)) && \
+    !defined(NO_WOLFSSH_SERVER) && !defined(NO_FILESYSTEM)
 
     #ifndef SIZEOF_OFF_T
         /* if not using autoconf then make a guess on off_t size based on sizeof


### PR DESCRIPTION
1. Fix the wildcard config file include.
2. Update the guard flags so macOS can also use wildcards.
3. Change the user priviledge separating setting to a bitfield.
4. Add test_configuration test to gitignore.
5. Process the included config files in strcmp order.
