### PR TITLE
Automake Refactor

### DIFF
--- a/apps/wolfsshd/include.am
+++ b/apps/wolfsshd/include.am
@@ -1,23 +1,22 @@
 if BUILD_SSHD
 
 bin_PROGRAMS += apps/wolfsshd/wolfsshd
-noinst_HEADERS += apps/wolfsshd/configuration.h \
-                  apps/wolfsshd/auth.h
 apps_wolfsshd_wolfsshd_SOURCES = apps/wolfsshd/wolfsshd.c \
                                  apps/wolfsshd/configuration.c \
-                                 apps/wolfsshd/auth.c
+                                 apps/wolfsshd/configuration.h \
+                                 apps/wolfsshd/auth.c \
+                                 apps/wolfsshd/auth.h
 apps_wolfsshd_wolfsshd_LDADD        = src/libwolfssh.la
 apps_wolfsshd_wolfsshd_DEPENDENCIES = src/libwolfssh.la
 
 noinst_PROGRAMS += apps/wolfsshd/test/test_configuration
 apps_wolfsshd_test_test_configuration_SOURCES = apps/wolfsshd/test/test_configuration.c \
                                                 apps/wolfsshd/configuration.c \
-                                                apps/wolfsshd/auth.c
+                                                apps/wolfsshd/configuration.h \
+                                                apps/wolfsshd/auth.c \
+                                                apps/wolfsshd/auth.h
 apps_wolfsshd_test_test_configuration_LDADD        = src/libwolfssh.la
 apps_wolfsshd_test_test_configuration_DEPENDENCIES = src/libwolfssh.la
 apps_wolfsshd_test_test_configuration_CPPFLAGS     = $(AM_CPPFLAGS) -DWOLFSSH_SSHD -DWOLFSSHD_UNIT_TEST -I$(srcdir)/apps/wolfsshd/
-
-DISTCLEANFILES+= apps/wolfsshd/.libs/wolfsshd \
-                 apps/wolfsshd/test/.libs/test_configuration
 
 endif BUILD_SSHD

--- a/examples/client/include.am
+++ b/examples/client/include.am
@@ -3,10 +3,8 @@
 
 if BUILD_EXAMPLE_CLIENTS
 noinst_PROGRAMS += examples/client/client
-noinst_HEADERS += examples/client/client.h
-examples_client_client_SOURCES      = examples/client/client.c
+examples_client_client_SOURCES      = examples/client/client.c \
+                                      examples/client/client.h
 examples_client_client_LDADD        = src/libwolfssh.la
 examples_client_client_DEPENDENCIES = src/libwolfssh.la
 endif
-
-DISTCLEANFILES+= examples/client/.libs/client

--- a/examples/echoserver/include.am
+++ b/examples/echoserver/include.am
@@ -3,11 +3,9 @@
 
 if BUILD_EXAMPLE_SERVERS
 noinst_PROGRAMS += examples/echoserver/echoserver
-noinst_HEADERS += examples/echoserver/echoserver.h
-examples_echoserver_echoserver_SOURCES      = examples/echoserver/echoserver.c
+examples_echoserver_echoserver_SOURCES      = examples/echoserver/echoserver.c \
+                                              examples/echoserver/echoserver.h
 examples_echoserver_echoserver_LDADD        = src/libwolfssh.la
 examples_echoserver_echoserver_DEPENDENCIES = src/libwolfssh.la
 examples_echoserver_echoserver_CFLAGS       = $(AM_CFLAGS)
 endif
-
-DISTCLEANFILES+= examples/echoserver/.libs/echoserver

--- a/examples/portfwd/include.am
+++ b/examples/portfwd/include.am
@@ -3,10 +3,8 @@
 
 if BUILD_FWD
 noinst_PROGRAMS += examples/portfwd/portfwd
