### PR TITLE
Term Update

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -316,15 +316,6 @@ static THREAD_RET readInput(void* in)
     #else
         ret = (int)read(STDIN_FILENO, buf, bufSz -1);
         sz  = (word32)ret;
-
-        /* add carriage returns for interop with windows server */
-        if (ret > 0) {
-            if (ret == 1 && buf[0] == '\n') {
-                buf[1] = '\r';
-                ret++;
-                sz++;
-            }
-        }
     #endif
         if (ret <= 0) {
             fprintf(stderr, "Error reading stdin\n");

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -920,7 +920,8 @@ WOLFSSH_LOCAL int SendRequestSuccess(WOLFSSH*, int);
 WOLFSSH_LOCAL int SendChannelOpenSession(WOLFSSH*, WOLFSSH_CHANNEL*);
 WOLFSSH_LOCAL int SendChannelOpenForward(WOLFSSH*, WOLFSSH_CHANNEL*);
 WOLFSSH_LOCAL int SendChannelOpenConf(WOLFSSH*, WOLFSSH_CHANNEL*);
-WOLFSSH_LOCAL int SendChannelOpenFail(WOLFSSH*, word32, word32, const char*, const char*);
+WOLFSSH_LOCAL int SendChannelOpenFail(WOLFSSH* ssh, word32 channel,
+        word32 reason, const char* description, const char* language);
 WOLFSSH_LOCAL int SendChannelEof(WOLFSSH*, word32);
 WOLFSSH_LOCAL int SendChannelEow(WOLFSSH*, word32);
 WOLFSSH_LOCAL int SendChannelClose(WOLFSSH*, word32);


### PR DESCRIPTION
1. Change GetTerminalSize() to GetTerminalInfo().
2. Add the term variable to the things GetTerminalInfo() looks up.
3. Return the actual value of the environment variable TERM to the server. If one isn't present, default to "xterm".
4. Clean up the whitespace in SendChannelTerminalRequest().

Misc other changes:
1. Cleanup whitespace in the recently added function SendChannelOpenFail().
2. Add labels to the parameters in the prototype for SendChannelOpenFail().
3. Remove the CR addition for Windows in the example client. Causes the enter key to double-strike.

Testing
-------

```
% echo $TERM
% ./examples/client/client -u username -i ~/.ssh/id_ecdsa -j ~/.ssh/id_ecdsa.pub -p 22 -t -h server
% echo $TERM
```

The TERM values should match. Before the change, the server will always be told "xterm". On my system TERM is set to "screen-256color". The noticeable difference I had was with vim. Before the fix, vim would be in black-and-white. With the fix it is full color.