### PR TITLE
SFTP Large File Fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@
 - Fixes for compiler complaints using GCC 4.0.2
 - Fixes for the directory path cleanup function for SFTP
 - Fixes for SFTP directory listing when on Windows
+- Fixes for large file transfers with SFTP
 - Fixes for port forwarding
 - Fix for building with QNX
 - Fix for the wolfSSHd grace time alarm

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -398,6 +398,16 @@ static WS_SFTPNAME* wolfSSH_SFTPNAME_new(void* heap);
 static int SFTP_CreateLongName(WS_SFTPNAME* name);
 
 
+/* A few errors are OK to get. They are a notice rather that a fault.
+ * return TRUE if ssh->error is one of the following: */
+INLINE int NoticeError(WOLFSSH* ssh)
+{
+    return (ssh->error == WS_WANT_READ ||
+            ssh->error == WS_WANT_WRITE ||
+            ssh->error == WS_CHAN_RXD);
+}
+
+
 static byte* wolfSSH_SFTP_buffer_data(WS_SFTP_BUFFER* buffer)
 {
     byte* ret = NULL;
@@ -8117,8 +8127,7 @@ int wolfSSH_SFTP_Get(WOLFSSH* ssh, char* from,
                             state->gOfst, state->r,
                             WOLFSSH_MAX_SFTP_RW);
                     if (sz < 0) {
-                        if (ssh->error == WS_WANT_READ ||
-                                ssh->error == WS_WANT_WRITE) {
+                        if (NoticeError(ssh)) {
                             return WS_FATAL_ERROR;
                         }
                         WLOG(WS_LOG_SFTP, "Error reading packet");


### PR DESCRIPTION
1. There were a couple spots during a large file transfer where the client rekeying the session would interrupt the transfer and/or reset the amount of file data transfered. Fixed that with a check for WS_CHAN_RXD.
2. Added a build option to interrupt a file transfer after 2 minutes. Large files will take longer.

To recreate: generate a 2GB file. Use wolfsftp client to transfer the file from the echoserver. It should fail out after a while. When testing the PR, add the CFLAGS WOLFSSH_NO_SFTP_TIMEOUT.