### PR TITLE
Multiple Server Keys

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -2087,7 +2087,7 @@ static void ShowUsage(void)
     printf(" -?            display this help and exit\n");
     printf(" -1            exit after single (one) connection\n");
     printf(" -e            expect ECC public key from client\n");
-    printf(" -E            use ECC private key\n");
+    printf(" -E            load ECC private key first\n");
 #ifdef WOLFSSH_SHELL
     printf(" -f            echo input\n");
 #endif
@@ -2327,12 +2327,26 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
 
         bufSz = load_key(peerEcc, keyLoadBuf, bufSz);
         if (bufSz == 0) {
-            fprintf(stderr, "Couldn't load key file.\n");
+            fprintf(stderr, "Couldn't load first key file.\n");
             WEXIT(EXIT_FAILURE);
         }
         if (wolfSSH_CTX_UsePrivateKey_buffer(ctx, keyLoadBuf, bufSz,
                                              WOLFSSH_FORMAT_ASN1) < 0) {
-            fprintf(stderr, "Couldn't use key buffer.\n");
+            fprintf(stderr, "Couldn't use first key buffer.\n");
+            WEXIT(EXIT_FAILURE);
+        }
+
+        peerEcc = !peerEcc;
+        bufSz = EXAMPLE_KEYLOAD_BUFFER_SZ;
+
+        bufSz = load_key(peerEcc, keyLoadBuf, bufSz);
+        if (bufSz == 0) {
+            fprintf(stderr, "Couldn't load second key file.\n");
+            WEXIT(EXIT_FAILURE);
+        }
+        if (wolfSSH_CTX_UsePrivateKey_buffer(ctx, keyLoadBuf, bufSz,
+                                             WOLFSSH_FORMAT_ASN1) < 0) {
+            fprintf(stderr, "Couldn't use second key buffer.\n");
             WEXIT(EXIT_FAILURE);
         }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -938,7 +938,13 @@ static void test_wolfSSH_SFTP_SendReadPacket(void)
         }
     }
 
-    AssertIntEQ(wolfSSH_shutdown(ssh), WS_SUCCESS);
+    argsCount = wolfSSH_shutdown(ssh);
+    if (argsCount == WS_SOCKET_ERROR_E) {
+        /* If the socket is closed on shutdown, peer is gone, this is OK. */
+        argsCount = WS_SUCCESS;
+    }
+    AssertIntEQ(argsCount, WS_SUCCESS);
+
     wolfSSH_free(ssh);
     wolfSSH_CTX_free(ctx);
     ThreadJoin(serThread);

--- a/tests/api.c
+++ b/tests/api.c
@@ -473,7 +473,7 @@ static const char serverKeyEccDer[] =
     "7bb87f38c66dd5a00a06082a8648ce3d030107a144034200048113ffa42bb79c"
     "45747a834c61f33fad26cf22cda9a3bca561b47ce662d4c2f755439a31fb8011"
     "20b5124b24f578d7fd22ef4635f005586b5f63c8da1bc4f569";
-static const int serverKeyEccCurveId = ECC_SECP256R1;
+static const byte serverKeyEccCurveId = ID_ECDSA_SHA2_NISTP256;
 #elif !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP384)
 static const char serverKeyEccDer[] =
     "3081a402010104303eadd2bbbf05a7be3a3f7c28151289de5bb3644d7011761d"
@@ -482,7 +482,7 @@ static const char serverKeyEccDer[] =
     "7724316d46a23105873f2986d5c712803a6f471ab86850eb063e108961349cf8"
     "b4c6a4cf5e97bd7e51e975e3e9217261506eb9cf3c493d3eb88d467b5f27ebab"
     "2161c00066febd";
-static const int serverKeyEccCurveId = ECC_SECP384R1;
+static const byte serverKeyEccCurveId = ID_ECDSA_SHA2_NISTP384;
 #elif !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP521)
 static const char serverKeyEccDer[] =
     "3081dc0201010442004ca4d86428d9400e7b2df3912eb996c195895043af92e8"
@@ -492,7 +492,7 @@ static const char serverKeyEccDer[] =
     "d18046a9717f2c6f59519c827095b29a6313306218c235769400d0f96d000a19"
     "3ba346652beb409a9a45c597a3ed932dd5aaae96bf2f317e5a7ac7458b3c6cdb"
     "aa90c355382cdfcdca7377d92eb20a5e8c74237ca5a345b19e3f1a2290b154";
