### PR TITLE
wolfSFTP Size Check

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -3398,6 +3398,10 @@ int wolfSSH_SFTP_RecvRead(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
         return WS_BUFFER_E;
     }
 
+    if (sz > WOLFSSH_MAX_SFTP_RW) {
+        sz = WOLFSSH_MAX_SFTP_RW;
+    }
+
     /* read from handle and send data back to client */
     out = (byte*)WMALLOC(sz + WOLFSSH_SFTP_HEADER + UINT32_SZ,
             ssh->ctx->heap, DYNTYPE_BUFFER);

--- a/wolfssh/wolfsftp.h
+++ b/wolfssh/wolfsftp.h
@@ -149,6 +149,13 @@ struct WS_SFTPNAME {
     WS_SFTPNAME* next;
 };
 
+/*
+ * WOLFSSH_MAX_SFTP_RW: Limit on how much file data the client will request
+ *     or send in a file transfer message. Also a limit on how much file
+ *     data a server will send per request from the client.
+ * WOLFSSH_MAX_SFTP_RECV: Used as a bounds check on a SFTP message's size.
+ *     Is not used to allocate any buffers directly.
+ */
 #ifndef WOLFSSH_MAX_SFTP_RW
     #define WOLFSSH_MAX_SFTP_RW 1024
 #endif


### PR DESCRIPTION
1. Add some comments describing the constants WOLFSSH_MAX_SFTP_RW and WOLFSSH_MAX_SFTP_RECV.
2. When the server processor receives a request for file data during a file transfer, limit the amount of data sent to the client by the value WOLFSSH_MAX_SFTP_RW.

(ZD 13057)