### PR TITLE
Threading Deduplication

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -24,6 +24,12 @@
 
 #define WOLFSSH_TEST_CLIENT
 
+#ifdef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/wolfcrypt/settings.h>
+#else
+    #include <wolfssl/options.h>
+#endif
+
 #include <wolfssh/ssh.h>
 #include <wolfssh/internal.h>
 #include <wolfssh/test.h>

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1873,7 +1873,6 @@ static int wsUserAuth(byte authType,
     PwMapList* list;
     PwMap* map;
     byte authHash[WC_SHA256_DIGEST_SIZE];
-    int ret;
 
     if (ctx == NULL) {
         fprintf(stderr, "wsUserAuth: ctx not set");
@@ -1909,6 +1908,7 @@ static int wsUserAuth(byte authType,
             word32 fascnSz;
             word32 uuidSz;
             word32 i;
+            int ret;
 
             printf("Peer connected with FPKI certificate\n");
             wc_InitDecodedCert(&cert, authData->sf.publicKey.publicKey,
@@ -1993,34 +1993,13 @@ static int wsUserAuth(byte authType,
                         WOLFSSH_USERAUTH_REJECTED;
                  }
             }
-#ifdef WOLFSSH_ALLOW_USERAUTH_NONE
+            #ifdef WOLFSSH_ALLOW_USERAUTH_NONE
             else if (authData->type == WOLFSSH_USERAUTH_NONE) {
                 return WOLFSSH_USERAUTH_SUCCESS;
             }
-#endif /* WOLFSSH_ALLOW_USERAUTH_NONE */
+            #endif /* WOLFSSH_ALLOW_USERAUTH_NONE */
             else {
                  return WOLFSSH_USERAUTH_INVALID_AUTHTYPE;
-            }
-
-            if (authData->type == map->type) {
-                if (WMEMCMP(map->p, authHash, WC_SHA256_DIGEST_SIZE) == 0) {
-                    return WOLFSSH_USERAUTH_SUCCESS;
-                }
-                else {
-                    if (authType == WOLFSSH_USERAUTH_PASSWORD) {
-                        passwdRetry--;
-                        ret = (passwdRetry > 0) ?
-                            WOLFSSH_USERAUTH_INVALID_PASSWORD :
-                            WOLFSSH_USERAUTH_REJECTED;
-                    }
-                    else {
-                        ret = WOLFSSH_USERAUTH_INVALID_PUBLICKEY;
-                    }
-                    return ret;
-                }
-            }
-            else {
-                return WOLFSSH_USERAUTH_INVALID_AUTHTYPE;
             }
         }
         map = map->next;

--- a/examples/portfwd/portfwd.c
+++ b/examples/portfwd/portfwd.c
@@ -25,6 +25,11 @@
 #define WOLFSSH_TEST_CLIENT
 #define WOLFSSH_TEST_SERVER
 
+#ifdef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/wolfcrypt/settings.h>
+#else
+    #include <wolfssl/options.h>
+#endif
 
 #include <stdio.h>
 #ifdef HAVE_TERMIOS_H

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -24,6 +24,12 @@
 
 #define WOLFSSH_TEST_CLIENT
 
+#ifdef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/wolfcrypt/settings.h>
+#else
+    #include <wolfssl/options.h>
+#endif
+
 #include <stdio.h>
 #if !defined(USE_WINDOWS_API) && !defined(MICROCHIP_PIC32)
     #include <termios.h>

--- a/tests/api.c
+++ b/tests/api.c
@@ -22,22 +22,28 @@
     #include <config.h>
 #endif
 
+#ifdef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/wolfcrypt/settings.h>
+#else
+    #include <wolfssl/options.h>
+#endif
+
 #include <stdio.h>
 #include <wolfssh/ssh.h>
 #include <wolfssh/internal.h>
 #ifdef WOLFSSH_SCP
     #include <wolfssh/wolfscp.h>
 #endif
+
 #ifdef WOLFSSH_SFTP
     #define WOLFSSH_TEST_LOCKING
     #define WOLFSSH_TEST_THREADING
 
     #define WOLFSSH_TEST_SERVER
     #define WOLFSSH_TEST_ECHOSERVER
-    #include <wolfssh/test.h>
-
-    #include "examples/echoserver/echoserver.h"
 #endif
+#define WOLFSSH_TEST_HEX2BIN
+#include <wolfssh/test.h>
 #include "tests/api.h"
 
 /* for echoserver test cases */
@@ -95,161 +101,10 @@ char* myoptarg = NULL;
 #define AssertStrLE(x, y) AssertStr(x, y, <=,  >)
 
 
-/* Utility functions */
-
-#define BAD 0xFF
-
-const byte hexDecode[] =
-{
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-    BAD, BAD, BAD, BAD, BAD, BAD, BAD,
-    10, 11, 12, 13, 14, 15,  /* upper case A-F */
-    BAD, BAD, BAD, BAD, BAD, BAD, BAD, BAD,
-    BAD, BAD, BAD, BAD, BAD, BAD, BAD, BAD,
-    BAD, BAD, BAD, BAD, BAD, BAD, BAD, BAD,
-    BAD, BAD,  /* G - ` */
-    10, 11, 12, 13, 14, 15   /* lower case a-f */
-};  /* A starts at 0x41 not 0x3A */
-
-
-static int Base16_Decode(const byte* in, word32 inLen,
-                         byte* out, word32* outLen)
-{
-    word32 inIdx = 0;
-    word32 outIdx = 0;
-
-    if (inLen == 1 && *outLen && in) {
-        byte b = in[inIdx++] - 0x30;  /* 0 starts at 0x30 */
-
-        /* sanity check */
-        if (b >=  sizeof(hexDecode)/sizeof(hexDecode[0]))
-            return -1;
-
-        b  = hexDecode[b];
-
-        if (b == BAD)
-            return -1;
-
-        out[outIdx++] = b;
-
-        *outLen = outIdx;
-        return 0;
-    }
-
-    if (inLen % 2)
-        return -1;
-
-    if (*outLen < (inLen / 2))
-        return -1;
-
-    while (inLen) {
-        byte b = in[inIdx++] - 0x30;  /* 0 starts at 0x30 */
-        byte b2 = in[inIdx++] - 0x30;
-
-        /* sanity checks */
-        if (b >=  sizeof(hexDecode)/sizeof(hexDecode[0]))
-            return -1;
-        if (b2 >= sizeof(hexDecode)/sizeof(hexDecode[0]))
-            return -1;
-
-        b  = hexDecode[b];
-        b2 = hexDecode[b2];
-
-        if (b == BAD || b2 == BAD)
-            return -1;
-
-        out[outIdx++] = (byte)((b << 4) | b2);
-        inLen -= 2;
-    }
-
-    *outLen = outIdx;
-    return 0;
-}
-
-
-static void FreeBins(byte* b1, byte* b2, byte* b3, byte* b4)
-{
-    if (b1 != NULL) free(b1);
-    if (b2 != NULL) free(b2);
-    if (b3 != NULL) free(b3);
-    if (b4 != NULL) free(b4);
-}
-
-
-/* convert hex string to binary, store size, 0 success (free mem on failure) */
-static int ConvertHexToBin(const char* h1, byte** b1, word32* b1Sz,
-                           const char* h2, byte** b2, word32* b2Sz,
-                           const char* h3, byte** b3, word32* b3Sz,
-                           const char* h4, byte** b4, word32* b4Sz)
-{
-    int ret;
-
-    /* b1 */
-    if (h1 && b1 && b1Sz) {
-        *b1Sz = (word32)strlen(h1) / 2;
-        *b1 = (byte*)malloc(*b1Sz);
-        if (*b1 == NULL)
-            return -1;
-        ret = Base16_Decode((const byte*)h1, (word32)strlen(h1),
-                            *b1, b1Sz);
-        if (ret != 0) {
-            FreeBins(*b1, NULL, NULL, NULL);
-            return -1;
-        }
-    }
-
-    /* b2 */
-    if (h2 && b2 && b2Sz) {
-        *b2Sz = (word32)strlen(h2) / 2;
-        *b2 = (byte*)malloc(*b2Sz);
-        if (*b2 == NULL) {
-            FreeBins(b1 ? *b1 : NULL, NULL, NULL, NULL);
-            return -1;
-        }
-        ret = Base16_Decode((const byte*)h2, (word32)strlen(h2),
-                            *b2, b2Sz);
-        if (ret != 0) {
-            FreeBins(b1 ? *b1 : NULL, *b2, NULL, NULL);
-            return -1;
-        }
-    }
-
-    /* b3 */
-    if (h3 && b3 && b3Sz) {
-        *b3Sz = (word32)strlen(h3) / 2;
-        *b3 = (byte*)malloc(*b3Sz);
-        if (*b3 == NULL) {
-            FreeBins(b1 ? *b1 : NULL, b2 ? *b2 : NULL, NULL, NULL);
-            return -1;
-        }
-        ret = Base16_Decode((const byte*)h3, (word32)strlen(h3),
-                            *b3, b3Sz);
-        if (ret != 0) {
-            FreeBins(b1 ? *b1 : NULL, b2 ? *b2 : NULL, *b3, NULL);
-            return -1;
-        }
-    }
-
-    /* b4 */
-    if (h4 && b4 && b4Sz) {
-        *b4Sz = (word32)strlen(h4) / 2;
-        *b4 = (byte*)malloc(*b4Sz);
-        if (*b4 == NULL) {
-            FreeBins(b1 ? *b1 : NULL, b2 ? *b2 : NULL, b3 ? *b3 : NULL, NULL);
-            return -1;
-        }
-        ret = Base16_Decode((const byte*)h4, (word32)strlen(h4),
-                            *b4, b4Sz);
-        if (ret != 0) {
-            FreeBins(b1 ? *b1 : NULL, b2 ? *b2 : NULL, b3 ? *b3 : NULL, *b4);
-            return -1;
-        }
-    }
-
-    return 0;
-}
-
 #if defined(WOLFSSH_SFTP) && !defined(NO_WOLFSSH_CLIENT)
+
+#include "examples/echoserver/echoserver.h"
+
 byte userPassword[256];
 static int sftpUserAuth(byte authType, WS_UserAuthData* authData, void* ctx)
 {

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -22,182 +22,20 @@
     #include <config.h>
 #endif
 
+#ifdef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/wolfcrypt/settings.h>
+#else
+    #include <wolfssl/options.h>
+#endif
+
 #include <stdio.h>
 #include <wolfssh/ssh.h>
 #include <wolfssh/keygen.h>
 #include <wolfssh/internal.h>
+
+#define WOLFSSH_TEST_HEX2BIN
+#include <wolfssh/test.h>
 #include "tests/unit.h"
-
-
-/* Utility functions */
-
-#define BAD 0xFF
-
-const byte hexDecode[] =
-{
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-    BAD, BAD, BAD, BAD, BAD, BAD, BAD,
-    10, 11, 12, 13, 14, 15,  /* upper case A-F */
-    BAD, BAD, BAD, BAD, BAD, BAD, BAD, BAD,
-    BAD, BAD, BAD, BAD, BAD, BAD, BAD, BAD,
-    BAD, BAD, BAD, BAD, BAD, BAD, BAD, BAD,
-    BAD, BAD,  /* G - ` */
-    10, 11, 12, 13, 14, 15   /* lower case a-f */
-};  /* A starts at 0x41 not 0x3A */
-
-
-static int Base16_Decode(const byte* in, word32 inLen,
-                         byte* out, word32* outLen)
-{
-    word32 inIdx = 0;
-    word32 outIdx = 0;
-
-    if (inLen == 1 && *outLen && in) {
-        byte b = in[inIdx] - 0x30;  /* 0 starts at 0x30 */
-
-        /* sanity check */
-        if (b >=  sizeof(hexDecode)/sizeof(hexDecode[0]))
-            return -1;
-
-        b  = hexDecode[b];
-
-        if (b == BAD)
-            return -1;
-
-        out[outIdx++] = b;
-
-        *outLen = outIdx;
-        return 0;
-    }
-
-    if (inLen % 2)
-        return -1;
-
-    if (*outLen < (inLen / 2))
-        return -1;
-
-    while (inLen) {
-        byte b = in[inIdx++] - 0x30;  /* 0 starts at 0x30 */
-        byte b2 = in[inIdx++] - 0x30;
-
-        /* sanity checks */
-        if (b >=  sizeof(hexDecode)/sizeof(hexDecode[0]))
-            return -1;
-        if (b2 >= sizeof(hexDecode)/sizeof(hexDecode[0]))
-            return -1;
-
-        b  = hexDecode[b];
-        b2 = hexDecode[b2];
-
-        if (b == BAD || b2 == BAD)
-            return -1;
-
-        out[outIdx++] = (byte)((b << 4) | b2);
-        inLen -= 2;
-    }
-
-    *outLen = outIdx;
-    return 0;
-}
-
-
-static void FreeBins(byte* b1, byte* b2, byte* b3, byte* b4)
-{
-    if (b1 != NULL) free(b1);
-    if (b2 != NULL) free(b2);
-    if (b3 != NULL) free(b3);
-    if (b4 != NULL) free(b4);
-}
-
-
-/* convert hex string to binary, store size, 0 success (free mem on failure) */
-static int ConvertHexToBin(const char* h1, byte** b1, word32* b1Sz,
-                           const char* h2, byte** b2, word32* b2Sz,
-                           const char* h3, byte** b3, word32* b3Sz,
-                           const char* h4, byte** b4, word32* b4Sz)
-{
-    int ret;
-
-    /* b1 */
-    if (h1 && b1 && b1Sz) {
-        *b1Sz = (word32)strlen(h1) / 2;
-        *b1 = (byte*)malloc(*b1Sz);
-        if (*b1 == NULL)
-            return -1;
-        ret = Base16_Decode((const byte*)h1, (word32)strlen(h1),
-                            *b1, b1Sz);
-        if (ret != 0) {
-            FreeBins(*b1, NULL, NULL, NULL);
-            *b1 = NULL;
-            return -1;
-        }
-    }
-
-    /* b2 */
-    if (h2 && b2 && b2Sz) {
-        *b2Sz = (word32)strlen(h2) / 2;
-        *b2 = (byte*)malloc(*b2Sz);
-        if (*b2 == NULL) {
-            FreeBins(b1 ? *b1 : NULL, NULL, NULL, NULL);
-            if (b1) *b1 = NULL;
-            return -1;
-        }
-        ret = Base16_Decode((const byte*)h2, (word32)strlen(h2),
-                            *b2, b2Sz);
-        if (ret != 0) {
-            FreeBins(b1 ? *b1 : NULL, *b2, NULL, NULL);
-            if (b1) *b1 = NULL;
-            *b2 = NULL;
-            return -1;
-        }
-    }
-
-    /* b3 */
-    if (h3 && b3 && b3Sz) {
-        *b3Sz = (word32)strlen(h3) / 2;
-        *b3 = (byte*)malloc(*b3Sz);
-        if (*b3 == NULL) {
-            FreeBins(b1 ? *b1 : NULL, b2 ? *b2 : NULL, NULL, NULL);
-            if (b1) *b1 = NULL;
-            if (b2) *b2 = NULL;
-            return -1;
-        }
-        ret = Base16_Decode((const byte*)h3, (word32)strlen(h3),
-                            *b3, b3Sz);
-        if (ret != 0) {
-            FreeBins(b1 ? *b1 : NULL, b2 ? *b2 : NULL, *b3, NULL);
-            if (b1) *b1 = NULL;
-            if (b2) *b2 = NULL;
-            *b3 = NULL;
-            return -1;
-        }
-    }
-
-    /* b4 */
-    if (h4 && b4 && b4Sz) {
-        *b4Sz = (word32)strlen(h4) / 2;
-        *b4 = (byte*)malloc(*b4Sz);
-        if (*b4 == NULL) {
-            FreeBins(b1 ? *b1 : NULL, b2 ? *b2 : NULL, b3 ? *b3 : NULL, NULL);
-            if (b1) *b1 = NULL;
-            if (b2) *b2 = NULL;
-            if (b3) *b3 = NULL;
-            return -1;
-        }
-        ret = Base16_Decode((const byte*)h4, (word32)strlen(h4),
-                            *b4, b4Sz);
-        if (ret != 0) {
-            FreeBins(b1 ? *b1 : NULL, b2 ? *b2 : NULL, b3 ? *b3 : NULL, *b4);
-            if (b1) *b1 = NULL;
-            if (b2) *b2 = NULL;
-            if (b3) *b3 = NULL;
-            *b4 = NULL;
-            return -1;
-        }
-    }
-
-    return 0;
-}
 
 
 /* Key Derivation Function (KDF) Unit Test */


### PR DESCRIPTION
1. Deduplicate threading macros and typedefs where wolfCrypt has the default versions.
2. Add the user_settings.h/options.h include that is missing from examples.
3. Remove some dead code from the echoserver's user authentication function.