-static const int serverKeyEccCurveId = ECC_SECP521R1;
+static const byte serverKeyEccCurveId = ID_ECDSA_SHA2_NISTP521;
 #endif
 
 #ifndef WOLFSSH_NO_SSH_RSA_SHA1
@@ -552,8 +552,9 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
     byte* rsaKey;
     word32 rsaKeySz;
 #endif
-    byte* lastKey = NULL;
+    const byte* lastKey = NULL;
     word32 lastKeySz = 0;
+    int i;
 
 #if !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP256) || \
     !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP384) || \
@@ -573,77 +574,100 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
 #endif
 
     AssertNotNull(ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL));
-    AssertNull(ctx->privateKey);
-    AssertIntEQ(0, ctx->privateKeySz);
-    AssertIntEQ(0, ctx->useEcc);
+    for (i = 0; i < WOLFSSH_MAX_PVT_KEYS; i++) {
+        AssertNull(ctx->privateKey[i]);
+        AssertIntEQ(0, ctx->privateKeySz[i]);
+        AssertIntEQ(ID_NONE, ctx->privateKeyId[i]);
+    }
+    AssertIntEQ(0, ctx->privateKeyCount);
 
     /* Fail: all NULL/BAD */
     AssertIntNE(WS_SUCCESS,
         wolfSSH_CTX_UsePrivateKey_buffer(NULL, NULL, 0, TEST_BAD_FORMAT_NEXT));
-    AssertNull(ctx->privateKey);
-    AssertIntEQ(0, ctx->privateKeySz);
-    AssertIntEQ(0, ctx->useEcc);
+    AssertNull(ctx->privateKey[0]);
+    AssertIntEQ(0, ctx->privateKeySz[0]);
+    AssertIntEQ(ID_NONE, ctx->privateKeyId[0]);
+    AssertIntEQ(0, ctx->privateKeyCount);
 
     /* Fail: ctx set, others NULL/bad */
     AssertIntNE(WS_SUCCESS,
         wolfSSH_CTX_UsePrivateKey_buffer(ctx, NULL, 0, TEST_BAD_FORMAT_NEXT));
-    AssertNull(ctx->privateKey);
-    AssertIntEQ(0, ctx->privateKeySz);
-    AssertIntEQ(0, ctx->useEcc);
+    AssertNull(ctx->privateKey[0]);
+    AssertIntEQ(0, ctx->privateKeySz[0]);
+    AssertIntEQ(ID_NONE, ctx->privateKeyId[0]);
+    AssertIntEQ(0, ctx->privateKeyCount);
 
     /* Fail: ctx set, key set, others bad */
     AssertIntNE(WS_SUCCESS,
         wolfSSH_CTX_UsePrivateKey_buffer(ctx,
                                          lastKey, 0, TEST_BAD_FORMAT_NEXT));
-    AssertNull(ctx->privateKey);
-    AssertIntEQ(0, ctx->privateKeySz);
-    AssertIntEQ(0, ctx->useEcc);
+    AssertNull(ctx->privateKey[0]);
+    AssertIntEQ(0, ctx->privateKeySz[0]);
+    AssertIntEQ(ID_NONE, ctx->privateKeyId[0]);
+    AssertIntEQ(0, ctx->privateKeyCount);
 
     /* Fail: ctx set, keySz set, others NULL/bad */
     AssertIntNE(WS_SUCCESS,
         wolfSSH_CTX_UsePrivateKey_buffer(ctx, NULL, 1, TEST_BAD_FORMAT_NEXT));
-    AssertNull(ctx->privateKey);
-    AssertIntEQ(0, ctx->privateKeySz);
-    AssertIntEQ(0, ctx->useEcc);
+    AssertNull(ctx->privateKey[0]);
+    AssertIntEQ(0, ctx->privateKeySz[0]);
+    AssertIntEQ(ID_NONE, ctx->privateKeyId[0]);
+    AssertIntEQ(0, ctx->privateKeyCount);
 
     /* Fail: ctx set, key set, keySz set, format invalid */
     AssertIntNE(WS_SUCCESS, wolfSSH_CTX_UsePrivateKey_buffer(ctx,
                 lastKey, lastKeySz, TEST_GOOD_FORMAT_PEM));
