### PR TITLE
Guard Spelling

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -64,6 +64,9 @@ Flags:
     use of the function if the flag isn't set. If using wolfCrypt v4.5.0 or
     later, and not building with configure, set this flag.
     default: off
+  WOLFSSH_NO_SHA1
+    Set when SHA1 is disabled. Set to disable use of SHA1 in HMAC and digital
+    signature support.
   WOLFSSH_NO_HMAC_SHA1
     Set when HMAC or SHA1 are disabled. Set to disable HMAC-SHA1 support.
   WOLFSSH_NO_HMAC_SHA1_96
@@ -2741,7 +2744,7 @@ static INLINE byte AeadModeForId(byte id)
 static INLINE byte SigTypeForId(byte id)
 {
     switch (id) {
-#ifndef WOLFSSH_NO_SSHA_RSA_SHA1
+#ifndef WOLFSSH_NO_SSH_RSA_SHA1
     #ifdef WOLFSSH_CERTS
         case ID_X509V3_SSH_RSA:
     #endif

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -86,12 +86,17 @@ extern "C" {
     #define WOLFSSH_NO_DH
 #endif
 
+#ifdef NO_SHA
+    #undef WOLFSSH_NO_SHA1
+    #define WOLFSSH_NO_SHA1
+#endif
 
-#if defined(NO_HMAC) || defined(NO_SHA)
+
+#if defined(NO_HMAC) || defined(WOLFSSH_NO_SHA1)
     #undef WOLFSSH_NO_HMAC_SHA1
     #define WOLFSSH_NO_HMAC_SHA1
 #endif
-#if defined(NO_HMAC) || defined(NO_SHA)
+#if defined(NO_HMAC) || defined(WOLFSSH_NO_SHA1)
     #undef WOLFSSH_NO_HMAC_SHA1_96
     #define WOLFSSH_NO_HMAC_SHA1_96
 #endif
@@ -106,11 +111,11 @@ extern "C" {
 #endif
 
 
-#if defined(WOLFSSH_NO_DH) || defined(NO_SHA)
+#if defined(WOLFSSH_NO_DH) || defined(WOLFSSH_NO_SHA1)
     #undef WOLFSSH_NO_DH_GROUP1_SHA1
     #define WOLFSSH_NO_DH_GROUP1_SHA1
 #endif
-#if defined(WOLFSSH_NO_DH) || defined(NO_SHA)
+#if defined(WOLFSSH_NO_DH) || defined(WOLFSSH_NO_SHA1)
     #undef WOLFSSH_NO_DH_GROUP14_SHA1
     #define WOLFSSH_NO_DH_GROUP14_SHA1
 #endif
@@ -164,7 +169,7 @@ extern "C" {
     #define WOLFSSH_NO_ECDH
 #endif
 
-#if defined(WOLFSSH_NO_RSA) || defined(NO_SHA)
+#if defined(WOLFSSH_NO_RSA) || defined(WOLFSSH_NO_SHA1)
     #undef WOLFSSH_NO_SSH_RSA_SHA1
     #define WOLFSSH_NO_SSH_RSA_SHA1
 #endif
@@ -192,14 +197,14 @@ extern "C" {
     #undef WOLFSSH_NO_ECDSA_SHA2_NISTP521
     #define WOLFSSH_NO_ECDSA_SHA2_NISTP521
 #endif
-#if defined(WOLFSSH_NO_SHA_RSA_SHA1) && \
+#if defined(WOLFSSH_NO_SSH_RSA_SHA1) && \
     defined(WOLFSSH_NO_ECDSA_SHA2_NISTP256) && \
     defined(WOLFSSH_NO_ECDSA_SHA2_NISTP384) && \
     defined(WOLFSSH_NO_ECDSA_SHA2_NISTP521)
     #error "You need at least one signing algorithm."
 #endif
 
-#ifdef WOLFSSH_NO_SHA_RSA_SHA1
+#ifdef WOLFSSH_NO_SSH_RSA_SHA1
     #undef WOLFSSH_NO_RSA
     #define WOLFSSH_NO_RSA
 #endif


### PR DESCRIPTION
1. Fix the spelling on one of the feature disable guards.
2. Add a guard check to disable all things SHA-1.