### PR TITLE
Fixing name conflicts with the RTOS Integrity

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1023,17 +1023,13 @@ int wolfSSH_ProcessBuffer(WOLFSSH_CTX* ctx,
                           const byte* in, word32 inSz,
                           int format, int type)
 {
-    int dynamicType = 0;
-    int wcType;
-    int ret = WS_SUCCESS;
     void* heap = NULL;
     byte* der;
     word32 derSz;
+    int wcType;
+    int ret = WS_SUCCESS;
+    int dynamicType = 0;
     byte keyId = ID_NONE;
-
-    (void)dynamicType;
-    (void)wcType;
-    (void)heap;
 
     if (ctx == NULL || in == NULL || inSz == 0)
         return WS_BAD_ARGUMENT;
@@ -1123,6 +1119,10 @@ int wolfSSH_ProcessBuffer(WOLFSSH_CTX* ctx,
         }
     }
     #endif /* WOLFSSH_CERTS */
+
+    (void)dynamicType;
+    (void)wcType;
+    (void)heap;
 
     return ret;
 }
@@ -1729,7 +1729,7 @@ int ChannelRemove(WOLFSSH* ssh, word32 channel, byte peer)
 
 int ChannelPutData(WOLFSSH_CHANNEL* channel, byte* data, word32 dataSz)
 {
-    Buffer* inBuf;
+    WOLFSSH_BUFFER* inBuf;
 
     WLOG(WS_LOG_DEBUG, "Entering ChannelPutData()");
 
@@ -1763,7 +1763,7 @@ int ChannelPutData(WOLFSSH_CHANNEL* channel, byte* data, word32 dataSz)
 }
 
 