-    AssertNull(ctx->privateKey);
-    AssertIntEQ(0, ctx->privateKeySz);
-    AssertIntEQ(0, ctx->useEcc);
+    AssertNull(ctx->privateKey[0]);
+    AssertIntEQ(0, ctx->privateKeySz[0]);
+    AssertIntEQ(ID_NONE, ctx->privateKeyId[0]);
+    AssertIntEQ(0, ctx->privateKeyCount);
 
     /* Pass */
 #if !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP256) || \
     !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP384) || \
     !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP521)
-    lastKey = ctx->privateKey;
-    lastKeySz = ctx->privateKeySz;
+    lastKey = ctx->privateKey[ctx->privateKeyCount];
+    lastKeySz = ctx->privateKeySz[ctx->privateKeyCount];
 
     AssertIntEQ(WS_SUCCESS,
         wolfSSH_CTX_UsePrivateKey_buffer(ctx, eccKey, eccKeySz,
                                          TEST_GOOD_FORMAT_ASN1));
-    AssertNotNull(ctx->privateKey);
-    AssertIntNE(0, ctx->privateKeySz);
-    AssertIntEQ(serverKeyEccCurveId, ctx->useEcc);
+    AssertIntEQ(1, ctx->privateKeyCount);
+    AssertNotNull(ctx->privateKey[0]);
+    AssertIntNE(0, ctx->privateKeySz[0]);
+    AssertIntEQ(serverKeyEccCurveId, ctx->privateKeyId[0]);
 
-    AssertIntEQ(0, (lastKey == ctx->privateKey));
-    AssertIntNE(lastKeySz, ctx->privateKeySz);
+    AssertIntEQ(0, (lastKey == ctx->privateKey[0]));
+    AssertIntNE(lastKeySz, ctx->privateKeySz[0]);
 #endif
 
 #ifndef WOLFSSH_NO_RSA
-    lastKey = ctx->privateKey;
-    lastKeySz = ctx->privateKeySz;
+    lastKey = ctx->privateKey[ctx->privateKeyCount];
+    lastKeySz = ctx->privateKeySz[ctx->privateKeyCount];
 
     AssertIntEQ(WS_SUCCESS,
         wolfSSH_CTX_UsePrivateKey_buffer(ctx, rsaKey, rsaKeySz,
                                          TEST_GOOD_FORMAT_ASN1));
-    AssertNotNull(ctx->privateKey);
-    AssertIntNE(0, ctx->privateKeySz);
-    AssertIntEQ(0, ctx->useEcc);
+    AssertIntNE(0, ctx->privateKeyCount);
+    AssertNotNull(ctx->privateKey[0]);
+    AssertIntNE(0, ctx->privateKeySz[0]);
 
-    AssertIntEQ(0, (lastKey == ctx->privateKey));
-    AssertIntNE(lastKeySz, ctx->privateKeySz);
+    AssertIntEQ(0, (lastKey == ctx->privateKey[0]));
+    AssertIntNE(lastKeySz, ctx->privateKeySz[0]);
+#endif
+
+    /* Add the same keys again. This should succeed. */
+#if !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP256) || \
+    !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP384) || \
+    !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP521)
+    AssertIntEQ(WS_SUCCESS,
+        wolfSSH_CTX_UsePrivateKey_buffer(ctx, eccKey, eccKeySz,
+                                         TEST_GOOD_FORMAT_ASN1));
+#endif
+#ifndef WOLFSSH_NO_RSA
+    AssertIntEQ(WS_SUCCESS,
+        wolfSSH_CTX_UsePrivateKey_buffer(ctx, rsaKey, rsaKeySz,
+                                         TEST_GOOD_FORMAT_ASN1));
 #endif
 
     wolfSSH_CTX_free(ctx);

--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -126,8 +126,9 @@ enum WS_ErrorCodes {
     WS_CERT_OTHER_E         = -1085, /* Other certificate issue */
     WS_CERT_PROFILE_E       = -1086, /* Cert doesn't meet profile reqs */
     WS_CERT_KEY_SIZE_E      = -1087, /* Key size error */
+    WS_CTX_KEY_COUNT        = -1088, /* Adding too many private keys */
     
-    WS_LAST_E               = -1087  /* Update this to indicate last error */
+    WS_LAST_E               = -1088  /* Update this to indicate last error */
 };
 
 

