### PR TITLE
internal.c var initialization for Espressif Component Manager 

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -873,6 +873,7 @@ int IdentifyKey(const byte* in, word32 inSz, int isPrivate, void* heap)
     word32 idx;
     int ret;
     int dynType = isPrivate ? DYNTYPE_PRIVKEY : DYNTYPE_PUBKEY;
+    (void) dynType;
 
     key = (union wolfSSH_key*)WMALLOC(sizeof(union wolfSSH_key), heap, dynType);
 
@@ -8323,8 +8324,8 @@ int SendKexInit(WOLFSSH* ssh)
     byte* payload = NULL;
     char* kexAlgoNames = NULL;
     char* keyAlgoNames = NULL;
-    const byte* algo;
-    word32 algoCount, idx = 0, payloadSz = 0,
+    const byte* algo = 0;
+    word32 algoCount = 0, idx = 0, payloadSz = 0,
             kexAlgoNamesSz = 0, keyAlgoNamesSz = 0;
     int ret = WS_SUCCESS;
 
@@ -9051,8 +9052,8 @@ int SendKexDhReply(WOLFSSH* ssh)
     byte kPad = 0;
     word32 sigBlockSz = 0;
     word32 payloadSz = 0;
-    byte* output;
-    word32 idx;
+    byte* output = 0;
+    word32 idx = 0;
     word32 keyIdx = 0;
     byte msgId = MSGID_KEXDH_REPLY;
     enum wc_HashType hashId = WC_HASH_TYPE_NONE;

--- a/src/internal.c
+++ b/src/internal.c
@@ -873,7 +873,7 @@ int IdentifyKey(const byte* in, word32 inSz, int isPrivate, void* heap)
     word32 idx;
     int ret;
     int dynType = isPrivate ? DYNTYPE_PRIVKEY : DYNTYPE_PUBKEY;
-    (void) dynType;
+    WOLFSSH_UNUSED(dynType);
 
     key = (union wolfSSH_key*)WMALLOC(sizeof(union wolfSSH_key), heap, dynType);
 


### PR DESCRIPTION
Required for https://github.com/wolfSSL/wolfssh/issues/588, this PR addresses some minor issues where the Espressif compiler using cmake complained as shown below.

See the wolfSSH preview component: https://components-staging.espressif.com/components/gojimmypi/mywolfssh

Test drive the template example:

```bash
# Setup ESP-IDF
export WRK_IDF_PATH=/mnt/c/SysGCC/esp32/esp-idf/v5.1
echo "Run export.sh from ${WRK_IDF_PATH}"
. ${WRK_IDF_PATH}/export.sh

# fetch and build the example
idf.py create-project-from-example "gojimmypi/mywolfssh^1.0.5-test:wolfssh_template"
cd wolfssh_template
idf.py build
```

If these errors are observed, the wolfssl`user_settings.h` needs to be adjusted by adding `#define WOLFSSH_TERM`:
```text
C:/test/mqtest/6/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/ssh.c:1344:8: error: 'WOLFSSH' has no member named 'termResizeCb'
 1344 |     ssh->termResizeCb = cb;
      |        ^~
C:/test/mqtest/6/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/ssh.c: In function 'wolfSSH_SetTerminalResizeCtx':
C:/test/mqtest/6/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/ssh.c:1350:8: error: 'WOLFSSH' has no member named 'termCtx'
 1350 |     ssh->termCtx = usrCtx;
      |        ^~
```


Errors observed prior to and addressed in this PR:
```text
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c: In function 'IdentifyKey':
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:875:9: warning: unused variable 'dynType' [-Wunused-variable]
  875 |     int dynType = isPrivate ? DYNTYPE_PRIVKEY : DYNTYPE_PUBKEY;
      |         ^~~~~~~
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c: In function 'SendKexInit':
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:8399:15: error: 'algoCount' may be used uninitialized [-Werror=maybe-uninitialized]
 8399 |         ret = BuildNameList(keyAlgoNames, keyAlgoNamesSz, algo, algoCount);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:8327:12: note: 'algoCount' was declared here
 8327 |     word32 algoCount, idx = 0, payloadSz = 0,
      |            ^~~~~~~~~
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:8399:15: error: 'algo' may be used uninitialized [-Werror=maybe-uninitialized]
 8399 |         ret = BuildNameList(keyAlgoNames, keyAlgoNamesSz, algo, algoCount);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:8326:17: note: 'algo' was declared here
 8326 |     const byte* algo;
      |                 ^~~~
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c: In function 'SendKexDhReply':
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:9751:25: error: 'output' may be used uninitialized [-Werror=maybe-uninitialized]
 9751 |         if (fPad) output[idx++] = 0;
      |                         ^
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:9054:11: note: 'output' was declared here
 9054 |     byte* output;
      |           ^~~~~~
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:9751:29: error: 'idx' may be used uninitialized [-Werror=maybe-uninitialized]
 9751 |         if (fPad) output[idx++] = 0;
      |                          ~~~^~
C:/test/mqtest/5/wolfssh_template/managed_components/gojimmypi__mywolfssh/src/internal.c:9055:12: note: 'idx' was declared here
 9055 |     word32 idx;
      |            ^~~
cc1.exe: some warnings being treated as errors
[1000/1008] Building C object esp-idf/gojimmypi__mywolfssl...s/__idf_gojimmypi__mywolfssl.dir/wolfcrypt/test/test.c.objninja: build stopped: subcommand failed.
ninja failed with exit code 1, output of the command is in the C:\test\mqtest\5\wolfssh_template\build\log\idf_py_stderr_output_89800 and C:\test\mqtest\5\wolfssh_template\build\log\idf_py_stdout_output_89800
```

See https://github.com/wolfSSL/wolfssl/issues/6234 for a roadmap of all Espressif improvements  currently in progress.