### PR TITLE
Test Tools

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -1067,7 +1067,7 @@ int wolfSSH_ApiTest(int argc, char** argv)
 }
 
 
-#ifndef NO_MAIN_FUNCTION
+#ifndef NO_APITEST_MAIN_DRIVER
 int main(int argc, char** argv)
 {
     return wolfSSH_ApiTest(argc, argv);

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -47,7 +47,7 @@
     #include "tests/sftp.h"
 #endif
 
-#if !defined(NO_TESTSUITE_MAIN_DRIVER) && !defined(NO_MAIN_FUNCTION)
+#ifndef NO_TESTSUITE_MAIN_DRIVER
 
 int main(int argc, char** argv)
 {
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
 int myoptind = 0;
 char* myoptarg = NULL;
 
-#endif /* !NO_TESTSUITE_MAIN_DRIVER && !NO_MAIN_FUNCTION */
+#endif /* !NO_TESTSUITE_MAIN_DRIVER */
 
 
 #if !defined(NO_WOLFSSH_SERVER) && !defined(NO_WOLFSSH_CLIENT)

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -354,7 +354,7 @@ int wolfSSH_UnitTest(int argc, char** argv)
 }
 
 
-#ifndef NO_MAIN_FUNCTION
+#ifndef NO_UNITTEST_MAIN_DRIVER
 int main(int argc, char** argv)
 {
     return wolfSSH_UnitTest(argc, argv);


### PR DESCRIPTION
1. Remove the flag NO_MAIN_FUNCTION from the test tools.
2. For unit and api tests, follow the patter for the testsuite with its NO_TESTSUITE_MAIN_DRIVER check.