### PR TITLE
Made dirlist part of WolfSSH struct.

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -2141,15 +2141,6 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
 
 #ifndef NO_WOLFSSH_DIR
 
-/* hold pointers to directory handles */
-typedef struct DIR_HANDLE {
-    WDIR dir;
-    char* dirName; /* base name of directory */
-    byte isEof;    /* flag for if read everything */
-    word32 id[2];  /* handle ID */
-    struct DIR_HANDLE* next;
-} DIR_HANDLE;
-static DIR_HANDLE* dirList = NULL;
 static word32 idCount[2] = {0, 0};
 /* @TODO add locking for thread safety */
 
@@ -2238,9 +2229,9 @@ int wolfSSH_SFTP_RecvOpenDir(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
         c32toa(id[1], idFlat + UINT32_SZ);
         AddAssign64(idCount, 1);
         cur->isEof = 0;
-        cur->next  = dirList;
-        dirList    = cur;
-        dirList->dirName = dirName; /* take over ownership of buffer */
+        cur->next  = ssh->dirList;
+        ssh->dirList    = cur;
+        ssh->dirList->dirName = dirName; /* take over ownership of buffer */
     }
 
     out = (byte*)WMALLOC(outSz, ssh->ctx->heap, DYNTYPE_BUFFER);
@@ -2375,8 +2366,8 @@ int wolfSSH_SFTP_RecvOpenDir(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
         AddAssign64(idCount, 1);
         cur->isEof = 0;
         cur->dirName = dirName; /* take over ownership of buffer */
-        cur->next = dirList;
-        dirList = cur;
+        cur->next = ssh->dirList;
+        ssh->dirList = cur;
 
     }
 
@@ -3028,7 +3019,7 @@ int wolfSSH_SFTP_RecvReadDir(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
     WS_SFTPNAME* name = NULL;
     WS_SFTPNAME* list = NULL;
     word32 outSz = 0;
-    DIR_HANDLE* cur = dirList;
+    DIR_HANDLE* cur = ssh->dirList;
     char* dirName = NULL;
     byte* out;
 
@@ -3138,7 +3129,7 @@ int wolfSSH_SFTP_RecvReadDir(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
  */
 int wolfSSH_SFTP_RecvCloseDir(WOLFSSH* ssh, byte* handle, word32 handleSz)
 {
-    DIR_HANDLE* cur = dirList;
+    DIR_HANDLE* cur = ssh->dirList;
     word32 h[2] = {0,0};
 
     if (ssh == NULL || handle == NULL || handleSz != (sizeof(word32)*2)) {
@@ -3169,13 +3160,13 @@ int wolfSSH_SFTP_RecvCloseDir(WOLFSSH* ssh, byte* handle, word32 handleSz)
 
     /* remove directory from list */
     if (cur != NULL) {
-        DIR_HANDLE* pre = dirList;
+        DIR_HANDLE* pre = ssh->dirList;
 
         WLOG(WS_LOG_SFTP, "Free'ing and closing handle %d%d pointer of [%p]",
                 cur->id[1], cur->id[0], cur);
         /* case where node is at head of list */
         if (pre == cur) {
-            dirList = cur->next;
+            ssh->dirList = cur->next;
             WFREE(cur->dirName, ssh->ctx->heap, DYNTYPE_SFTP);
             WFREE(cur, ssh->ctx->heap, DYNTYPE_SFTP);
         }
@@ -8463,7 +8454,7 @@ int wolfSSH_SFTP_free(WOLFSSH* ssh)
 #ifndef NO_WOLFSSH_DIR
     {
         /* free all dirs if hung up on */
-        DIR_HANDLE* cur = dirList;
+        DIR_HANDLE* cur = ssh->dirList;
 
         /* find DIR given handle */
         while (cur != NULL) {
@@ -8479,7 +8470,7 @@ int wolfSSH_SFTP_free(WOLFSSH* ssh)
                 WFREE(toFree->dirName, ssh->ctx->heap, DYNTYPE_SFTP);
             WFREE(toFree, ssh->ctx->heap, DYNTYPE_SFTP);
         }
-        dirList = NULL;
+        ssh->dirList = NULL;
     }
 #endif /* NO_WOLFSSH_DIR */
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -602,6 +602,17 @@ struct WS_SFTP_RENAME_STATE;
 
 struct WOLFSSH_AGENT_CTX;
 
+#ifndef NO_WOLFSSH_DIR
+/* hold pointers to directory handles */
+typedef struct DIR_HANDLE {
+	WDIR dir;
+	char* dirName; /* base name of directory */
+	byte isEof;    /* flag for if read everything */
+	word32 id[2];  /* handle ID */
+	struct DIR_HANDLE* next;
+} DIR_HANDLE;
+#endif
+
 /* our wolfSSH session */
 struct WOLFSSH {
     WOLFSSH_CTX* ctx;      /* owner context */
@@ -753,6 +764,9 @@ struct WOLFSSH {
     char* sftpDefaultPath;
 #ifdef WOLFSSH_STOREHANDLE
     WS_HANDLE_LIST* handleList;
+#endif
+#ifndef NO_WOLFSSH_DIR
+    DIR_HANDLE* dirList;    /* hold pointers to directory handles */
 #endif
     struct WS_SFTP_RECV_STATE* recvState;
     struct WS_SFTP_RMDIR_STATE* rmdirState;


### PR DESCRIPTION
For concurrent access by the same user from different applications, the global variable dirlist can cause exception.