### PR TITLE
Semaphores

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -175,6 +175,7 @@ typedef struct thread_args {
     WOLFSSH* ssh;
     wolfSSL_Mutex lock;
     byte rawMode;
+    byte quit;
 } thread_args;
 
 #ifdef _POSIX_THREADS
@@ -253,6 +254,9 @@ static THREAD_RET windowMonitor(void* in)
     do {
     #if (defined(__OSX__) || defined(__APPLE__))
         dispatch_semaphore_wait(windowSem, DISPATCH_TIME_FOREVER);
+        if (args->quit) {
+            break;
+        }
     #else
         sem_wait(&windowSem);
     #endif
@@ -865,6 +869,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         pthread_t   thread[3];
 
         arg.ssh = ssh;
+        arg.quit = 0;
         wc_InitMutex(&arg.lock);
     #if (defined(__OSX__) || defined(__APPLE__))
         windowSem = dispatch_semaphore_create(0);
@@ -888,7 +893,10 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         pthread_create(&thread[1], NULL, readInput, (void*)&arg);
         pthread_create(&thread[2], NULL, readPeer, (void*)&arg);
         pthread_join(thread[2], NULL);
-        pthread_cancel(thread[0]);
+        /* Wake the windowMonitor thread so it can exit. */
+        arg.quit = 1;
+        dispatch_semaphore_signal(windowSem);
+        pthread_join(thread[0], NULL);
         pthread_cancel(thread[1]);
     #if (defined(__OSX__) || defined(__APPLE__))
         dispatch_release(windowSem);

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -254,12 +254,12 @@ static THREAD_RET windowMonitor(void* in)
     do {
     #if (defined(__OSX__) || defined(__APPLE__))
         dispatch_semaphore_wait(windowSem, DISPATCH_TIME_FOREVER);
-        if (args->quit) {
-            break;
-        }
     #else
         sem_wait(&windowSem);
     #endif
+        if (args->quit) {
+            break;
+        }
         ret = sendCurrentWindowSize(args);
         (void)ret;
     } while (1);
@@ -895,7 +895,11 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         pthread_join(thread[2], NULL);
         /* Wake the windowMonitor thread so it can exit. */
         arg.quit = 1;
+    #if (defined(__OSX__) || defined(__APPLE__))
         dispatch_semaphore_signal(windowSem);
+    #else
+        sem_post(&windowSem);
+    #endif
         pthread_join(thread[0], NULL);
         pthread_cancel(thread[1]);
     #if (defined(__OSX__) || defined(__APPLE__))


### PR DESCRIPTION
1. Add quit parameter to the example client's thread_args structure. This will be used to let the windowMonitor thread know the application is quitting.
2. If the windowMonitor's quit flag is set, it will exit and not call wait again.
3. Join the windowMonitor thread rather than cancel it.