### PR TITLE
Release Cleanup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# wolfSSH v1.4.12 (Dec 21, 2022)
+# wolfSSH v1.4.12 (Dec 28, 2022)
 
 ## New Feature Additions and Improvements
 - Support for Green Hills Software's INTEGRITY

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -481,7 +481,9 @@ static int wsUserAuth(byte authType,
 }
 
 
-#if defined(WOLFSSH_AGENT) || defined(WOLFSSH_CERTS)
+#if defined(WOLFSSH_AGENT) || \
+    (defined(WOLFSSH_CERTS) && \
+        (defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)))
 static inline void ato32(const byte* c, word32* u32)
 {
     *u32 = (c[0] << 24) | (c[1] << 16) | (c[2] << 8) | c[3];

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -711,16 +711,14 @@ static int wsUserAuth(byte authType,
 }
 
 
-#if defined(WOLFSSH_AGENT) || defined(WOLFSSH_CERTS)
+#if defined(WOLFSSH_CERTS) && \
+    (defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME))
 static inline void ato32(const byte* c, word32* u32)
 {
     *u32 = (c[0] << 24) | (c[1] << 16) | (c[2] << 8) | c[3];
 }
-#endif
 
 
-#if defined(WOLFSSH_CERTS) && \
-    (defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME))
 static int ParseRFC6187(const byte* in, word32 inSz, byte** leafOut,
     word32* leafOutSz)
 {

--- a/src/internal.c
+++ b/src/internal.c
@@ -10736,8 +10736,8 @@ static int BuildUserAuthRequestEccCert(WOLFSSH* ssh,
                 #endif
                 #ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP521
                 case ID_X509V3_ECDSA_SHA2_NISTP521:
-                    names = cannedKeyAlgoX509Ecc512Names;
-                    namesSz = cannedKeyAlgoX509Ecc512NamesSz;
+                    names = cannedKeyAlgoX509Ecc521Names;
+                    namesSz = cannedKeyAlgoX509Ecc521NamesSz;
                     break;
                 #endif
                 default:

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -400,7 +400,7 @@ static int SFTP_CreateLongName(WS_SFTPNAME* name);
 
 /* A few errors are OK to get. They are a notice rather that a fault.
  * return TRUE if ssh->error is one of the following: */
-INLINE int NoticeError(WOLFSSH* ssh)
+static INLINE int NoticeError(WOLFSSH* ssh)
 {
     return (ssh->error == WS_WANT_READ ||
             ssh->error == WS_WANT_WRITE ||

--- a/tests/api.c
+++ b/tests/api.c
@@ -1085,6 +1085,15 @@ int wolfSSH_ApiTest(int argc, char** argv)
 
     AssertIntEQ(wolfSSH_Init(), WS_SUCCESS);
 
+    #if defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,2)
+    {
+        int i;
+        for (i = 0; i < FIPS_CAST_COUNT; i++) {
+            AssertIntEQ(wc_RunCast_fips(i), WS_SUCCESS);
+        }
+    }
+    #endif /* HAVE_FIPS */
+
     test_wstrcat();
     test_wolfSSH_CTX_new();
     test_server_wolfSSH_new();

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -47,6 +47,10 @@
     #include "tests/sftp.h"
 #endif
 
+#ifdef HAVE_FIPS
+    #include <wolfssl/wolfcrypt/fips_test.h>
+#endif
+
 #ifndef NO_TESTSUITE_MAIN_DRIVER
 
 int main(int argc, char** argv)
@@ -111,6 +115,16 @@ int wolfSSH_TestsuiteTest(int argc, char** argv)
     #endif
 
     wolfSSH_Init();
+
+    #if defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,2)
+    {
+        int i;
+        for (i = 0; i < FIPS_CAST_COUNT; i++) {
+            wc_RunCast_fips(i);
+        }
+    }
+    #endif /* HAVE_FIPS */
+
     #if !defined(WOLFSSL_TIRTOS)
         ChangeToWolfSshRoot();
     #endif

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -329,6 +329,8 @@ int wolfSSH_UnitTest(int argc, char** argv)
     (void)argc;
     (void)argv;
 
+    wolfSSH_Init();
+
     unitResult = test_Errors();
     printf("Errors: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));
     testResult = testResult || unitResult;
@@ -349,6 +351,8 @@ int wolfSSH_UnitTest(int argc, char** argv)
     testResult = testResult || unitResult;
 #endif
 #endif
+
+    wolfSSH_Cleanup();
 
     return (testResult ? 1 : 0);
 }


### PR DESCRIPTION
1. Update the release date in the ChangeLog.
2. Move some compiler guards around to hush warnings depending on the build options.
3. Fix a string name for ECDSA P521 algo.
4. Fix a stray static function definition.
5. For FIPSv5 builds, add CAST tests to the API test and testsuite.
6. Add the wolfSSH_Init() and wolfSSH_Cleanup() to the unit test.