-noinst_HEADERS += examples/portfwd/wolfssh_portfwd.h
-examples_portfwd_portfwd_SOURCES = examples/portfwd/portfwd.c
+examples_portfwd_portfwd_SOURCES = examples/portfwd/portfwd.c \
+                                   examples/portfwd/wolfssh_portfwd.h
 examples_portfwd_portfwd_LDADD = src/libwolfssh.la
 examples_portfwd_portfwd_DEPENDENCIES = src/libwolfssh.la
 endif
-
-DISTCLEANFILES+= examples/portfwd/.libs/portfwd

--- a/examples/scpclient/include.am
+++ b/examples/scpclient/include.am
@@ -4,11 +4,9 @@
 if BUILD_SCP
 if BUILD_EXAMPLE_CLIENTS
 noinst_PROGRAMS += examples/scpclient/wolfscp
-noinst_HEADERS += examples/scpclient/scpclient.h
-examples_scpclient_wolfscp_SOURCES      = examples/scpclient/scpclient.c
+examples_scpclient_wolfscp_SOURCES      = examples/scpclient/scpclient.c \
+                                          examples/scpclient/scpclient.h
 examples_scpclient_wolfscp_LDADD        = src/libwolfssh.la
 examples_scpclient_wolfscp_DEPENDENCIES = src/libwolfssh.la
 endif
 endif
-
-DISTCLEANFILES+= examples/scpclient/.libs/wolfscp

--- a/examples/server/include.am
+++ b/examples/server/include.am
@@ -3,10 +3,8 @@
 
 if BUILD_EXAMPLE_SERVERS
 noinst_PROGRAMS += examples/server/server
-noinst_HEADERS += examples/server/server.h
-examples_server_server_SOURCES      = examples/server/server.c
+examples_server_server_SOURCES      = examples/server/server.c \
+                                      examples/server/server.h
 examples_server_server_LDADD        = src/libwolfssh.la
 examples_server_server_DEPENDENCIES = src/libwolfssh.la
 endif
-
-DISTCLEANFILES+= examples/server/.libs/server

--- a/examples/sftpclient/include.am
+++ b/examples/sftpclient/include.am
@@ -3,10 +3,8 @@
 
 if BUILD_SFTP
 noinst_PROGRAMS += examples/sftpclient/wolfsftp
-noinst_HEADERS += examples/sftpclient/sftpclient.h
-examples_sftpclient_wolfsftp_SOURCES      = examples/sftpclient/sftpclient.c
+examples_sftpclient_wolfsftp_SOURCES      = examples/sftpclient/sftpclient.c \
+                                            examples/sftpclient/sftpclient.h
 examples_sftpclient_wolfsftp_LDADD        = src/libwolfssh.la
 examples_sftpclient_wolfsftp_DEPENDENCIES = src/libwolfssh.la
 endif
-
-DISTCLEANFILES+= examples/sftpclient/.libs/wolfsftp

--- a/tests/api.c
+++ b/tests/api.c
@@ -37,8 +37,8 @@
     #include <wolfssh/test.h>
 
     #include "examples/echoserver/echoserver.h"
-
 #endif
+#include "tests/api.h"
 
 /* for echoserver test cases */
 int myoptind = 0;
@@ -1179,8 +1179,11 @@ static void test_wolfSSH_RealPath(void) { ; }
 #endif
 
 
-int main(void)
+int wolfSSH_ApiTest(int argc, char** argv)
 {
+    (void)argc;
+    (void)argv;
+
     AssertIntEQ(wolfSSH_Init(), WS_SUCCESS);
 
     test_wstrcat();
@@ -1207,3 +1210,11 @@ int main(void)
 
     return 0;
 }
+
+
+#ifndef NO_MAIN_FUNCTION
+int main(int argc, char** argv)
+{
+    return wolfSSH_ApiTest(argc, argv);
+}
+#endif

--- a/tests/api.h
+++ b/tests/api.h
@@ -1,0 +1,26 @@
+/* api.h
+ *
+ * Copyright (C) 2014-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSH.
+ *
+ * wolfSSH is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _WOLFSSH_TESTS_API_H_
+#define _WOLFSSH_TESTS_API_H_
+
+int wolfSSH_ApiTest(int argc, char** argv);
+
+#endif /* _WOLFSSH_TESTS_API_H_ */

