### PR TITLE
wolfSSHd Shadow Fix

### DIFF
--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -292,6 +292,7 @@ static int CheckPasswordHashUnix(const char* input, char* stored)
 {
     int ret = WSSHD_AUTH_SUCCESS;
     char* hashedInput;
+    word32 hashedInputSz = 0, storedSz = 0;
 
     if (input == NULL || stored == NULL) {
         ret = WS_BAD_ARGUMENT;
@@ -303,7 +304,13 @@ static int CheckPasswordHashUnix(const char* input, char* stored)
             ret = WS_FATAL_ERROR;
         }
         else {
-            if (WMEMCMP(hashedInput, stored, WSTRLEN(stored)) != 0) {
+            hashedInputSz = (word32)WSTRLEN(hashedInput);
+            storedSz = (word32)WSTRLEN(stored);
+
+            if (storedSz == 0 || stored[0] == '*' ||
+                    hashedInputSz == 0 || hashedInput[0] == '*' ||
+                    hashedInputSz != storedSz ||
+                    WMEMCMP(hashedInput, stored, storedSz) != 0) {
                 ret = WSSHD_AUTH_FAILURE;
             }
         }


### PR DESCRIPTION
1. Checking the string returned from crypt() to make sure it isn't a "*".
2. Checking the lengths of the strings when checking the password.

Testing:

```
./configure --enable-sshd --enable-sftp --with-wolfssl=<path>
make
cd apps/wolfsshd
touch sshd_config
sudo ./wolfsshd -p 22222 -h <path-to>/wolfssh/keys/server-key-ecc.pem -f ./sshd_config
sudo adduser --diabled-password foo
ssh -p 22222 foo@localhost
<enter random, should fail>
sudo passwd foo
<set a password>
ssh -p 22222 foo@local
<enter random, should fail>
ssh -p 22222 foo@local
<enter password, should login, logout>
sudo passwd -l foo
ssh -p 22222 foo@localhost
<enter password, should fail>
```