--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -126,7 +126,7 @@ enum WS_ErrorCodes {
     WS_CERT_OTHER_E         = -1085, /* Other certificate issue */
     WS_CERT_PROFILE_E       = -1086, /* Cert doesn't meet profile reqs */
     WS_CERT_KEY_SIZE_E      = -1087, /* Key size error */
-    WS_CTX_KEY_COUNT        = -1088, /* Adding too many private keys */
+    WS_CTX_KEY_COUNT_E      = -1088, /* Adding too many private keys */
     
     WS_LAST_E               = -1088  /* Update this to indicate last error */
 };

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -784,6 +784,8 @@ WOLFSSH_LOCAL void ChannelDelete(WOLFSSH_CHANNEL*, void*);
 WOLFSSH_LOCAL WOLFSSH_CHANNEL* ChannelFind(WOLFSSH*, word32, byte);
 WOLFSSH_LOCAL int ChannelRemove(WOLFSSH*, word32, byte);
 WOLFSSH_LOCAL int ChannelPutData(WOLFSSH_CHANNEL*, byte*, word32);
+WOLFSSH_LOCAL int IdentifyKey(const byte* in, word32 inSz,
+        int isPrivate, void* heap);
 WOLFSSH_LOCAL int wolfSSH_ProcessBuffer(WOLFSSH_CTX*,
                                         const byte*, word32,
                                         int, int);

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -374,6 +374,9 @@ enum {
 #ifndef WOLFSSH_MAX_FILE_SIZE
     #define WOLFSSH_MAX_FILE_SIZE (1024ul * 1024ul * 4)
 #endif
+#ifndef WOLFSSH_MAX_PVT_KEYS
+    #define WOLFSSH_MAX_PVT_KEYS 2
+#endif
 
 WOLFSSH_LOCAL byte NameToId(const char*, word32);
 WOLFSSH_LOCAL const char* IdToName(byte);
@@ -395,7 +398,6 @@ typedef struct Buffer {
     ALIGN16 byte staticBuffer[STATIC_BUFFER_LEN];
     byte dynamicFlag; /* dynamic memory currently in use */
 } Buffer;
-
 
 WOLFSSH_LOCAL int BufferInit(Buffer*, word32, void*);
 WOLFSSH_LOCAL int GrowBuffer(Buffer*, word32, word32);
@@ -431,16 +433,15 @@ struct WOLFSSH_CTX {
 #endif /* WOLFSSH_CERTS */
     WS_CallbackPublicKeyCheck publicKeyCheckCb;
                                       /* Check server's public key callback */
-
-    byte* privateKey;                 /* Owned by CTX */
-    word32 privateKeySz;
-    byte useEcc;                      /* Depends on the private key */
-#ifndef WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256
-    byte useEccKyber;                 /* Depends on the private key */
+    byte* privateKey[WOLFSSH_MAX_PVT_KEYS];
+                                      /* Owned by CTX */
+    word32 privateKeySz[WOLFSSH_MAX_PVT_KEYS];
+#ifdef WOLFSSH_CERTS
+    byte* cert[WOLFSSH_MAX_PVT_KEYS];
+    word32 certSz[WOLFSSH_MAX_PVT_KEYS];
 #endif
-    byte* cert;
-    word32 certSz;
-    byte useCert;
+    byte privateKeyId[WOLFSSH_MAX_PVT_KEYS];
+    word32 privateKeyCount;
     word32 highwaterMark;
     const char* banner;
     word32 bannerSz;


### PR DESCRIPTION
1. Allow user to add multiple server keys to the CTX up to a limit.
2. Clear the list of server's keys when releasing the CTX.
3. Update the API test case.
4. Server key algo list based on keys loaded.
5. Server uses key requested by client.
6. Change echoserver to load ECC and RSA key, -E option to select order.
7. Added a function to identify keys, and another to identify certs.
8. Added a function to add keys or certs to the list of keys and certs.
9. Fix return value for MAC Algo C2S match fail to the correct value.