### PR TITLE
SFTP Speed

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -6710,17 +6710,14 @@ int wolfSSH_SFTP_SendWritePacket(WOLFSSH* ssh, byte* handle, word32 handleSz,
                 WLOG(WS_LOG_SFTP, "SFTP SEND_WRITE STATE: SEND_BODY");
                 state->sentSz = wolfSSH_stream_send(ssh, in, inSz);
                 if (state->sentSz == WS_WINDOW_FULL ||
-                        state->sentSz == WS_REKEYING) {
+                        state->sentSz == WS_REKEYING ||
+                        state->sentSz == WS_WANT_READ ||
+                        state->sentSz == WS_WANT_WRITE) {
                     ret = wolfSSH_worker(ssh, NULL);
-                    if (ret == WS_SUCCESS)
-                        continue; /* skip past rest and send more */
+                    continue; /* skip past rest and send more */
                 }
 
                 if (state->sentSz <= 0) {
-                    if (ssh->error == WS_WANT_READ ||
-                            ssh->error == WS_WANT_WRITE) {
-                        return WS_FATAL_ERROR;
-                    }
                     ssh->error = state->sentSz;
                     ret = WS_FATAL_ERROR;
                     state->state = STATE_SEND_WRITE_CLEANUP;

--- a/wolfssh/wolfsftp.h
+++ b/wolfssh/wolfsftp.h
@@ -152,12 +152,14 @@ struct WS_SFTPNAME {
 /*
  * WOLFSSH_MAX_SFTP_RW: Limit on how much file data the client will request
  *     or send in a file transfer message. Also a limit on how much file
- *     data a server will send per request from the client.
+ *     data a server will send per request from the client. Most SFTP clients
+ *     will allow the peer to send less than requested, but one in particular
+ *     expects the amount requested to be sent, and that's 32kiB.
  * WOLFSSH_MAX_SFTP_RECV: Used as a bounds check on a SFTP message's size.
  *     Is not used to allocate any buffers directly.
  */
 #ifndef WOLFSSH_MAX_SFTP_RW
-    #define WOLFSSH_MAX_SFTP_RW 1024
+    #define WOLFSSH_MAX_SFTP_RW 32768
 #endif
 #ifndef WOLFSSH_MAX_SFTP_RECV
     #define WOLFSSH_MAX_SFTP_RECV 32768


### PR DESCRIPTION
Improve the througput of SFTP. Clients will request a particular size chunk of a file at a time. Most clients are flexible with receiving less than requested. But, sending 1kiB at a time requires many times more messages, encryptions, and transmits than when sending a larger block. One particular client requests 32kiB blocks, always, and expects to get 32kiB at a time. This changes the amount buffered to 32kiB. You can change the value smaller, but may have issues with some clients.

Testing using Windows on VmWare as the client and the echoserver running on the macOS host machine.