### PR TITLE
Fix Terminal Window Size Update

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -13025,7 +13025,7 @@ int SendChannelTerminalResize(WOLFSSH* ssh, word32 columns, word32 rows,
     }
 
     if (ret == WS_SUCCESS) {
-        typeSz = (word32)sizeof(cType) - 1;
+        typeSz = (word32)WSTRLEN(cType);
         ret = PreparePacket(ssh, MSG_ID_SZ + UINT32_SZ + LENGTH_SZ +
                                  typeSz + BOOLEAN_SZ + (4 * UINT32_SZ));
     }


### PR DESCRIPTION
Change sizeof a pointer to a string to WSTRLEN(). It was only copying part of the string "window-change" to the channel status message.