### PR TITLE
add WOLFSSL_ESPIDF Espressif sections in test.h

### DIFF
--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -136,6 +136,14 @@
     #endif
     #define SOCKET_T int
     #define NUM_SOCKETS 5
+#elif defined(WOLFSSL_ESPIDF)
+    #include "sdkconfig.h"
+    #include <esp_idf_version.h>
+    #include <esp_log.h>
+    #include <lwip/sockets.h>
+    #include <lwip/netdb.h>
+    #define SOCKET_T int
+    #define NUM_SOCKETS 5
 #else /* USE_WINDOWS_API */
     #include <unistd.h>
     #include <sys/socket.h>
@@ -519,6 +527,8 @@ static INLINE void tcp_socket(WS_SOCKET_T* sockFd)
 #elif defined(MICROCHIP_MPLAB_HARMONY) && !defined(_FULL_SIGNAL_IMPLEMENTATION)
     /* not full signal implementation */
 #elif defined(WOLFSSL_NUCLEUS)
+    /* nothing to define */
+#elif defined(WOLFSSL_ESPIDF)
     /* nothing to define */
 #else  /* no S_NOSIGPIPE */
     signal(SIGPIPE, SIG_IGN);


### PR DESCRIPTION
The minor PR adds some `#elif defined(WOLFSSL_ESPIDF)` sections to [wolfssh/test.h](https://github.com/wolfSSL/wolfssh/blob/master/wolfssh/test.h) that will be used by examples I have in the works for the Espressif ESP Component Registry at [components.espressif.com](https://components.espressif.com/components/wolfssl/wolfssl) as related to https://github.com/wolfSSL/wolfssh/issues/588.

My WIP is on the [staging site](https://components-staging.espressif.com/components/gojimmypi/mywolfssh?language=en) and the example of interest is [wolfssh_server](https://github.com/gojimmypi/wolfssh/tree/component-manager/ide/Espressif/ESP-IDF/examples/wolfssh_server).