### PR TITLE
set ssh error in sftp status not ok state

### DIFF
--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1113,7 +1113,7 @@ static int doCmds(func_args* args)
                 ret = wolfSSH_SFTP_Put(ssh, pt, to, resume, &myStatusCb);
                 err = wolfSSH_get_error(ssh);
             } while ((err == WS_WANT_READ || err == WS_WANT_WRITE ||
-                        err == WS_CHAN_RXD) && ret != WS_SUCCESS);
+                        err == WS_CHAN_RXD) && ret == WS_FATAL_ERROR);
 
 #ifndef WOLFSSH_NO_TIMESTAMP
             WMEMSET(currentFile, 0, WOLFSSH_MAX_FILENAME);

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1013,7 +1013,7 @@ static int doCmds(func_args* args)
 
             do {
                 ret = wolfSSH_SFTP_Get(ssh, pt, to, resume, &myStatusCb);
-                if (ret != WS_SUCCESS) {
+                if (ret != WS_SUCCESS && ret == WS_FATAL_ERROR) {
                     ret = wolfSSH_get_error(ssh);
                 }
             } while (ret == WS_WANT_READ || ret == WS_WANT_WRITE ||
@@ -1523,7 +1523,7 @@ static int doAutopilot(int cmd, char* local, char* remote)
         }
         err = wolfSSH_get_error(ssh);
     } while ((err == WS_WANT_READ || err == WS_WANT_WRITE ||
-                err == WS_CHAN_RXD) && ret != WS_SUCCESS);
+                err == WS_CHAN_RXD) && ret == WS_FATAL_ERROR);
 
     if (ret != WS_SUCCESS) {
         if (cmd == AUTOPILOT_PUT) {

--- a/scripts/get-put.test
+++ b/scripts/get-put.test
@@ -86,6 +86,16 @@ then
     exit 1
 fi
 
+# Test fail on file that does not exist
+rm -rf sample1-does-not-exist
+if ./examples/sftpclient/wolfsftp -u jill -P upthehill -p "$PORT" \
+    -G -l sample1-copy.txt -r sample1-does-not-exist
+then
+    echo "Success when expecting fail to get file."
+    do_cleanup
+    exit 1
+fi
+
 # Put test.
 if ! ./examples/sftpclient/wolfsftp -u jill -P upthehill -p "$PORT" \
     -g -l sample2.txt -r sample2-copy.txt

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -5302,6 +5302,12 @@ static int wolfSSH_SFTP_DoStatus(WOLFSSH* ssh, word32 reqId,
     }
 
     wolfSSH_SFTP_buffer_seek(buffer, 0, localIdx);
+
+    if (status != WOLFSSH_FTP_OK &&
+            ssh->error != WS_WANT_READ && ssh->error != WS_WANT_WRITE) {
+        /* set ssh error as the SFTP status not being ok */
+        ssh->error = WS_SFTP_STATUS_NOT_OK;
+    }
     return status;
 }
 


### PR DESCRIPTION
Current master will hang with SFTP get-put where the file does not exist.

This adds setting the ssh->error value and a test case.