### PR TITLE
Initial PTY Window Size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ AC_CHECK_SIZEOF([long])
 AC_CHECK_SIZEOF([off_t])
 
 # Check headers/libs
-AC_CHECK_HEADERS([sys/select.h sys/time.h pty.h util.h termios.h])
+AC_CHECK_HEADERS([sys/select.h sys/time.h sys/ioctl.h pty.h util.h termios.h])
 AC_CHECK_LIB([network],[socket])
 AC_CHECK_LIB([util],[forkpty])
 


### PR DESCRIPTION
1. Changed gathering the PTY window size from being OS dependent to availability of ioctl.h so both Linux and MacOS would start with the correct size.
2. Added a check to configure for sys/ioctl.h.
3. Changed GetTerminalSize() so it returns the pix width and height as well.

Test Case
---------

```
% echo $COLUMNS
% echo $LINES
% ./examples/client/client -t -p 22 -u user -i private-key -j public-key
% echo $COLUMNS
% echo $LINES
```

Without the change, on the macOS terminal, when you connect to the localhost server, the columns and lines will be 80x24. With the change, the columns and lines will match whatever your window is set to. (Mac would update correctly on window size change.)