--- a/tests/include.am
+++ b/tests/include.am
@@ -61,7 +61,7 @@ tests_api_test_LDADD         = src/libwolfssh.la
 tests_api_test_DEPENDENCIES  = src/libwolfssh.la
 
 tests_testsuite_test_SOURCES = tests/testsuite.c tests/testsuite.h \
-                               tests/sftp.c \
+                               tests/sftp.c tests/sftp.h \
                                examples/echoserver/echoserver.c \
                                examples/client/client.c \
                                examples/sftpclient/sftpclient.c

--- a/tests/include.am
+++ b/tests/include.am
@@ -7,7 +7,7 @@ check_PROGRAMS  += tests/unit.test tests/api.test \
 noinst_PROGRAMS += tests/unit.test tests/api.test \
                    tests/testsuite.test
 
-tests_unit_test_SOURCES      = tests/unit.c
+tests_unit_test_SOURCES      = tests/unit.c tests/unit.h
 tests_unit_test_CPPFLAGS     = -DNO_MAIN_DRIVER
 if BUILD_KEYGEN
 tests_unit_test_CPPFLAGS     += -DWOLFSSH_KEYGEN
@@ -33,7 +33,7 @@ endif
 tests_unit_test_LDADD        = src/libwolfssh.la
 tests_unit_test_DEPENDENCIES = src/libwolfssh.la
 
-tests_api_test_SOURCES       = tests/api.c \
+tests_api_test_SOURCES       = tests/api.c tests/api.h \
                                examples/echoserver/echoserver.c
 tests_api_test_CPPFLAGS      = -DNO_MAIN_DRIVER
 if BUILD_KEYGEN
@@ -60,7 +60,7 @@ endif
 tests_api_test_LDADD         = src/libwolfssh.la
 tests_api_test_DEPENDENCIES  = src/libwolfssh.la
 
-tests_testsuite_test_SOURCES = tests/testsuite.c \
+tests_testsuite_test_SOURCES = tests/testsuite.c tests/testsuite.h \
                                tests/sftp.c \
                                examples/echoserver/echoserver.c \
                                examples/client/client.c \
@@ -89,7 +89,3 @@ tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_CERTS
 endif
 tests_testsuite_test_LDADD   = src/libwolfssh.la
 tests_testsuite_test_DEPENDENCIES = src/libwolfssh.la
-
-DISTCLEANFILES+= tests/.libs/unit.test tests/.libs/api.test \
-                 tests/.libs/testsuite.test
-EXTRA_DIST += tests/testsuite.h

--- a/tests/sftp.c
+++ b/tests/sftp.c
@@ -30,7 +30,7 @@
 #define WOLFSSH_TEST_THREADING
 #include <wolfssh/test.h>
 
-#include "tests/testsuite.h"
+#include "tests/sftp.h"
 #include "examples/echoserver/echoserver.h"
 #include "examples/sftpclient/sftpclient.h"
 
@@ -141,7 +141,7 @@ static int commandCb(const char* in, char* out, int outSz)
 
 /* test SFTP commands, if flag is set to 1 then use non blocking
  * return 0 on success */