-int BufferInit(Buffer* buffer, word32 size, void* heap)
+int BufferInit(WOLFSSH_BUFFER* buffer, word32 size, void* heap)
 {
     if (buffer == NULL)
         return WS_BAD_ARGUMENT;
@@ -1771,7 +1771,7 @@ int BufferInit(Buffer* buffer, word32 size, void* heap)
     if (size <= STATIC_BUFFER_LEN)
         size = STATIC_BUFFER_LEN;
 
-    WMEMSET(buffer, 0, sizeof(Buffer));
+    WMEMSET(buffer, 0, sizeof(WOLFSSH_BUFFER));
     buffer->heap = heap;
     buffer->bufferSz = size;
     if (size > STATIC_BUFFER_LEN) {
@@ -1787,7 +1787,7 @@ int BufferInit(Buffer* buffer, word32 size, void* heap)
 }
 
 
-int GrowBuffer(Buffer* buf, word32 sz, word32 usedSz)
+int GrowBuffer(WOLFSSH_BUFFER* buf, word32 sz, word32 usedSz)
 {
 #if 0
     WLOG(WS_LOG_DEBUG, "GB: buf = %p", buf);
@@ -1829,7 +1829,7 @@ int GrowBuffer(Buffer* buf, word32 sz, word32 usedSz)
 }
 
 
-void ShrinkBuffer(Buffer* buf, int forcedFree)
+void ShrinkBuffer(WOLFSSH_BUFFER* buf, int forcedFree)
 {
     WLOG(WS_LOG_DEBUG, "Entering ShrinkBuffer()");
 
@@ -1862,7 +1862,7 @@ void ShrinkBuffer(Buffer* buf, int forcedFree)
 }
 
 
-static int Receive(WOLFSSH* ssh, byte* buf, word32 sz)
+static int ReceiveData(WOLFSSH* ssh, byte* buf, word32 sz)
 {
     int recvd;
 
@@ -1915,7 +1915,7 @@ static int GetInputText(WOLFSSH* ssh, byte** pEol)
         return WS_MEMORY_E;
 
     do {
-        in = Receive(ssh,
+        in = ReceiveData(ssh,
                      ssh->inputBuffer.buffer + ssh->inputBuffer.length, inSz);
 
         if (in == -1)
@@ -2068,7 +2068,7 @@ static int GetInputData(WOLFSSH* ssh, word32 size)
 
     /* read data from network */
     do {
-        in = Receive(ssh,
+        in = ReceiveData(ssh,
                      ssh->inputBuffer.buffer + ssh->inputBuffer.length, inSz);
         if (in == -1) {
             ssh->error = WS_SOCKET_ERROR_E;
@@ -6596,7 +6596,7 @@ static int DoChannelData(WOLFSSH* ssh,
 
 /* deletes current buffer and updates it
  * return WS_SUCCESS on success */
-static int PutBuffer(Buffer* buf, byte* data, word32 dataSz)
+static int PutBuffer(WOLFSSH_BUFFER* buf, byte* data, word32 dataSz)
 {
     int ret;
 

--- a/src/io.c
+++ b/src/io.c
@@ -264,7 +264,7 @@ void* wolfSSH_GetIOWriteCtx(WOLFSSH* ssh)
 
 
 /* Translates return codes returned from send() and recv() if need be. */
-static INLINE int TranslateReturnCode(int old, WS_SOCKET_T sd)
+static INLINE int wsReturnCode(int old, WS_SOCKET_T sd)
 {
     (void)sd;
 
@@ -296,7 +296,7 @@ static INLINE int TranslateReturnCode(int old, WS_SOCKET_T sd)
     return old;
 }
 
-static INLINE int LastError(void)
+static INLINE int wsErrno(void)
 {
 #ifdef USE_WINDOWS_API
     return WSAGetLastError();
@@ -327,10 +327,10 @@ int wsEmbedRecv(WOLFSSH* ssh, void* data, word32 sz, void* ctx)
 
     recvd = (int)RECV_FUNCTION(sd, buf, sz, ssh->rflags);
 
-    recvd = TranslateReturnCode(recvd, sd);
+    recvd = wsReturnCode(recvd, sd);
 
     if (recvd < 0) {
-        err = LastError();
+        err = wsErrno();
         WLOG(WS_LOG_DEBUG,"Embed Receive error");
 
         if (err == SOCKET_EWOULDBLOCK || err == SOCKET_EAGAIN) {
@@ -404,9 +404,9 @@ int wsEmbedSend(WOLFSSH* ssh, void* data, word32 sz, void* ctx)
 #endif /* MICROCHIP_MPLAB_HARMONY */
 
     sent = (int)SEND_FUNCTION(sd, buf, sz, ssh->wflags);
-    sent = TranslateReturnCode(sent, sd);
+    sent = wsReturnCode(sent, sd);
     if (sent < 0) {
-        err = LastError();
+        err = wsErrno();
         WLOG(WS_LOG_DEBUG,"Embed Send error");
 
         if (err == SOCKET_EWOULDBLOCK || err == SOCKET_EAGAIN) {

--- a/src/log.c
+++ b/src/log.c
@@ -189,6 +189,7 @@ void DefaultLoggingCb(enum wolfSSH_LogLevel level, const char *const msgStr)
 
 void wolfSSH_Log(enum wolfSSH_LogLevel level, const char *const fmt, ...)
 {
+    (void)logFunction;
     (void)level;
     (void)fmt;
 }

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -991,7 +991,7 @@ int wolfSSH_TriggerKeyExchange(WOLFSSH* ssh)
  * returns number of bytes was able to peek at on success */
 int wolfSSH_stream_peek(WOLFSSH* ssh, byte* buf, word32 bufSz)
 {
-    Buffer* inputBuffer;
+    WOLFSSH_BUFFER* inputBuffer;
 
     WLOG(WS_LOG_DEBUG, "Entering wolfSSH_stream_peek()");
 
@@ -1014,7 +1014,7 @@ static int wolfSSH_stream_adjust_window(WOLFSSH* ssh)
     word32  usedSz;
     word32  bytesToAdd;
     int     ret;
-    Buffer* inputBuffer;
+    WOLFSSH_BUFFER* inputBuffer;
 
     inputBuffer = &ssh->channelList->inputBuffer;
     usedSz      = inputBuffer->length - inputBuffer->idx;
@@ -1064,7 +1064,7 @@ static int wolfSSH_stream_adjust_window(WOLFSSH* ssh)
 int wolfSSH_stream_read(WOLFSSH* ssh, byte* buf, word32 bufSz)
 {
     int ret = WS_SUCCESS;
-    Buffer* inputBuffer;
+    WOLFSSH_BUFFER* inputBuffer;
 
     WLOG(WS_LOG_DEBUG, "Entering wolfSSH_stream_read()");
 
@@ -2030,7 +2030,7 @@ int wolfSSH_ChannelGetFwdFd(const WOLFSSH_CHANNEL* channel)
 
 static int _UpdateChannelWindow(WOLFSSH_CHANNEL* channel)
 {
-    Buffer* inputBuffer;
+    WOLFSSH_BUFFER* inputBuffer;
     int sendResult = WS_SUCCESS;
 
     if (channel == NULL)
@@ -2071,7 +2071,7 @@ static int _UpdateChannelWindow(WOLFSSH_CHANNEL* channel)
 
 static int _ChannelRead(WOLFSSH_CHANNEL* channel, byte* buf, word32 bufSz)
 {
-    Buffer* inputBuffer;
+    WOLFSSH_BUFFER* inputBuffer;
     int updateResult = WS_SUCCESS;
 
     if (channel == NULL || buf == NULL || bufSz == 0)

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -388,7 +388,7 @@ WOLFSSH_LOCAL const char* IdToName(byte);
  * the rest of the data. */
 
 
-typedef struct Buffer {
+typedef struct WOLFSSH_BUFFER {
     void* heap;       /* Heap for allocations */
     int   plainSz;    /* amount of plain text bytes to send with WANT_WRITE */
     word32 length;    /* total buffer length used */
@@ -397,11 +397,11 @@ typedef struct Buffer {
     word32 bufferSz;  /* current buffer size */
     ALIGN16 byte staticBuffer[STATIC_BUFFER_LEN];
     byte dynamicFlag; /* dynamic memory currently in use */
-} Buffer;
+} WOLFSSH_BUFFER;
 
-WOLFSSH_LOCAL int BufferInit(Buffer*, word32, void*);
-WOLFSSH_LOCAL int GrowBuffer(Buffer*, word32, word32);
-WOLFSSH_LOCAL void ShrinkBuffer(Buffer* buf, int);
+WOLFSSH_LOCAL int BufferInit(WOLFSSH_BUFFER* buffer, word32 size, void* heap);
+WOLFSSH_LOCAL int GrowBuffer(WOLFSSH_BUFFER* buf, word32 sz, word32 usedSz);
+WOLFSSH_LOCAL void ShrinkBuffer(WOLFSSH_BUFFER* buf, int forcedFree);
 
 
 /* our wolfSSH Context */
@@ -654,9 +654,9 @@ struct WOLFSSH {
     byte channelNameSz;
     word32 lastRxId;
 
-    Buffer inputBuffer;
-    Buffer outputBuffer;
-    Buffer extDataBuffer; /* extended data ready to be read */
+    WOLFSSH_BUFFER inputBuffer;
+    WOLFSSH_BUFFER outputBuffer;
+    WOLFSSH_BUFFER extDataBuffer; /* extended data ready to be read */
     WC_RNG* rng;
 
     byte h[WC_MAX_DIGEST_SIZE];
@@ -763,7 +763,7 @@ struct WOLFSSH_CHANNEL {
     int fwdFd;
     int isDirect;
 #endif /* WOLFSSH_FWD */
-    Buffer inputBuffer;
+    WOLFSSH_BUFFER inputBuffer;
     char* command;
     struct WOLFSSH* ssh;
     struct WOLFSSH_CHANNEL* next;


### PR DESCRIPTION
1. Rename the type struct Buffer as struct WOLFSSH_BUFFER.
2. Rename the function Receive() as ReceiveData().
3. Fix unused variable value.
4. Rename the I/O callback functions LastError() as wsErrno() and TranslateReturnCode() as wsReturnCode(). LastError was conflicting with something, and TRC was just long.
5. The logFunction callback pointer isn't used in non-debug builds, and the compiler reported as such. Reference the variable to hush the warning.