### PR TITLE
Fix compile errors when WOLFSSH_TERM is undefined

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -190,6 +190,7 @@ typedef struct thread_args {
 #endif
 
 
+#ifdef WOLFSSH_TERM
 static int sendCurrentWindowSize(thread_args* args)
 {
     int ret;
@@ -221,6 +222,7 @@ static int sendCurrentWindowSize(thread_args* args)
 
     return ret;
 }
+#endif
 
 
 #ifndef _MSC_VER
@@ -260,7 +262,9 @@ static THREAD_RET windowMonitor(void* in)
         if (args->quit) {
             break;
         }
+#ifdef WOLFSSH_TERM
         ret = sendCurrentWindowSize(args);
+#endif
         (void)ret;
     } while (1);
 
@@ -877,6 +881,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         sem_init(&windowSem, 0, 0);
     #endif
 
+#ifdef WOLFSSH_TERM
         if (cmd) {
             int err;
 
@@ -887,6 +892,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
                 fprintf(stderr, "Issue sending exec initial terminal size\n\r");
             }
         }
+#endif
 
         signal(SIGWINCH, WindowChangeSignal);
         pthread_create(&thread[0], NULL, windowMonitor, (void*)&arg);

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1315,6 +1315,7 @@ void* wolfSSH_GetPublicKeyCheckCtx(WOLFSSH* ssh)
     return NULL;
 }
 
+#ifdef WOLFSSH_TERM
 
 /* Used to resize terminal window with shell connections
  * returns WS_SUCCESS on success */
@@ -1349,6 +1350,8 @@ void wolfSSH_SetTerminalResizeCtx(WOLFSSH* ssh, void* usrCtx)
 {
     ssh->termCtx = usrCtx;
 }
+
+#endif
 
 
 /* Used to set the channel request type sent in wolfSSH connect. The default


### PR DESCRIPTION
compiling with --disable-term generates errors in src/ssh.c