### PR TITLE
fix for x509 use, add cert use to sftp client

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,7 @@ AS_IF([test "x$ax_enable_debug" = "xyes"],
        AM_CPPFLAGS="-DNDEBUG $AM_CPPFLAGS"])
 
 AX_PTHREAD([
+    AC_DEFINE([HAVE_PTHREAD], [1], [Define if you have POSIX threads libraries and header files.])
     # If AX_PTHREAD is adding -Qunused-arguments, need to prepend with
     # -Xcompiler libtool will use it. Newer versions of clang don't need
     # the -Q flag when using pthreads.

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -596,6 +596,9 @@ static int wsPublicKeyCheck(const byte* pubKey, word32 pubKeySz, void* ctx)
             FreeDecodedCert(&dCert);
         }
     }
+#else
+    printf("wolfSSL not built with OPENSSL_ALL or WOLFSSL_IP_ALT_NAME\n");
+    printf("\tnot checking IP address from peer's cert\n");
 #endif
 #endif
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1666,6 +1666,9 @@ int wolfSSH_CTX_UsePrivateKey_buffer(WOLFSSH_CTX* ctx,
 
 #ifdef WOLFSSH_CERTS
 
+/* load in a X509 certificate that has public key to use
+ * return WS_SUCCESS on success
+ */
 int wolfSSH_CTX_UseCert_buffer(WOLFSSH_CTX* ctx,
         const byte* cert, word32 certSz, int format)
 {
@@ -1680,6 +1683,9 @@ int wolfSSH_CTX_UseCert_buffer(WOLFSSH_CTX* ctx,
 }
 
 
+/* Add a CA for verifiying the peer's certificate with.
+ * returns WS_SUCCESS on success
+ */
 int wolfSSH_CTX_AddRootCert_buffer(WOLFSSH_CTX* ctx,
         const byte* cert, word32 certSz, int format)
 {

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -437,6 +437,7 @@ struct WOLFSSH_CTX {
                                       /* Owned by CTX */
     word32 privateKeySz[WOLFSSH_MAX_PVT_KEYS];
 #ifdef WOLFSSH_CERTS
+    /* public certificate matching the private key */
     byte* cert[WOLFSSH_MAX_PVT_KEYS];
     word32 certSz[WOLFSSH_MAX_PVT_KEYS];
 #endif


### PR DESCRIPTION
Fixes verification of the host when using X509 certificates:

The following commands should print out the IP check of the hosts certificate on the client side (with it using X509). Without this PR it is not using certificates with the connection, which can be seen by changing the clients -A CA certificate and the connection still being established.
```
sudo ./apps/wolfsshd/wolfsshd -f sshd_config -D -d

./examples/client/client -i ./keys/fred-key.der -J ./keys/fred-cert.der -A ./keys/ca-cert-ecc.der
```


Adds X509 support to SFTP example client.