### PR TITLE
Build Cleanup

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -2335,6 +2335,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
             return 0;
         }
 
+        #if !defined(WOLFSSH_NO_RSA) && !defined(WOLFSSH_NO_ECC)
         peerEcc = !peerEcc;
         bufSz = EXAMPLE_KEYLOAD_BUFFER_SZ;
 
@@ -2350,6 +2351,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
             serverArgs->return_code = EXIT_FAILURE;
             return 0;
         }
+        #endif
 
         if (userPubKey) {
             byte* userBuf = NULL;

--- a/tests/api.c
+++ b/tests/api.c
@@ -336,7 +336,7 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
     byte* eccKey;
     word32 eccKeySz;
 #endif
-#ifndef WOLFSSH_NO_RSA
+#ifndef WOLFSSH_NO_SSH_RSA_SHA1
     byte* rsaKey;
     word32 rsaKeySz;
 #endif
@@ -353,7 +353,7 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
                     NULL, NULL, NULL,
                     NULL, NULL, NULL));
 #endif
-#ifndef WOLFSSH_NO_RSA
+#ifndef WOLFSSH_NO_SSH_RSA_SHA1
     AssertIntEQ(0,
             ConvertHexToBin(serverKeyRsaDer, &rsaKey, &rsaKeySz,
                     NULL, NULL, NULL,
@@ -429,7 +429,7 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
     AssertIntNE(lastKeySz, ctx->privateKeySz[0]);
 #endif
 
-#ifndef WOLFSSH_NO_RSA
+#ifndef WOLFSSH_NO_SSH_RSA_SHA1
     lastKey = ctx->privateKey[ctx->privateKeyCount];
     lastKeySz = ctx->privateKeySz[ctx->privateKeyCount];
 
@@ -452,7 +452,7 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
         wolfSSH_CTX_UsePrivateKey_buffer(ctx, eccKey, eccKeySz,
                                          TEST_GOOD_FORMAT_ASN1));
 #endif
-#ifndef WOLFSSH_NO_RSA
+#ifndef WOLFSSH_NO_SSH_RSA_SHA1
     AssertIntEQ(WS_SUCCESS,
         wolfSSH_CTX_UsePrivateKey_buffer(ctx, rsaKey, rsaKeySz,
                                          TEST_GOOD_FORMAT_ASN1));
@@ -464,7 +464,7 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer(void)
     !defined(WOLFSSH_NO_ECDSA_SHA2_NISTP521)
     FreeBins(eccKey, NULL, NULL, NULL);
 #endif
-#ifndef WOLFSSH_NO_RSA
+#ifndef WOLFSSH_NO_SSH_RSA_SHA1
     FreeBins(rsaKey, NULL, NULL, NULL);
 #endif
 #endif /* WOLFSSH_NO_SERVER */


### PR DESCRIPTION
1. Found a few cases where disabling RSA made some things either not build or run correctly.
2. Hushed a few unused variables in gated-disabled situations.
3. Moved a temp variable closer to where it is used.