### PR TITLE
Mac Build Fix

### DIFF
--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -1130,6 +1130,12 @@ int wolfSSHD_AuthReducePermissions(WOLFSSHD_AUTH* auth)
 }
 
 
+#if defined(__OSX__) || defined( __APPLE__)
+    #define WGETGROUPLIST(x,y,z,w) getgrouplist((x),(y),(int*)(z),(w))
+#else
+    #define WGETGROUPLIST(x,y,z,w) getgrouplist((x),(y),(z),(w))
+#endif
+
 /* sets the extended groups the user is in, returns WS_SUCCESS on success */
 int wolfSSHD_AuthSetGroups(const WOLFSSHD_AUTH* auth, const char* usr,
         WGID_T gid)
@@ -1139,14 +1145,14 @@ int wolfSSHD_AuthSetGroups(const WOLFSSHD_AUTH* auth, const char* usr,
     int ret = WS_SUCCESS;
 
     /* should return -1 if grpListSz is smaller than actual groups */
-    if (getgrouplist(usr, gid, NULL, &grpListSz) == -1) {
+    if (WGETGROUPLIST(usr, gid, NULL, &grpListSz) == -1) {
         grpList = (gid_t*)WMALLOC(sizeof(gid_t) * grpListSz, auth->heap,
             DYNTYPE_SSHD);
         if (grpList == NULL) {
             ret = WS_MEMORY_E;
         }
         else {
-            if (getgrouplist(usr, gid, grpList, &grpListSz)
+            if (WGETGROUPLIST(usr, gid, grpList, &grpListSz)
                     != grpListSz) {
                 ret = WS_FATAL_ERROR;
             }


### PR DESCRIPTION
Put macro wrapper around function getgrouplist(). The mac is treating it as taking a pointer to int rather than gid_t. Wrapper juggles that.