### PR TITLE
ecc_p256-kyber_level1 interop with OQS OpenSSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ The following is sufficient for build and execution:
     $ cd openssh-OQS-OpenSSH-snapshot-2021-08/
     $ ./configure --with-liboqs-dir=/usr/local
     $ make all
-    $ ./ssh -o"KexAlgorithms +ecdh-nistp256-kyber-512-sha256" \
+    $ ./ssh -o"KexAlgorithms=ecdh-nistp256-kyber-512r3-sha256-d00@openquantumsafe.org" \
       -o"PubkeyAcceptedAlgorithms +ssh-rsa" \
       -o"HostkeyAlgorithms +ssh-rsa" \
       jill@localhost -p 22222

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1735,9 +1735,10 @@ int wolfSSH_KDF(byte hashId, byte keyId,
                 const byte* h, word32 hSz,
                 const byte* sessionId, word32 sessionIdSz)
 {
+    int doKeyPadding = 1;
     WLOG(WS_LOG_DEBUG, "Entering wolfSSH_KDF()");
     return GenerateKey(hashId, keyId, key, keySz, k, kSz, h, hSz,
-                       sessionId, sessionIdSz);
+                       sessionId, sessionIdSz, doKeyPadding);
 }
 
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -141,8 +141,8 @@ extern "C" {
     #define WOLFSSH_NO_ECDH_SHA2_ED25519
 #endif
 #if !defined(WOLFSSH_HAVE_LIBOQS) || defined(NO_SHA256)
-    #undef WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256
-    #define WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256
+    #undef WOLFSSH_NO_ECDH_NISTP256_KYBER_LEVEL1_SHA256
+    #define WOLFSSH_NO_ECDH_NISTP256_KYBER_LEVEL1_SHA256
 #endif
 
 #if defined(WOLFSSH_NO_DH_GROUP1_SHA1) && \
@@ -152,7 +152,7 @@ extern "C" {
     defined(WOLFSSH_NO_ECDH_SHA2_NISTP384) && \
     defined(WOLFSSH_NO_ECDH_SHA2_NISTP521) && \
     defined(WOLFSSH_NO_ECDH_SHA2_ED25519) && \
-    defined(WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256)
+    defined(WOLFSSH_NO_ECDH_NISTP256_KYBER_LEVEL1_SHA256)
     #error "You need at least one key agreement algorithm."
 #endif
 
@@ -285,8 +285,8 @@ enum {
     ID_ECDH_SHA2_ED25519,
     ID_ECDH_SHA2_ED25519_LIBSSH,
     ID_DH_GROUP14_SHA256,
-#ifndef WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256
-    ID_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256,
+#ifndef WOLFSSH_NO_ECDH_NISTP256_KYBER_LEVEL1_SHA256
+    ID_ECDH_NISTP256_KYBER_LEVEL1_SHA256,
 #endif
 
     /* Public Key IDs */
@@ -369,7 +369,7 @@ enum {
     #define WOLFSSH_DEFAULT_GEXDH_MAX 8192
 #endif
 #ifndef MAX_KEX_KEY_SZ
-    #ifndef WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256
+    #ifndef WOLFSSH_NO_ECDH_NISTP256_KYBER_LEVEL1_SHA256
         /* Private key size of Kyber Level1. Biggest artifact. */
         #define MAX_KEX_KEY_SZ 1632
     #else
@@ -513,7 +513,7 @@ typedef struct HandshakeInfo {
 #endif
 
     byte useEcc;
-#ifndef WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256
+#ifndef WOLFSSH_NO_ECDH_NISTP256_KYBER_LEVEL1_SHA256
     byte useEccKyber;
 #endif
 
@@ -863,7 +863,7 @@ WOLFSSH_LOCAL int SendChannelTerminalRequest(WOLFSSH* ssh);
 WOLFSSH_LOCAL int SendChannelAgentRequest(WOLFSSH* ssh);
 WOLFSSH_LOCAL int SendChannelSuccess(WOLFSSH*, word32, int);
 WOLFSSH_LOCAL int GenerateKey(byte, byte, byte*, word32, const byte*, word32,
-                              const byte*, word32, const byte*, word32);
+                              const byte*, word32, const byte*, word32, byte doKeyPad);
 
 
 enum AcceptStates {
@@ -958,13 +958,13 @@ enum WS_MessageIds {
 
     MSGID_KEXDH_INIT = 30,
     MSGID_KEXECDH_INIT = 30,
-#ifndef WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256
+#ifndef WOLFSSH_NO_ECDH_NISTP256_KYBER_LEVEL1_SHA256
     MSGID_KEXKEM_INIT = 30,
 #endif
 
     MSGID_KEXDH_REPLY = 31,
     MSGID_KEXECDH_REPLY = 31,
-#ifndef WOLFSSH_NO_ECDH_SHA2_NISTP256_KYBER_LEVEL1_SHA256
+#ifndef WOLFSSH_NO_ECDH_NISTP256_KYBER_LEVEL1_SHA256
     MSGID_KEXKEM_REPLY = 31,
 #endif
 


### PR DESCRIPTION
The implementation now complies with the following draft: 

https://www.ietf.org/id/draft-kampanakis-curdle-ssh-pq-ke-01.html

We implement the method as defined by the following name in that draft: 

ecdh-nistp256-kyber-512r3-sha256-d00@openquantumsafe.org