### PR TITLE
SFTP Stall Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ For building under Windows with Visual Studio, see the file
 
 NOTE: On resource constrained devices the `DEFAULT_WINDOW_SZ` may need
 to be set to a lower size. It can also be increased in desktop use cases
-to help with large file transfers. By default channels are set to handle
-16,384 bytes of data being sent and received. An example of setting a
-window size for new channels would be as follows
-`./configure CPPFLAGS=-DDEFAULT_WINDOW_SZ=16384`
+to help with large file transfers. By default channels are set to receive
+up to 128kB of data before sending a channel window adjust message. An
+example of setting a window size for new channels would be as follows
+`./configure CPPFLAGS="-DDEFAULT_WINDOW_SZ=16384"`
 
 For 32bit Linux platforms you can add support for files > 2GB by compling
 with `CFLAGS=-D_FILE_OFFSET_BITS=64`.

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1017,7 +1017,7 @@ static int doCmds(func_args* args)
                     ret = wolfSSH_get_error(ssh);
                 }
             } while (ret == WS_WANT_READ || ret == WS_WANT_WRITE ||
-                    ret == WS_CHAN_RXD);
+                    ret == WS_CHAN_RXD || ret == WS_REKEYING);
 
 #ifndef WOLFSSH_NO_TIMESTAMP
             WMEMSET(currentFile, 0, WOLFSSH_MAX_FILENAME);
@@ -1113,7 +1113,8 @@ static int doCmds(func_args* args)
                 ret = wolfSSH_SFTP_Put(ssh, pt, to, resume, &myStatusCb);
                 err = wolfSSH_get_error(ssh);
             } while ((err == WS_WANT_READ || err == WS_WANT_WRITE ||
-                        err == WS_CHAN_RXD) && ret == WS_FATAL_ERROR);
+                        err == WS_CHAN_RXD || err == WS_REKEYING) &&
+                    ret == WS_FATAL_ERROR);
 
 #ifndef WOLFSSH_NO_TIMESTAMP
             WMEMSET(currentFile, 0, WOLFSSH_MAX_FILENAME);

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1031,6 +1031,7 @@ int wolfSSH_stream_read(WOLFSSH* ssh, byte* buf, word32 bufSz)
         return WS_BAD_ARGUMENT;
 
     inputBuffer = &ssh->channelList->inputBuffer;
+    ssh->error = WS_SUCCESS;
 
     if (ret == WS_SUCCESS) {
         WLOG(WS_LOG_DEBUG, "    Stream read index of %u", inputBuffer->idx);

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -341,10 +341,10 @@ enum {
     #define DEFAULT_HIGHWATER_MARK ((1024 * 1024 * 1024) - (32 * 1024))
 #endif
 #ifndef DEFAULT_WINDOW_SZ
-    #define DEFAULT_WINDOW_SZ 16384
+    #define DEFAULT_WINDOW_SZ (128 * 1024)
 #endif
 #ifndef DEFAULT_MAX_PACKET_SZ
-    #define DEFAULT_MAX_PACKET_SZ (16 * 1024)
+    #define DEFAULT_MAX_PACKET_SZ 32768
 #endif
 #ifndef DEFAULT_NEXT_CHANNEL
     #define DEFAULT_NEXT_CHANNEL 0

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -344,6 +344,7 @@ enum {
     #define DEFAULT_WINDOW_SZ (128 * 1024)
 #endif
 #ifndef DEFAULT_MAX_PACKET_SZ
+    /* This is from RFC 4253 section 6.1. */
     #define DEFAULT_MAX_PACKET_SZ 32768
 #endif
 #ifndef DEFAULT_NEXT_CHANNEL


### PR DESCRIPTION
SFTP Stall Fix

1. Fixed issue where a SFTP connection would stall while upload a large file.
2. Remove a little duplicate code.
3. Increased the channel receive buffer size to 128k.
4. Fixed the max packet size to 32k.
5. Clear the error register when calling stream read.

To test: Enable SFTP. Start the echoserver. Connect to the echoserver with WinSCP. Upload a 1GB file to the echoserver. If you back out the size change commit, it should stall while uploading. (The size change commit improves throughput.)

(ZD 14607)