### PR TITLE
Fix build error in client_test

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1084,10 +1084,11 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
                 caCert = myoptarg;
                 break;
 
+            #if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
             case 'X':
                 IPOverride = 1;
                 break;
-
+            #endif
         #endif
 
             case 'x':

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1675,10 +1675,11 @@ THREAD_RETURN WOLFSSH_THREAD sftpclient_test(void* args)
                 caCert = myoptarg;
                 break;
 
+            #if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
             case 'X':
                 IPOverride = 1;
                 break;
-
+            #endif
         #endif
 
             case '?':


### PR DESCRIPTION
Gate use of `IPOverride` with `#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)`

Fixes #501 