-int test_SFTP(int flag)
+int wolfSSH_SftpTest(int flag)
 {
     func_args ser;
     func_args cli;

--- a/tests/sftp.h
+++ b/tests/sftp.h
@@ -1,0 +1,26 @@
+/* sftp.h
+ *
+ * Copyright (C) 2014-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSH.
+ *
+ * wolfSSH is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _WOLFSSH_TESTS_SFTP_H_
+#define _WOLFSSH_TESTS_SFTP_H_
+
+int wolfSSH_SftpTest(int flag);
+
+#endif /* _WOLFSSH_TESTS_SFTP_H_ */

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -43,6 +43,10 @@
 #include "examples/client/client.h"
 #include "tests/testsuite.h"
 
+#if defined(WOLFSSH_SFTP) && !defined(SINGLE_THREADED)
+    #include "tests/sftp.h"
+#endif
+
 #ifndef NO_TESTSUITE_MAIN_DRIVER
 
 static int TestsuiteTest(int argc, char** argv);
@@ -156,9 +160,9 @@ int TestsuiteTest(int argc, char** argv)
 
 #ifdef WOLFSSH_SFTP
     printf("testing SFTP blocking\n");
-    test_SFTP(0);
+    wolfSSH_SftpTest(0);
     printf("testing SFTP non blocking\n");
-    test_SFTP(1);
+    wolfSSH_SftpTest(1);
 #endif
 
     return EXIT_SUCCESS;

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -47,20 +47,18 @@
     #include "tests/sftp.h"
 #endif
 
-#ifndef NO_TESTSUITE_MAIN_DRIVER
-
-static int TestsuiteTest(int argc, char** argv);
+#if !defined(NO_TESTSUITE_MAIN_DRIVER) && !defined(NO_MAIN_FUNCTION)
 
 int main(int argc, char** argv)
 {
-    return TestsuiteTest(argc, argv);
+    return wolfSSH_TestsuiteTest(argc, argv);
 }
 
 
 int myoptind = 0;
 char* myoptarg = NULL;
 
-#endif /* NO_TESTSUITE_MAIN_DRIVER */
+#endif /* !NO_TESTSUITE_MAIN_DRIVER && !NO_MAIN_FUNCTION */
 
 
 #if !defined(NO_WOLFSSH_SERVER) && !defined(NO_WOLFSSH_CLIENT)
@@ -87,7 +85,7 @@ static int tsClientUserAuth(byte authType, WS_UserAuthData* authData, void* ctx)
 #define NUMARGS 5
 #define ARGLEN 32
 
-int TestsuiteTest(int argc, char** argv)
+int wolfSSH_TestsuiteTest(int argc, char** argv)
 {
     tcp_ready ready;
     THREAD_TYPE serverThread;

--- a/tests/testsuite.h
+++ b/tests/testsuite.h
@@ -18,7 +18,9 @@
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#ifndef _WOLFSSH_TESTS_TESTSUITE_H_
+#define _WOLFSSH_TESTS_TESTSUITE_H_
 
-int test_SFTP(int flag);
+int wolfSSH_TestsuiteTest(int argc, char** argv);
 
+#endif /* _WOLFSSH_TESTS_TESTSUITE_H_ */

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -26,6 +26,7 @@
 #include <wolfssh/ssh.h>
 #include <wolfssh/keygen.h>
 #include <wolfssh/internal.h>
+#include "tests/unit.h"
 
 
 /* Utility functions */
@@ -483,9 +484,12 @@ static int test_Errors(void)
 }
 
 
-int main(void)
+int wolfSSH_UnitTest(int argc, char** argv)
 {
     int testResult = 0, unitResult = 0;
+
+    (void)argc;
+    (void)argv;
 
     unitResult = test_Errors();
     printf("Errors: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));
@@ -511,3 +515,10 @@ int main(void)
     return (testResult ? 1 : 0);
 }
 
+
+#ifndef NO_MAIN_FUNCTION
+int main(int argc, char** argv)
+{
+    return wolfSSH_UnitTest(argc, argv);
+}
+#endif

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -1,0 +1,26 @@
+/* unit.h
+ *
+ * Copyright (C) 2014-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSH.
+ *
+ * wolfSSH is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSH is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _WOLFSSH_TESTS_UNIT_H_
+#define _WOLFSSH_TESTS_UNIT_H_
+
+int wolfSSH_UnitTest(int argc, char** argv);
+
+#endif /* _WOLFSSH_TESTS_UNIT_H_ */


### PR DESCRIPTION
Make a few changes to the automake scripts used in the wolfSSH test and examples. Removed and consolidated some of the build control variables. Added some header files for the tests so they can be run in separate test applications.