### PR TITLE
Old Compiler Warning Cleanup (GCC 4.0.2)

### DIFF
--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -714,7 +714,7 @@ static void* HandleConnection(void* arg)
     }
 
     if (ret == WS_SUCCESS || ret == WS_SFTP_COMPLETE) {
-        WPASSWD* pPasswd;
+        WPASSWD* pPasswd = NULL;
         WOLFSSHD_CONFIG* usrConf;
         char* usr;
 

--- a/examples/portfwd/portfwd.c
+++ b/examples/portfwd/portfwd.c
@@ -160,7 +160,7 @@ static int wsUserAuth(byte authType,
                       void* ctx)
 {
     const char* defaultPassword = (const char*)ctx;
-    word32 passwordSz;
+    word32 passwordSz = 0;
     int ret = WOLFSSH_USERAUTH_SUCCESS;
 
     (void)authType;

--- a/src/internal.c
+++ b/src/internal.c
@@ -9392,7 +9392,7 @@ static int BuildUserAuthRequestRsa(WOLFSSH* ssh,
 {
     wc_HashAlg hash;
     byte digest[WC_MAX_DIGEST_SIZE];
-    word32 digestSz;
+    word32 digestSz = 0;
     word32 begin;
     enum wc_HashType hashId = WC_HASH_TYPE_SHA;
     int ret = WS_SUCCESS;
@@ -9563,7 +9563,7 @@ static int BuildUserAuthRequestRsaCert(WOLFSSH* ssh,
 {
     wc_HashAlg hash;
     byte digest[WC_MAX_DIGEST_SIZE];
-    word32 digestSz;
+    word32 digestSz = 0;
     word32 begin;
     enum wc_HashType hashId = WC_HASH_TYPE_SHA;
     int ret = WS_SUCCESS;


### PR DESCRIPTION
Fixed a few "possibly used uninialized variable" warnings.