### PR TITLE
fix file offest on Windows and change offset increment

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -13217,12 +13217,20 @@ int wolfSSH_oct2dec(WOLFSSH* ssh, byte* oct, word32 octSz)
 }
 
 
+/* not using UINT_MAX here because word32 should always be 32 bits where an
+ * int type can change depending on platform */
+#define WS_WORD32_MAX_SZ 4294967295U
+
 /* addend1 += addend2 */
 void AddAssign64(word32* addend1, word32 addend2)
 {
-    word32 tmp = addend1[0];
-    if ((addend1[0] += addend2) < tmp)
+    if (addend1[0] > (WS_WORD32_MAX_SZ - addend2)) {
         addend1[1]++;
+        addend1[0] = addend2 - (WS_WORD32_MAX_SZ - addend1[0]);
+    }
+    else {
+        addend1[0] += addend2;
+    }
 }
 
 #endif /* WOLFSSH_SFTP */

--- a/src/internal.c
+++ b/src/internal.c
@@ -13217,16 +13217,12 @@ int wolfSSH_oct2dec(WOLFSSH* ssh, byte* oct, word32 octSz)
 }
 
 
-/* not using UINT_MAX here because word32 should always be 32 bits where an
- * int type can change depending on platform */
-#define WS_WORD32_MAX_SZ 4294967295U
-
 /* addend1 += addend2 */
 void AddAssign64(word32* addend1, word32 addend2)
 {
-    if (addend1[0] > (WS_WORD32_MAX_SZ - addend2)) {
+    if (addend1[0] > (WOLFSSL_MAX_32BIT - addend2)) {
         addend1[1]++;
-        addend1[0] = addend2 - (WS_WORD32_MAX_SZ - addend1[0]);
+        addend1[0] = addend2 - (WOLFSSL_MAX_32BIT- addend1[0]);
     }
     else {
         addend1[0] += addend2;

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -8378,7 +8378,7 @@ int wolfSSH_SFTP_Put(WOLFSSH* ssh, char* from, char* to, byte resume,
                 }
                 if (resume) {
                     WMEMSET(&state->offset, 0, sizeof(OVERLAPPED));
-                    state->offset.OffsetHigh = 0;
+                    state->offset.OffsetHigh = state->pOfst[1];
                     state->offset.Offset = state->pOfst[0];
                 }
             #endif /* USE_WINDOWS_API */
@@ -8434,7 +8434,7 @@ int wolfSSH_SFTP_Put(WOLFSSH* ssh, char* from, char* to, byte resume,
                     else {
                         AddAssign64(state->pOfst, sz);
                         #ifdef USE_WINDOWS_API
-                            state->offset.OffsetHigh = 0;
+                            state->offset.OffsetHigh = state->pOfst[1];
                             state->offset.Offset = state->pOfst[0];
                         #endif /* USE_WINDOWS_API */
                         state->rSz -= sz;


### PR DESCRIPTION
Reported via direct email. On Windows the high offset was not getting set with SFTP leading to not stopping when writing files larger than max word32 size (over 4G). When fixing that I also changed the assign function to not depend on overflow (undefined behavior) for incrementing the high offset value.