### PR TITLE
Remove Public Math

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -775,7 +775,7 @@ static int SignHashEcc(WOLFSSH_AGENT_KEY_ECDSA* rawKey, int curveId,
 
 
 static int PostSignRequest(WOLFSSH_AGENT_CTX* agent,
-        byte* keyBlob, word32 keyBlobSz, byte* data, word32 dataSz,
+        const byte* keyBlob, word32 keyBlobSz, const byte* data, word32 dataSz,
         word32 flags)
 {
     WOLFSSH_AGENT_ID* id = NULL;
@@ -959,8 +959,8 @@ static int DoIdentitiesAnswer(WOLFSSH_AGENT_CTX* agent,
 static int DoSignRequest(WOLFSSH_AGENT_CTX* agent,
         byte* buf, word32 len, word32* idx)
 {
-    byte* keyBlob;
-    byte* data;
+    const byte* keyBlob;
+    const byte* data;
     word32 begin, keyBlobSz, dataSz, flags;
     int ret = WS_SUCCESS;
     WLOG_ENTER();
@@ -1004,7 +1004,7 @@ static int DoSignResponse(WOLFSSH_AGENT_CTX* agent,
         ret = WS_BAD_ARGUMENT;
 
     if ( ret == WS_SUCCESS)
-        ret = GetStringRef(&sigSz, &sig, buf, len, idx);
+        ret = GetStringRef(&sigSz, (const byte**)&sig, buf, len, idx);
 
     if (ret == WS_SUCCESS) {
         agent->msg = sig;
@@ -1052,7 +1052,7 @@ static int DoAddIdentity(WOLFSSH_AGENT_CTX* agent,
         if (keyType == ID_SSH_RSA) {
 #ifndef WOLFSSH_NO_RSA
             byte* key;
-            byte* scratch;
+            const byte* scratch;
             word32 keySz, nSz, eSz, dSz, iqmpSz, pSz, qSz, commentSz;
 
             key = buf + begin;
@@ -1099,7 +1099,7 @@ static int DoAddIdentity(WOLFSSH_AGENT_CTX* agent,
                 keyType == ID_ECDSA_SHA2_NISTP521) {
 #ifndef WOLFSSH_NO_ECDSA
             byte* key;
-            byte* scratch;
+            const byte* scratch;
             word32 keySz, curveNameSz, qSz, dSz, commentSz;
 
             key = buf + begin;
@@ -1145,7 +1145,7 @@ static int DoRemoveIdentity(WOLFSSH_AGENT_CTX* agent,
         byte* buf, word32 len, word32* idx)
 {
     int ret = WS_SUCCESS;
-    byte* keyBlob = NULL;
+    const byte* keyBlob = NULL;
     word32 keyBlobSz = 0;
     word32 begin;
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -792,13 +792,20 @@ WOLFSSH_LOCAL int wolfSSH_ProcessBuffer(WOLFSSH_CTX*,
 WOLFSSH_LOCAL int wolfSSH_FwdWorker(WOLFSSH*);
 
 /* Parsing functions */
-WOLFSSH_LOCAL int GetBoolean(byte*, byte*, word32, word32*);
-WOLFSSH_LOCAL int GetUint32(word32*, const byte*, word32, word32*);
-WOLFSSH_LOCAL int GetSize(word32*, const byte*, word32, word32*);
-WOLFSSH_LOCAL int GetMpint(word32*, byte**, byte*, word32, word32*);
-WOLFSSH_LOCAL int GetString(char*, word32*, byte*, word32, word32*);
-WOLFSSH_LOCAL int GetStringAlloc(void*, char**, byte*, word32, word32*);
-WOLFSSH_LOCAL int GetStringRef(word32*, byte**, byte*, word32, word32*);
+WOLFSSH_LOCAL int GetBoolean(byte* v,
+        const byte* buf, word32 len, word32* idx);
+WOLFSSH_LOCAL int GetUint32(word32* v,
+        const byte* buf, word32 len, word32* idx);
+WOLFSSH_LOCAL int GetSize(word32* v,
+        const byte* buf, word32 len, word32* idx);
+WOLFSSH_LOCAL int GetMpint(word32* mpintSz, const byte** mpint,
+        const byte* buf, word32 len, word32* idx);
+WOLFSSH_LOCAL int GetString(char* s, word32* sSz,
+        const byte* buf, word32 len, word32* idx);
+WOLFSSH_LOCAL int GetStringAlloc(void* heap, char** s,
+        const byte* buf, word32 len, word32* idx);
+WOLFSSH_LOCAL int GetStringRef(word32* strSz, const byte **str,
+        const byte* buf, word32 len, word32* idx);
 
 
 #ifndef WOLFSSH_USER_IO


### PR DESCRIPTION
Refactoring to remove the need for mp_int types and any of the math functions from wolfCrypt. wolfCrypt provides APIs for generating and verifying signatures and for checking keys, use them. The functions were only used for ECDSA public keys and ECDSA X.509 certificates.

To test the X.509 certificates:

```
./configure --enable-certs CFLAGS=-DWOLFSSH_NO_FPKI && make
./examples/echoserver/echoserver -J fred:./keys/fred-cert.pem -j ./keys/fred-key.der -a ./keys/ca-cert-ecc.pem
./examples/client/client -u fred -i ./keys/fred-key.der -J ./keys/fred-cert.der -A ./keys/ca-cert-ecc.der
```

This should correct issue #413.