### PR TITLE
Initial wolfSSH Espressif Component Publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,13 +31,21 @@ libtool
 libtool.m4
 *.log
 *.gz
+*.zip
+*.bak
+*.dummy
+*.xcworkspace
 Makefile
 Makefile.in
 *.deps
 .dirstamp
 *.libs
 stamp-h*
+src/stamp-h1
 build-aux/
+wolfmqtt-config
+build-test/
+build/
 wolfssh-config
 aminclude.am
 
@@ -48,7 +56,7 @@ tags
 diff
 .vimrc
 
-# examples
+# wolfSSL examples
 examples/client/client
 examples/echoserver/echoserver
 examples/server/server
@@ -56,10 +64,25 @@ examples/portfwd/portfwd
 examples/sftpclient/wolfsftp
 examples/scpclient/wolfscp
 
-# applications
+# wolfSSH applications
 apps/wolfssh/wolfssh
 apps/wolfsshd/wolfsshd
 apps/wolfsshd/test/test_configuration
+
+# wolfMQTT examples
+examples/aws/awsiot
+examples/azure/azureiothub
+examples/firmware/fwclient
+examples/firmware/fwpush
+examples/mqttclient/mqttclient
+examples/mqttsimple/mqttsimple
+examples/nbclient/nbclient
+examples/sn-client/sn-client
+examples/sn-client/sn-client_qos-1
+examples/sn-client/sn-multithread
+examples/multithread/multithread
+examples/wiot/wiot
+
 
 # test output
 tests/*.test
@@ -70,6 +93,18 @@ client.plist
 
 # misc
 .DS_Store
+
+# Visual Studio Code Workspace Files
+*.vscode
+*.userprefs
+*.exe
+*.dll
+.vs
+Backup
+UpgradeLog.htm
+*.aps
+*.VC.db
+*.filters
 
 # VS debris
 *.sdf
@@ -84,7 +119,80 @@ Release
 DLL Debug
 DLL Release
 
-# Eclipse
+*.trs
+firmware.bin
+wolfmqtt/options.h
+IDE/ARDUINO/wolfMQTT
+IDE/Microchip-Harmony/wolfmqtt_client/firmware/mqtt_client.X/dist/default/
+build/
+
+# eclipse
 .cproject
 .project
 .settings
+
+
+# auto-created CMake backups
+**/CMakeLists.txt.old
+
+# VisualGDB
+**/.visualgdb
+**/*.vgdbproj.*.user
+
+
+# Espressif sdk config default should be saved in sdkconfig.defaults
+# we won't track the actual working sdkconfig files
+/IDE/Espressif/**/out/
+/ide/Espressif/**/sdkconfig
+
+# Espressif managed components to exclude:
+/ide/Espressif/**/managed_components/**
+
+# Espressif managed component lock files to exclude.
+# "In general, it's ok to have it under version control, however, it ties
+# the solution to the exact version of ESP-IDF and will be ignored if an
+# example is built against another IDF version or for a different target.
+# So it's better to git ignore it for the examples."
+/ide/Espressif/**/dependencies.lock
+
+# exclude any local oqs components
+/ide/Espressif/ESP-IDF/examples/**/components/oqs
+
+/ide/Espressif/**/sdkconfig.old
+
+# ESP Registry Files
+
+# Temporary wolfssl component install directories that are copied locally at install time
+/ide/Espressif/wolfssl
+/ide/Espressif/component-manager/wolfssl
+/ide/Espressif/component-manager/wolfcrypt
+/ide/Espressif/component-manager/src
+/ide/Espressif/component-manager/dist
+
+# Exclude most of the example files that are copied at install time
+# from https://github.com/wolfSSL/wolfssl/tree/master/ide/Espressif/ESP-IDF/examples
+/ide/Espressif/component-manager/examples/**/CMakeLists.txt
+/ide/Espressif/component-manager/examples/**/partitions_singleapp_large.csv
+/ide/Espressif/component-manager/examples/**/sdkconfig.defaults
+/ide/Espressif/component-manager/examples/**/main/CMakeLists.txt
+/ide/Espressif/component-manager/examples/**/main/*.c
+/ide/Espressif/component-manager/examples/**/main/*.h
+/ide/Espressif/component-manager/examples/**/main/include/*.h
+/ide/Espressif/component-manager/examples/**/main/component.mk
+/ide/Espressif/component-manager/examples/**/VisualGDB/*.sln
+/ide/Espressif/component-manager/examples/**/VisualGDB/*.vgdbproj
+
+# The only ESP Registry Files specific to this location
+/ide/Espressif/ESP-IDF/examples/wolfssl_test/**/components/cryptoauthlib
+
+# Never include the build failure semaphore file
+/ide/build_failed.txt
+/ide/Espressif/ESP-IDF/component-manager/dist.bak
+/ide/Espressif/ESP-IDF/component-manager/src
+/ide/Espressif/ESP-IDF/component-manager/wolfcrypt
+/ide/Espressif/ESP-IDF/component-manager/wolfssl
+/ide/Espressif/ESP-IDF/component-manager/dist
+
+/ide/Espressif/component-manager/wolfssh
+/ide/Espressif/component-manager/examples/**/*
+/ide/Espressif/ESP-IDF/examples

--- a/ide/Espressif/component-manager/CMakeLists.txt
+++ b/ide/Espressif/component-manager/CMakeLists.txt
@@ -1,0 +1,111 @@
+#
+# Copyright (C) 2006-2022 wolfSSL Inc.  All rights reserved.
+#
+# This file is part of wolfSSH.
+#
+# Contact licensing@wolfssl.com with any questions or comments.
+#
+# https://www.wolfssl.com
+#/
+
+#
+# This is the CMakeLists.txt for the Espressif ESP-IDF wolfSSH component
+#
+cmake_minimum_required(VERSION 3.5)
+
+if( "$ENV{IDF_COMPONENT_REGISTRY_URL}" STREQUAL "https://components-staging.espressif.com" )
+    message(STATUS "Using Staging Component Test for wolfSSL: mywolfssl")
+    set(WOLFSSL_COMPONENT_NAME "mywolfssl")
+else()
+    set(WOLFSSL_COMPONENT_NAME "wolfssl")
+endif()
+
+# These flags apply only to compiling this component independently.
+# be sure to include this like in the root CMakeFiles.txt
+# for proper application-wide use of WOLFSSL_USER_SETTINGS:
+#
+#   add_compile_definitions("WOLFSSL_USER_SETTINGS")
+#   add_compile_definitions("WOLFSSH_USER_SETTINGS")
+#
+# if using ESP-IDF prior to 4.4, see:
+# https://github.com/wolfSSL/wolfssl/issues/5727
+if (CONFIG_DEBUG_WOLFSSH)
+    message(STATUS "Config DEBUG_WOLFSSH is enabled for components/wolfssh")
+endif()
+
+if (WOLFSSL_USER_SETTINGS)
+    message(STATUS "Component wolfssh: Found predefined WOLFSSL_USER_SETTINGS")
+else()
+    # wolfSSL settings should have occurred in project makefiles
+    #message(WARNING "Component wolfssh: Setting WOLFSSL_USER_SETTINGS \
+                     #(should have been a project-wide setting)")
+    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -DWOLFSSL_USER_SETTINGS")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWOLFSSL_USER_SETTINGS")
+endif()
+
+if (WOLFSSH_USER_SETTINGS)
+    message(STATUS "Component wolfssh: Found predefined WOLFSSH_USER_SETTINGS")
+else()
+    # wolfSSL settings should have occurred in project makefiles. See
+    message(WARNING "Component wolfssh: Setting WOLFSSH_USER_SETTINGS
+                     (should have been a project-wide setting)")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSH_USER_SETTINGS")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWOLFSSH_USER_SETTINGS")
+endif()
+
+
+message(STATUS "wolfssh CMAKE_C_FLAGS = ${CMAKE_C_FLAGS}")
+
+set(CMAKE_CURRENT_SOURCE_DIR ".")
+set(WOLFSSL_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+set(INCLUDE_PATH ${WOLFSSL_ROOT})
+
+set(COMPONENT_SRCDIRS
+        "./src/"
+   )
+
+
+set(COMPONENT_REQUIRES lwip "${WOLFSSL_COMPONENT_NAME}")
+
+set(COMPONENT_ADD_INCLUDEDIRS
+    "."
+    )
+
+
+# list(REMOVE_ITEM ASM_FILES  ".*\\.(asm|S)")
+
+message(STATUS "WOLFSSL_ROOT = ${WOLFSSL_ROOT}")
+message(STATUS "ASM_FILES = ${ASM_FILES}")
+
+
+#TODO remove:
+#idf_component_register(
+                        #SRC_DIRS "${COMPONENT_SRCDIRS}"
+                        #INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                        #REQUIRES "${COMPONENT_REQUIRES}"
+                        #EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                        ## SRCS wolfssl/wolfcrypt/test/test.c
+                        #)
+if(CMAKE_BUILD_EARLY_EXPANSION)
+    message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
+    idf_component_register(
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                           )
+else()
+    idf_component_register(
+                            SRC_DIRS "${COMPONENT_SRCDIRS}"
+                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                            REQUIRES "${COMPONENT_REQUIRES}"
+                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                            PRIV_REQUIRES "${WOLFSSL_COMPONENT_NAME}" # this will typically only be needed for wolfSSL benchmark
+                           )
+endif()
+
+# check to see if there's both a local copy and EDP-IDF copy of the wolfssh components
+if( EXISTS "${CMAKE_HOME_DIRECTORY}/components/wolfssh/" AND EXISTS "$ENV{IDF_PATH}/components/wolfssh/" )
+    message(STATUS  "")
+    message(WARNING "WARNING: Found components/wolfssh in both local project and IDF_PATH")
+    message(STATUS  "")
+endif()
+# end multiple component check
+

--- a/ide/Espressif/component-manager/INSTALL.md
+++ b/ide/Espressif/component-manager/INSTALL.md
@@ -1,0 +1,234 @@
+# Install for ESP Component Manager
+
+This is the documentation for the wolfSSH install / publish to [components.espressif.com](https://components.espressif.com/components/wolfssl/wolfssl).
+When using a managed component, all of the respective source code is in the local project `managed_components` directory.
+The wolfssl component `CMakeFiles.txt` from the examples is _not_ used. The managed component is manged entirely by `idf.py`.
+
+See the [Espressif idf-component-manager docs](https://docs.espressif.com/projects/idf-component-manager/en/latest/).
+
+Configuration for the component is in the top-level [idf_component.yml](./idf_component.yml) file.
+Note that this is *different* from the same-name files in the example projects.
+
+Edit version in:
+- Component configuration [idf_component.yml](./idf_component.yml) 
+- Example application [lib/idf_component.yml](./lib/idf_component.yml) 
+- [README_REGISTRY_PREPEND.md](./README_REGISTRY_PREPEND.md)
+Version numbers must exactly match between these files.
+
+Note that when using the staging environment, the staging user namespace and component name
+will be used. There should be a `./lib/idf_component-staging-[user name].yml` file.
+For example, for the `gojimmypi` user, the [./lib/idf_component-staging-gojimmypi.yml](./lib/idf_component-staging-gojimmypi.yml)
+should contain the alternate namespace (typically the username) and component name (typically with "my" prefix):
+
+```yml
+## IDF Component Manager Manifest File
+dependencies:
+  gojimmypi/mywolfssl: "^5.6.3-f9082c5.2"
+```
+
+See the `wolfssl_component_publish.sh` bash script. Set private `IDF_COMPONENT_API_TOKEN`
+environment variable as appropriate. Optionally set the `IDF_COMPONENT_REGISTRY_URL`.
+Typically there's only one valid option. See [Staging](./INSTALL.md#Staging), below.
+
+```bash
+# set your paths as appropriate:
+export IDF_COMPONENT_API_TOKEN=YOUR_TOKEN_VALUE
+export WRK_IDF_PATH=/mnt/c/SysGCC/esp32/esp-idf/v5.1
+export WOLFSSH_ROOT=/mnt/c/workspace/wolfSSH-$USER/IDE/Espressif/component-manager/
+export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com
+
+# install looks for wolfssh-master
+cd /mnt/c/workspace/
+git clone https://github.com/wolfSSL/wolfssh.git wolfssh-master
+
+cd "$WOLFSSL_ROOT"
+echo "Run export.sh from ${WRK_IDF_PATH}"
+. ${WRK_IDF_PATH}/export.sh
+
+./wolfssl_component_publish.sh
+```
+
+Set the staging environment from PowerShell:
+```
+$env:IDF_COMPONENT_REGISTRY_URL = "https://components-staging.espressif.com"
+```
+
+The script automates the process of populating a directory with wolfSSL source code and examples to publish.
+The core command for this is:
+
+```bash
+compote component upload --namespace wolfssl --name wolfssh
+```
+
+An alternative manual staging looks like this:
+
+```
+compote component upload --namespace gojimmypi --name mywolfssh
+```
+
+The output can be found in the `dist` directory, for example a file called `wolfssl_5.6.0-stable.tgz` and
+directory of the contents:
+
+```text
+mywolfssh_1.0.0-test
+mywolfssh_1.0.0-test.tgz
+```
+
+Consider disconnecting local network to go through the whole process without actually
+uploading. There's a `dryrun` capability not yet implemented in script.
+
+Examples are copied into the local [./examples/](./examples/README.md) directory.
+
+Each example project needs to have a `main/idf_component.yml` file,
+as well as a file called `init_demo.sh`.
+
+The example project `idf_component.yml` file should be edited as needed. Typical contents:
+
+```
+## IDF Component Manager Manifest File
+dependencies:
+  wolfssl/wolfssl: "^5.6.0-stable"
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+```
+
+## Staging
+
+There's a staging site at https://components-staging.espressif.com/ for testing deployments.
+
+To use this, set the `IDF_COMPONENT_REGISTRY_URL` environment variable:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com/ 
+```
+
+This setting is needed for _both_ deployment and client testing of staging-site components.
+
+The default when not set is the production site at https://components.espressif.com
+
+## License File
+
+License field is added to the manifest: See [docs](https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/manifest_file.html#manifest-file-idf-component-yml-format-reference).
+The [spdx format license text](https://spdx.org/licenses/) is used.
+
+## ESP Component Examples
+
+Note that when the ESP Component manager installs wolfSSL, then the source code for wolfSSL
+will be *in the local component directory*. Normally there's only a cmake file that points
+to where the wolfSSL library is located.
+
+Managed components are distinguished by the `idf_component.yml` file in the `projectname/main` directory.
+
+The wolfSSL component must be either managed or non-managed. Not both.
+
+```
+idf.py create-project-from-example "gojimmypi/mywolfssl^5.6.3-f9082c5.5:wolfssl_benchmark"
+cd wolfssl_benchmark
+idf.py -b 115200 flash monitor
+```
+
+## Coponent Configuration
+
+Examples such as the wolfssl_server and wolfssl_client need specific parameters set, in particular
+the target server IP address, SSID, and SSID password. The `idf.py menuconfig` command is needed.
+Set values in `Example Configuration` and `Example Connection Configuration`:
+
+```bash
+idf.py menuconfig
+```
+
+## Non-ESP Component Example
+
+For a wolfSSL getting started example, see the basic [wolfSSL Template Project](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/template)
+and the [other examples](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples).
+
+Non-managed components are distinguished by having no `idf_component.yml` file in the `projectname/main` directory.
+Instead there's a `components/wolfssl/CMakeLists.txt` file.
+
+The wolfSSL component must be either managed or non-managed. Not both.
+
+## Test build of examples
+
+Set `WOLFSSL_ROOT` to the location of the to-be-published wolfSSL directory:
+
+```bash
+export WOLFSSL_ROOT=/mnt/c/workspace/wolfssl-gojimmypi-PR/IDE/Espressif/component-manager/
+cd "$WOLFSSL_ROOT"
+```
+
+The component files in [./lib/components/wolfssl](./lib/components/wolfssl/README.md) will
+be copied to each respective example project to confirm they will build.
+
+There's a [wolfssl_build_example.sh](./wolfssl_build_example.sh) script the will temporarily remove
+the project `./main/idf_component.yml` component file to ensure the currently-published ESP Registry code
+is not used during the build test. That script is called for each of the [component manager examples](./examples/README.md).
+
+The source code for the local examples to be published is copied from [Espressif/ESP-IDF/examples](../ESP-IDF/examples/README.md).
+
+
+## Common Problems
+
+
+When there's both `idf_component.yml` file in the `projectname/main` and a
+`components/wolfssl/CMakeLists.txt` file, an error such as this will occur:
+
+```
+CMake Error at /mnt/c/SysGCC/esp32/esp-idf/v5.1/tools/cmake/component.cmake:250 (message):
+  ERROR: Cannot process component requirements.  Multiple candidates to
+  satisfy project requirements:
+
+    requirement: "wolfssl" candidates: "wolfssl, wolfssl__wolfssl"
+```
+
+To resolve, either:
+
+* Remove the `idf_component.yml` file and remove wolfssl directory from `projectname/managed__components`
+* Remove the wolfssl directory from `projectname/components`
+
+### Cannot program, _The chip needs to be in download mode_:
+
+```
+Serial port /dev/ttyS9
+Connecting......................................
+
+A fatal error occurred: Failed to connect to ESP32: Wrong boot mode detected (0x13)! The chip needs to be in download mode.
+For troubleshooting steps visit: https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html
+CMake Error at run_serial_tool.cmake:66 (message):
+
+  /home/gojimmypi/.espressif/python_env/idf5.1_py3.10_env/bin/python;;/mnt/c/SysGCC/esp32/esp-idf/v5.1/components/esptool_py/esptool/esptool.py;--chip;esp32
+  failed.
+
+
+
+FAILED: CMakeFiles/flash
+```
+
+While holding the `boot` button down, tap the `en` button, then release the `boot` button. Try again.
+
+If that didn't work, try the same sequence _after_ you've press `enter` for the `idf.py flash` command
+while the `esptool.py` is attempting the upload.
+
+If _that_ didn't work, try the same sequence but press `boot` _before_ you've pressed `enter` 
+for the `idf.py flash` command, and press & release `en` _after_ you've pressed `enter` 
+while attempting the upload.
+
+If _still_ reading as none of _those_ options worked, try first erasing the flash:
+
+```
+idf.py erase-flash -p /dev/ttyS9 -b 115200
+```
+
+For a robust programing experience that does not depend on bootloader mode, consider a JTAG
+programmer such as the [Tigard](https://github.com/tigard-tools/tigard).
+
+## Cannot find source
+
+```text
+Executing action: create-project-from-example
+ERROR: Version of the component "gojimmypi/mywolfssl" satisfying the spec "^5.6.3-f9082c5.7" was not found.
+```
+
+Check the `IDF_COMPONENT_REGISTRY_URL` setting. Blank defaults to production. See above for staging.
+
+See also [Espressif ESP32 Troubleshooting](https://docs.espressif.com/projects/esptool/en/latest/esp32/troubleshooting.html)

--- a/ide/Espressif/component-manager/LICENSE.txt
+++ b/ide/Espressif/component-manager/LICENSE.txt
@@ -1,0 +1,354 @@
+
+wolfSSL (formerly known as CyaSSL) and wolfCrypt are either licensed for use
+under the GPLv2 (or at your option any later version) or a standard commercial
+license. For our users who cannot use wolfSSL under GPLv2
+(or any later version), a commercial license to wolfSSL and wolfCrypt is
+available.
+
+Please contact wolfSSL Inc. directly at:
+
+Email: licensing@wolfssl.com
+Phone: +1 425 245-8247
+
+More information can be found on the wolfSSL website at www.wolfssl.com.
+
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/ide/Espressif/component-manager/NEW_README.md
+++ b/ide/Espressif/component-manager/NEW_README.md
@@ -1,0 +1,609 @@
+This is a staging experimental version!
+
+When testing staging components, be sure to set `IDF_COMPONENT_REGISTRY_URL`:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com
+```
+
+Set the value when not testing:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components.espressif.com
+```
+This is the Espressif Component Version of wolfSSH 1.0.11-test, Release #11 (version ^1.0.11-test)
+
+When testing staging components:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com
+```
+
+For questions or beta test of this library, please send a message to support@wolfssl.com
+
+For details on how wolfSSL is published to the ESP Component Registry, see the
+[INSTALL.md](https://github.com/wolfssl/wolfssl/tree/master/IDE/Espressif/component-manager/INSTALL.md) file.
+
+See the [wolfSSH Manual](https://www.wolfssl.com/documentation/manuals/wolfssh/index.html).
+
+The [wolfSSL embedded TLS library](https://www.wolfssl.com/products/wolfssl/) is a lightweight, portable, 
+C-language-based SSL/TLS library targeted at IoT, embedded, and RTOS environments primarily because of its size, 
+speed, and feature set. It works seamlessly in desktop, enterprise, and cloud environments as well. 
+wolfSSL supports industry standards up to the current [TLS 1.3](https://www.wolfssl.com/tls13) and DTLS 1.3, 
+is up to 20 times smaller than OpenSSL, offers a simple API, an OpenSSL compatibility layer,
+OCSP and CRL support, is backed by the robust [wolfCrypt cryptography library](https://github.com/wolfssl/wolfssl/tree/master/wolfcrypt), 
+and much more.
+
+The CMVP has issued FIPS 140-2 Certificates #3389 and #2425 for the wolfCrypt Module developed by wolfSSL Inc.  
+For more information, see our [FIPS FAQ](https://www.wolfssl.com/license/fips/) or contact fips@wolfssl.com.
+
+# Getting Started
+
+Check out the Examples on the right pane of the [wolfssl component page](https://components.espressif.com/components/wolfssl/wolfssl/).
+
+Typically you need only 4 lines to run an example from scratch in the EDP-IDF environment:
+
+```
+. ~/esp/esp-idf/export.sh
+idf.py create-project-from-example "wolfssl/wolfssl^5.6.0-stable:wolfssl_benchmark"
+cd wolfssl_benchmark
+idf.py -b 115200 flash monitor
+```
+
+or for VisualGDB:
+
+```
+. /mnt/c/SysGCC/esp32/esp-idf/v5.0/export.sh
+```
+
+
+### Espressif Component Notes
+
+Here are some ESP Registry-specific details of the wolfssl component.
+
+#### Component Name
+
+The naming convention of the build-system name of a dependency installed by the component manager
+is always `namespace__component`. The namespace for wolfSSL is `wolfssl`. The build-system name
+is thus `wolfssl__wolfssl`. We'll soon be publishing `wolfssl__wolfssh`, `wolfssl__wolfmqtt` and more.
+
+A project `cmakelists.txt` doesn't need to mention it at all when using wolfSSL as a managed component.
+
+
+#### Component Manager
+
+To check which version of the [Component Manager](https://docs.espressif.com/projects/idf-component-manager/en/latest/getting_started/index.html#checking-the-idf-component-manager-version) 
+is currently available, use the command:
+
+```
+python -m idf_component_manager -h
+```
+
+The Component Manager should have been installed during the [installation of the ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/#installation). 
+If your version of ESP-IDF doesn't come with the IDF Component Manager, 
+you can [install it](https://docs.espressif.com/projects/idf-component-manager/en/latest/guides/updating_component_manager.html#installing-and-updating-the-idf-component-manager):
+
+```
+python -m pip install --upgrade idf-component-manager
+```
+
+For further details on the Espressif Component Manager, see the [idf-component-manager repo](https://github.com/espressif/idf-component-manager/).
+
+#### Contact
+
+Have a specific request or questions? We'd love to hear from you! Please contact us at 
+[support@wolfssl.com](mailto:support@wolfssl.com?subject=Espressif%20Component%20Question) or 
+[open an issue on GitHub](https://github.com/wolfSSL/wolfssl/issues/new/choose).
+
+# Licensing and Support
+
+wolfSSL (formerly known as CyaSSL) and wolfCrypt are either licensed for use
+under the GPLv2 (or at your option any later version) or a standard commercial
+license. For our users who cannot use wolfSSL under GPLv2
+(or any later version), a commercial license to wolfSSL and wolfCrypt is
+available. 
+
+See the [LICENSE.txt](./LICENSE.txt), visit [wolfssl.com/license](https://www.wolfssl.com/license/),
+contact us at [licensing@wolfssl.com](mailto:licensing@wolfssl.com?subject=Espressif%20Component%20License%20Question) 
+or call +1 425 245 8247
+
+View Commercial Support Options: [wolfssl.com/products/support-and-maintenance](https://www.wolfssl.com/products/support-and-maintenance/)
+WOLFSSH
+=======
+
+wolfSSL's Embeddable SSH Server
+[wolfSSH Manual](https://www.wolfssl.com/docs/wolfssh-manual/)
+
+dependencies
+------------
+
+[wolfSSH](https://www.wolfssl.com/wolfssh/) is dependent on
+[wolfCrypt](https://www.wolfssl.com/download/), found as a part of
+wolfSSL. The following is the simplest configuration of wolfSSL to
+enable wolfSSH.
+
+    $ cd wolfssl
+    $ ./configure [OPTIONS] --enable-ssh
+    $ make check
+    $ sudo make install
+
+On some systems the optional ldconfig command is needed after installing.
+
+To use the key generation function in wolfSSH, wolfSSL will need to be
+configured with keygen: `--enable-keygen`.
+
+When using X.509 certificates for user authentication, wolfSSL must be
+built with TLS enabled. wolfSSH uses wolfSSL's certificate manager system
+for X.509, including OCSP lookups. To allow OCSP, add `--enable-ocsp` to the
+wolfSSL configure.
+
+If the bulk of wolfSSL code isn't desired, wolfSSL can be configured with
+the crypto only option: `--enable-cryptonly`.
+
+Additional build options for wolfSSL are located in
+[chapter two](https://www.wolfssl.com/docs/wolfssl-manual/ch2/).
+of the wolfSSH manual.
+
+building
+--------
+
+From the wolfSSH source directory run:
+
+    $ ./autogen.sh
+    $ ./configure --with-wolfssl=[/usr/local]
+    $ make
+    $ make check
+
+The `autogen.sh` script only has to be run the first time after cloning
+the repository. If you have already run it or are using code from a
+source archive, you should skip it.
+
+For building under Windows with Visual Studio, see the file
+"ide/winvs/README.md".
+
+NOTE: On resource constrained devices the `DEFAULT_WINDOW_SZ` may need
+to be set to a lower size. It can also be increased in desktop use cases
+to help with large file transfers. By default channels are set to receive
+up to 128kB of data before sending a channel window adjust message. An
+example of setting a window size for new channels would be as follows
+`./configure CPPFLAGS="-DDEFAULT_WINDOW_SZ=16384"`
+
+For 32bit Linux platforms you can add support for files > 2GB by compling
+with `CFLAGS=-D_FILE_OFFSET_BITS=64`.
+
+examples
+--------
+
+The directory `examples` contains an echoserver that any client should
+be able to connect to. From the terminal run:
+
+    $ ./examples/echoserver/echoserver -f
+
+The option `-f` enables echo-only mode. From another terminal run:
+
+    $ ssh jill@localhost -p 22222
+
+When prompted for a password, enter "upthehill". The server will send a
+canned banner to the client:
+
+    wolfSSH Example Echo Server
+
+Characters typed into the client will be echoed to the screen by the
+server. If the characters are echoed twice, the client has local echo
+enabled. The echoserver isn't being a proper terminal so the CR/LF
+translation will not work as expected.
+
+The following control characters will trigger special actions in the
+echoserver:
+
+- CTRL-C: Terminate the connection.
+- CTRL-E: Print out some session statistics.
+- CTRL-F: Trigger a new key exchange.
+
+
+testing notes
+-------------
+
+After cloning the repository, be sure to make the testing private keys
+read-only for the user, otherwise `ssh` will tell you to do it.
+
+    $ chmod 0600 ./keys/gretel-key-rsa.pem ./keys/hansel-key-rsa.pem \
+                 ./keys/gretel-key-ecc.pem ./keys/hansel-key-ecc.pem
+
+Authentication against the example echoserver can be done with a
+password or public key. To use a password the command line:
+
+    $ ssh -p 22222 USER@localhost
+
+Where the *USER* and password pairs are:
+
+    jill:upthehill
+    jack:fetchapail
+
+To use public key authentication use the command line:
+
+    $ ssh -i ./keys/USER-key-TYPE.pem -p 22222 USER@localhost
+
+Where the *USER* can be `gretel` or `hansel`, and *TYPE* is `rsa` or
+`ecc`.
+
+Keep in mind, the echoserver has several fake accounts in its
+`wsUserAuth()` callback function. (jack, jill, hansel, and gretel) When
+the shell support is enabled, those fake accounts will not work. They
+don't exist in the system's _passwd_ file. The users will authenticate,
+but the server will err out because they don't exist in the system. You
+can add your own username to the password or public key list in the
+echoserver. That account will be logged into a shell started by the
+echoserver with the privileges of the user running echoserver.
+
+
+EXAMPLE TOOLS
+=============
+
+wolfSSH comes packaged with a few example tools for testing purposes
+and to demonstrate interoperability with other SSH implementations.
+
+
+echoserver
+----------
+
+The echoserver is the workhorse of wolfSSH. It originally only allowed one
+to authenticate one of the canned account and would repeat the characters
+typed into it. When enabling [shell support](#shell-support), it can
+spawn a user shell. It will need an actual user name on the machine and an
+updated user authentication callback function to validate the credentials.
+The echoserver can also handle SCP and SFTP connections.
+
+The echoserver tool accepts the following command line options:
+
+    -1             exit after a single (one) connection
+    -e             expect ECC public key from client
+    -E             use ECC private key
+    -f             echo input
+    -p <num>       port to accept on, default 22222
+    -N             use non-blocking sockets
+    -d <string>    set the home directory for SFTP connections
+    -j <file>      load in a public key to accept from peer
+
+
+client
+------
+
+The client establishes a connection to an SSH server. In its simplest mode,
+it sends the string "Hello, wolfSSH!" to the server, prints the response,
+and then exits. With the pseudo terminal option, the client will be a real
+client.
+
+The client tool accepts the following command line options:
+
+    -h <host>      host to connect to, default 127.0.0.1
+    -p <num>       port to connect on, default 22222
+    -u <username>  username to authenticate as (REQUIRED)
+    -P <password>  password for username, prompted if omitted
+    -e             use sample ecc key for user
+    -i <filename>  filename for the user's private key
+    -j <filename>  filename for the user's public key
+    -x             exit after successful connection without doing
+                   read/write
+    -N             use non-blocking sockets
+    -t             use psuedo terminal
+    -c <command>   executes remote command and pipe stdin/stdout
+    -a             Attempt to use SSH-AGENT
+
+
+portfwd
+-------
+
+The portfwd tool establishes a connection to an SSH server and sets up a
+listener for local port forwarding or requests a listener for remote port
+forwarding. After a connection, the tool terminates.
+
+The portfwd tool accepts the following command line options:
+
+    -h <host>      host to connect to, default 127.0.0.1
+    -p <num>       port to connect on, default 22222
+    -u <username>  username to authenticate as (REQUIRED)
+    -P <password>  password for username, prompted if omitted
+    -F <host>      host to forward from, default 0.0.0.0
+    -f <num>       host port to forward from (REQUIRED)
+    -T <host>      host to forward to, default to host
+    -t <num>       port to forward to (REQUIRED)
+
+
+scpclient
+---------
+
+The scpclient, wolfscp, establishes a connection to an SSH server and copies
+the specified files from or to the local machine.
+
+The scpclient tool accepts the following command line options:
+
+    -H <host>      host to connect to, default 127.0.0.1
+    -p <num>       port to connect on, default 22222
+    -u <username>  username to authenticate as (REQUIRED)
+    -P <password>  password for username, prompted if omitted
+    -L <from>:<to> copy from local to server
+    -S <from>:<to> copy from server to local
+
+
+sftpclient
+----------
+
+The sftpclient, wolfsftp, establishes a connection to an SSH server and
+allows directory navigation, getting and putting files, making and removing
+directories, etc.
+
+The sftpclient tool accepts the following command line options:
+
+    -h <host>      host to connect to, default 127.0.0.1
+    -p <num>       port to connect on, default 22222
+    -u <username>  username to authenticate as (REQUIRED)
+    -P <password>  password for username, prompted if omitted
+    -d <path>      set the default local path
+    -N             use non blocking sockets
+    -e             use ECC user authentication
+    -l <filename>  local filename
+    -r <filename>  remote filename
+    -g             put local filename as remote filename
+    -G             get remote filename as local filename
+
+
+server
+------
+
+This tool is a place holder.
+
+
+SCP
+===
+
+wolfSSH includes server-side support for scp, which includes support for both
+copying files 'to' the server, and copying files 'from' the server. Both
+single file and recursive directory copy are supported with the default
+send and receive callbacks.
+
+To compile wolfSSH with scp support, use the `--enable-scp` build option
+or define `WOLFSSL_SCP`:
+
+    $ ./configure --enable-scp
+    $ make
+
+For full API usage and implementation details, please see the wolfSSH User
+Manual.
+
+The wolfSSL example server has been set up to accept a single scp request,
+and is compiled by default when compiling the wolfSSH library. To start the
+example server, run:
+
+    $ ./examples/server/server
+
+Standard scp commands can be used on the client side. The following are a
+few examples, where `scp` represents the ssh client you are using.
+
+To copy a single file TO the server, using the default example user "jill":
+
+    $ scp -P 22222 <local_file> jill@127.0.0.1:<remote_path>
+
+To copy the same single file TO the server, but with timestamp and in
+verbose mode:
+
+    $ scp -v -p -P 22222 <local_file> jill@127.0.0.1:<remote_path>
+
+To recursively copy a directory TO the server:
+
+    $ scp -P 22222 -r <local_dir> jill@127.0.0.1:<remote_dir>
+
+To copy a single file FROM the server to the local client:
+
+    $ scp -P 22222 jill@127.0.0.1:<remote_file> <local_path>
+
+To recursively copy a directory FROM the server to the local client:
+
+    $ scp -P 22222 -r jill@127.0.0.1:<remote_dir> <local_path>
+
+
+PORT FORWARDING
+===============
+
+wolfSSH provides support for port forwarding. This allows the user
+to set up an encrypted tunnel to another server, where the SSH client listens
+on a socket and forwards connections on that socket to another socket on
+the server.
+
+To compile wolfSSH with port forwarding support, use the `--enable-fwd` build
+option or define `WOLFSSH_FWD`:
+
+    $ ./configure --enable-fwd
+    $ make
+
+For full API usage and implementation details, please see the wolfSSH User
+Manual.
+
+The portfwd example tool will create a "direct-tcpip" style channel. These
+directions assume you have OpenSSH's server running in the background with
+port forwarding enabled. This example forwards the port for the wolfSSL
+client to the server as the application. It assumes that all programs are run
+on the same machine in different terminals.
+
+    src/wolfssl$ ./examples/server/server
+    src/wolfssh$ ./examples/portfwd/portfwd -p 22 -u <username> \
+                 -f 12345 -t 11111
+    src/wolfssl$ ./examples/client/client -p 12345
+
+By default, the wolfSSL server listens on port 11111. The client is set to
+try to connect to port 12345. The portfwd logs in as user "username", opens
+a listener on port 12345 and connects to the server on port 11111. Packets
+are routed back and forth between the client and server. "Hello, wolfSSL!"
+
+The source for portfwd provides an example on how to set up and use the
+port forwarding support in wolfSSH.
+
+The echoserver will handle local and remote port forwarding. To connect with
+the ssh tool, using one of the following command lines. You can run either of
+the ssh command lines from anywhere:
+
+    src/wolfssl$ ./examples/server/server
+    src/wolfssh$ ./examples/echoserver/echoserver
+    anywhere 1$ ssh -p 22222 -L 12345:localhost:11111 jill@localhost
+    anywhere 2$ ssh -p 22222 -R 12345:localhost:11111 jill@localhost
+    src/wolfssl$ ./examples/client/client -p 12345
+
+This will allow port forwarding between the wolfSSL client and server like in
+the previous example.
+
+
+SFTP
+====
+
+wolfSSH provides server and client side support for SFTP version 3. This
+allows the user to set up an encrypted connection for managing file systems.
+
+To compile wolfSSH with SFTP support, use the `--enable-sftp` build option or
+define `WOLFSSH_SFTP`:
+
+    $ ./configure --enable-sftp
+    $ make
+
+For full API usage and implementation details, please see the wolfSSH User
+Manual.
+
+The SFTP client created is located in the directory examples/sftpclient/ and the
+server is ran using the same echoserver as with wolfSSH.
+
+    src/wolfssh$ ./examples/sftpclient/wolfsftp
+
+A full list of supported commands can be seen with typeing "help" after a
+connection.
+
+
+    wolfSSH sftp> help
+
+    Commands :
+        cd  <string>                      change directory
+        chmod <mode> <path>               change mode
+        get <remote file> <local file>    pulls file(s) from server
+        ls                                list current directory
+        mkdir <dir name>                  creates new directory on server
+        put <local file> <remote file>    push file(s) to server
+        pwd                               list current path
+        quit                              exit
+        rename <old> <new>                renames remote file
+        reget <remote file> <local file>  resume pulling file
+        reput <remote file> <local file>  resume pushing file
+        <crtl + c>                        interrupt get/put cmd
+
+An example of connecting to another system would be
+
+    src/wolfssh$ ./examples/sftpclient/wolfsftp -p 22 -u user -h 192.168.1.111
+
+
+SHELL SUPPORT
+=============
+
+wolfSSH's example echoserver can now fork a shell for the user trying to log
+in. This currently has only been tested on Linux and macOS. The file
+echoserver.c must be modified to have the user's credentials in the user
+authentication callback, or the user authentication callback needs to be
+changed to verify the provided password.
+
+To compile wolfSSH with shell support, use the `--enable-shell` build option
+or define `WOLFSSH_SHELL`:
+
+    $ ./configure --enable-shell
+    $ make
+
+By default, the echoserver will try to start a shell. To use the echo testing
+behavior, give the echoserver the command line option `-f`.
+
+    $ ./examples/echoserver/echoserver -f
+
+
+POST-QUANTUM
+============
+
+wolfSSH now supports the post-quantum algorithm Kyber. It uses the NIST
+submission's Level 1 parameter set implemented by liboqs via an integration
+with wolfSSH. It is hybridized with ECDHE over the P-256 ECC curve.
+
+In order be able to use liboqs, you must have it built and installed on your
+system. We support the 0.7.0 release of liboqs. You can download it from the
+following link:
+
+    https://github.com/open-quantum-safe/liboqs/archive/refs/tags/0.7.0.tar.gz
+
+Once unpacked, this would be sufficient:
+
+    $ cd liboqs-0.7.0
+    $ mkdir build
+    $ cd build
+    $ cmake -DOQS_USE_OPENSSL=0 ..
+    $ make all
+    $ sudo make install
+
+
+In order to enable support for Kyber Level1 hybridized with ECDHE over the P-256
+ECC curve in wolfSSH, use the `--with-liboqs` build option during configuration:
+
+    $ ./configure --with-liboqs
+
+The wolfSSH client and server will automatically negotiate using Kyber Level1
+hybridized with ECDHE over the P-256 ECC curve if this feature is enabled.
+
+    $ ./examples/echoserver/echoserver -f
+
+    $ ./examples/client/client -u jill -P upthehill
+
+On the client side, you will see the following output:
+
+Server said: Hello, wolfSSH!
+
+If you want to see inter-operability with OpenQauntumSafe's fork of OpenSSH, you
+can build and execute the fork while the echoserver is running. Download the
+release from here:
+
+    https://github.com/open-quantum-safe/openssh/archive/refs/tags/OQS-OpenSSH-snapshot-2021-08.tar.gz
+
+The following is sufficient for build and execution:
+
+    $ tar xmvf openssh-OQS-OpenSSH-snapshot-2021-08.tar.gz
+    $ cd openssh-OQS-OpenSSH-snapshot-2021-08/
+    $ ./configure --with-liboqs-dir=/usr/local
+    $ make all
+    $ ./ssh -o"KexAlgorithms=ecdh-nistp256-kyber-512r3-sha256-d00@openquantumsafe.org" \
+      -o"PubkeyAcceptedAlgorithms +ssh-rsa" \
+      -o"HostkeyAlgorithms +ssh-rsa" \
+      jill@localhost -p 22222
+
+NOTE: when prompted, enter the password which is "upthehill".
+
+You can type a line of text and when you press enter, the line will be echoed
+back. Use CTRL-C to terminate the connection.
+
+
+CERTIFICATE SUPPORT
+===================
+
+wolfSSH can accept X.509 certificates in place of just public keys when
+authenticating a user.
+
+To compile wolfSSH with X.509 support, use the `--enable-certs` build option
+or define `WOLFSSH_CERTS`:
+
+    $ ./configure --enable-certs
+    $ make
+
+To provide a CA root certificate to validate a user's certificate, give the
+echoserver the command line option `-a`.
+
+    $ ./examples/echoserver/echoserver -a ./keys/ca-cert-ecc.pem
+
+The echoserver and client have a fake user named "john" whose certificate
+will be used for authentication.
+
+An example echoserver / client connection using the example certificate
+john-cert.der would be:
+
+    $ ./examples/echoserver/echoserver -a ./keys/ca-cert-ecc.pem -K john:./keys/john-cert.der
+
+    $ ./examples/client/client -u john -J ./keys/john-cert.der -i ./keys/john-key.der
+

--- a/ide/Espressif/component-manager/README.md
+++ b/ide/Espressif/component-manager/README.md
@@ -1,0 +1,609 @@
+This is a staging experimental version!
+
+When testing staging components, be sure to set `IDF_COMPONENT_REGISTRY_URL`:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com
+```
+
+Set the value when not testing:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components.espressif.com
+```
+This is the Espressif Component Version of wolfSSH 1.0.11-test, Release #11 (version ^1.0.11-test)
+
+When testing staging components:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com
+```
+
+For questions or beta test of this library, please send a message to support@wolfssl.com
+
+For details on how wolfSSL is published to the ESP Component Registry, see the
+[INSTALL.md](https://github.com/wolfssl/wolfssl/tree/master/IDE/Espressif/component-manager/INSTALL.md) file.
+
+See the [wolfSSH Manual](https://www.wolfssl.com/documentation/manuals/wolfssh/index.html).
+
+The [wolfSSL embedded TLS library](https://www.wolfssl.com/products/wolfssl/) is a lightweight, portable, 
+C-language-based SSL/TLS library targeted at IoT, embedded, and RTOS environments primarily because of its size, 
+speed, and feature set. It works seamlessly in desktop, enterprise, and cloud environments as well. 
+wolfSSL supports industry standards up to the current [TLS 1.3](https://www.wolfssl.com/tls13) and DTLS 1.3, 
+is up to 20 times smaller than OpenSSL, offers a simple API, an OpenSSL compatibility layer,
+OCSP and CRL support, is backed by the robust [wolfCrypt cryptography library](https://github.com/wolfssl/wolfssl/tree/master/wolfcrypt), 
+and much more.
+
+The CMVP has issued FIPS 140-2 Certificates #3389 and #2425 for the wolfCrypt Module developed by wolfSSL Inc.  
+For more information, see our [FIPS FAQ](https://www.wolfssl.com/license/fips/) or contact fips@wolfssl.com.
+
+# Getting Started
+
+Check out the Examples on the right pane of the [wolfssl component page](https://components.espressif.com/components/wolfssl/wolfssl/).
+
+Typically you need only 4 lines to run an example from scratch in the EDP-IDF environment:
+
+```
+. ~/esp/esp-idf/export.sh
+idf.py create-project-from-example "wolfssl/wolfssl^5.6.0-stable:wolfssl_benchmark"
+cd wolfssl_benchmark
+idf.py -b 115200 flash monitor
+```
+
+or for VisualGDB:
+
+```
+. /mnt/c/SysGCC/esp32/esp-idf/v5.0/export.sh
+```
+
+
+### Espressif Component Notes
+
+Here are some ESP Registry-specific details of the wolfssl component.
+
+#### Component Name
+
+The naming convention of the build-system name of a dependency installed by the component manager
+is always `namespace__component`. The namespace for wolfSSL is `wolfssl`. The build-system name
+is thus `wolfssl__wolfssl`. We'll soon be publishing `wolfssl__wolfssh`, `wolfssl__wolfmqtt` and more.
+
+A project `cmakelists.txt` doesn't need to mention it at all when using wolfSSL as a managed component.
+
+
+#### Component Manager
+
+To check which version of the [Component Manager](https://docs.espressif.com/projects/idf-component-manager/en/latest/getting_started/index.html#checking-the-idf-component-manager-version) 
+is currently available, use the command:
+
+```
+python -m idf_component_manager -h
+```
+
+The Component Manager should have been installed during the [installation of the ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/#installation). 
+If your version of ESP-IDF doesn't come with the IDF Component Manager, 
+you can [install it](https://docs.espressif.com/projects/idf-component-manager/en/latest/guides/updating_component_manager.html#installing-and-updating-the-idf-component-manager):
+
+```
+python -m pip install --upgrade idf-component-manager
+```
+
+For further details on the Espressif Component Manager, see the [idf-component-manager repo](https://github.com/espressif/idf-component-manager/).
+
+#### Contact
+
+Have a specific request or questions? We'd love to hear from you! Please contact us at 
+[support@wolfssl.com](mailto:support@wolfssl.com?subject=Espressif%20Component%20Question) or 
+[open an issue on GitHub](https://github.com/wolfSSL/wolfssl/issues/new/choose).
+
+# Licensing and Support
+
+wolfSSL (formerly known as CyaSSL) and wolfCrypt are either licensed for use
+under the GPLv2 (or at your option any later version) or a standard commercial
+license. For our users who cannot use wolfSSL under GPLv2
+(or any later version), a commercial license to wolfSSL and wolfCrypt is
+available. 
+
+See the [LICENSE.txt](./LICENSE.txt), visit [wolfssl.com/license](https://www.wolfssl.com/license/),
+contact us at [licensing@wolfssl.com](mailto:licensing@wolfssl.com?subject=Espressif%20Component%20License%20Question) 
+or call +1 425 245 8247
+
+View Commercial Support Options: [wolfssl.com/products/support-and-maintenance](https://www.wolfssl.com/products/support-and-maintenance/)
+WOLFSSH
+=======
+
+wolfSSL's Embeddable SSH Server
+[wolfSSH Manual](https://www.wolfssl.com/docs/wolfssh-manual/)
+
+dependencies
+------------
+
+[wolfSSH](https://www.wolfssl.com/wolfssh/) is dependent on
+[wolfCrypt](https://www.wolfssl.com/download/), found as a part of
+wolfSSL. The following is the simplest configuration of wolfSSL to
+enable wolfSSH.
+
+    $ cd wolfssl
+    $ ./configure [OPTIONS] --enable-ssh
+    $ make check
+    $ sudo make install
+
+On some systems the optional ldconfig command is needed after installing.
+
+To use the key generation function in wolfSSH, wolfSSL will need to be
+configured with keygen: `--enable-keygen`.
+
+When using X.509 certificates for user authentication, wolfSSL must be
+built with TLS enabled. wolfSSH uses wolfSSL's certificate manager system
+for X.509, including OCSP lookups. To allow OCSP, add `--enable-ocsp` to the
+wolfSSL configure.
+
+If the bulk of wolfSSL code isn't desired, wolfSSL can be configured with
+the crypto only option: `--enable-cryptonly`.
+
+Additional build options for wolfSSL are located in
+[chapter two](https://www.wolfssl.com/docs/wolfssl-manual/ch2/).
+of the wolfSSH manual.
+
+building
+--------
+
+From the wolfSSH source directory run:
+
+    $ ./autogen.sh
+    $ ./configure --with-wolfssl=[/usr/local]
+    $ make
+    $ make check
+
+The `autogen.sh` script only has to be run the first time after cloning
+the repository. If you have already run it or are using code from a
+source archive, you should skip it.
+
+For building under Windows with Visual Studio, see the file
+"ide/winvs/README.md".
+
+NOTE: On resource constrained devices the `DEFAULT_WINDOW_SZ` may need
+to be set to a lower size. It can also be increased in desktop use cases
+to help with large file transfers. By default channels are set to receive
+up to 128kB of data before sending a channel window adjust message. An
+example of setting a window size for new channels would be as follows
+`./configure CPPFLAGS="-DDEFAULT_WINDOW_SZ=16384"`
+
+For 32bit Linux platforms you can add support for files > 2GB by compling
+with `CFLAGS=-D_FILE_OFFSET_BITS=64`.
+
+examples
+--------
+
+The directory `examples` contains an echoserver that any client should
+be able to connect to. From the terminal run:
+
+    $ ./examples/echoserver/echoserver -f
+
+The option `-f` enables echo-only mode. From another terminal run:
+
+    $ ssh jill@localhost -p 22222
+
+When prompted for a password, enter "upthehill". The server will send a
+canned banner to the client:
+
+    wolfSSH Example Echo Server
+
+Characters typed into the client will be echoed to the screen by the
+server. If the characters are echoed twice, the client has local echo
+enabled. The echoserver isn't being a proper terminal so the CR/LF
+translation will not work as expected.
+
+The following control characters will trigger special actions in the
+echoserver:
+
+- CTRL-C: Terminate the connection.
+- CTRL-E: Print out some session statistics.
+- CTRL-F: Trigger a new key exchange.
+
+
+testing notes
+-------------
+
+After cloning the repository, be sure to make the testing private keys
+read-only for the user, otherwise `ssh` will tell you to do it.
+
+    $ chmod 0600 ./keys/gretel-key-rsa.pem ./keys/hansel-key-rsa.pem \
+                 ./keys/gretel-key-ecc.pem ./keys/hansel-key-ecc.pem
+
+Authentication against the example echoserver can be done with a
+password or public key. To use a password the command line:
+
+    $ ssh -p 22222 USER@localhost
+
+Where the *USER* and password pairs are:
+
+    jill:upthehill
+    jack:fetchapail
+
+To use public key authentication use the command line:
+
+    $ ssh -i ./keys/USER-key-TYPE.pem -p 22222 USER@localhost
+
+Where the *USER* can be `gretel` or `hansel`, and *TYPE* is `rsa` or
+`ecc`.
+
+Keep in mind, the echoserver has several fake accounts in its
+`wsUserAuth()` callback function. (jack, jill, hansel, and gretel) When
+the shell support is enabled, those fake accounts will not work. They
+don't exist in the system's _passwd_ file. The users will authenticate,
+but the server will err out because they don't exist in the system. You
+can add your own username to the password or public key list in the
+echoserver. That account will be logged into a shell started by the
+echoserver with the privileges of the user running echoserver.
+
+
+EXAMPLE TOOLS
+=============
+
+wolfSSH comes packaged with a few example tools for testing purposes
+and to demonstrate interoperability with other SSH implementations.
+
+
+echoserver
+----------
+
+The echoserver is the workhorse of wolfSSH. It originally only allowed one
+to authenticate one of the canned account and would repeat the characters
+typed into it. When enabling [shell support](#shell-support), it can
+spawn a user shell. It will need an actual user name on the machine and an
+updated user authentication callback function to validate the credentials.
+The echoserver can also handle SCP and SFTP connections.
+
+The echoserver tool accepts the following command line options:
+
+    -1             exit after a single (one) connection
+    -e             expect ECC public key from client
+    -E             use ECC private key
+    -f             echo input
+    -p <num>       port to accept on, default 22222
+    -N             use non-blocking sockets
+    -d <string>    set the home directory for SFTP connections
+    -j <file>      load in a public key to accept from peer
+
+
+client
+------
+
+The client establishes a connection to an SSH server. In its simplest mode,
+it sends the string "Hello, wolfSSH!" to the server, prints the response,
+and then exits. With the pseudo terminal option, the client will be a real
+client.
+
+The client tool accepts the following command line options:
+
+    -h <host>      host to connect to, default 127.0.0.1
+    -p <num>       port to connect on, default 22222
+    -u <username>  username to authenticate as (REQUIRED)
+    -P <password>  password for username, prompted if omitted
+    -e             use sample ecc key for user
+    -i <filename>  filename for the user's private key
+    -j <filename>  filename for the user's public key
+    -x             exit after successful connection without doing
+                   read/write
+    -N             use non-blocking sockets
+    -t             use psuedo terminal
+    -c <command>   executes remote command and pipe stdin/stdout
+    -a             Attempt to use SSH-AGENT
+
+
+portfwd
+-------
+
+The portfwd tool establishes a connection to an SSH server and sets up a
+listener for local port forwarding or requests a listener for remote port
+forwarding. After a connection, the tool terminates.
+
+The portfwd tool accepts the following command line options:
+
+    -h <host>      host to connect to, default 127.0.0.1
+    -p <num>       port to connect on, default 22222
+    -u <username>  username to authenticate as (REQUIRED)
+    -P <password>  password for username, prompted if omitted
+    -F <host>      host to forward from, default 0.0.0.0
+    -f <num>       host port to forward from (REQUIRED)
+    -T <host>      host to forward to, default to host
+    -t <num>       port to forward to (REQUIRED)
+
+
+scpclient
+---------
+
+The scpclient, wolfscp, establishes a connection to an SSH server and copies
+the specified files from or to the local machine.
+
+The scpclient tool accepts the following command line options:
+
+    -H <host>      host to connect to, default 127.0.0.1
+    -p <num>       port to connect on, default 22222
+    -u <username>  username to authenticate as (REQUIRED)
+    -P <password>  password for username, prompted if omitted
+    -L <from>:<to> copy from local to server
+    -S <from>:<to> copy from server to local
+
+
+sftpclient
+----------
+
+The sftpclient, wolfsftp, establishes a connection to an SSH server and
+allows directory navigation, getting and putting files, making and removing
+directories, etc.
+
+The sftpclient tool accepts the following command line options:
+
+    -h <host>      host to connect to, default 127.0.0.1
+    -p <num>       port to connect on, default 22222
+    -u <username>  username to authenticate as (REQUIRED)
+    -P <password>  password for username, prompted if omitted
+    -d <path>      set the default local path
+    -N             use non blocking sockets
+    -e             use ECC user authentication
+    -l <filename>  local filename
+    -r <filename>  remote filename
+    -g             put local filename as remote filename
+    -G             get remote filename as local filename
+
+
+server
+------
+
+This tool is a place holder.
+
+
+SCP
+===
+
+wolfSSH includes server-side support for scp, which includes support for both
+copying files 'to' the server, and copying files 'from' the server. Both
+single file and recursive directory copy are supported with the default
+send and receive callbacks.
+
+To compile wolfSSH with scp support, use the `--enable-scp` build option
+or define `WOLFSSL_SCP`:
+
+    $ ./configure --enable-scp
+    $ make
+
+For full API usage and implementation details, please see the wolfSSH User
+Manual.
+
+The wolfSSL example server has been set up to accept a single scp request,
+and is compiled by default when compiling the wolfSSH library. To start the
+example server, run:
+
+    $ ./examples/server/server
+
+Standard scp commands can be used on the client side. The following are a
+few examples, where `scp` represents the ssh client you are using.
+
+To copy a single file TO the server, using the default example user "jill":
+
+    $ scp -P 22222 <local_file> jill@127.0.0.1:<remote_path>
+
+To copy the same single file TO the server, but with timestamp and in
+verbose mode:
+
+    $ scp -v -p -P 22222 <local_file> jill@127.0.0.1:<remote_path>
+
+To recursively copy a directory TO the server:
+
+    $ scp -P 22222 -r <local_dir> jill@127.0.0.1:<remote_dir>
+
+To copy a single file FROM the server to the local client:
+
+    $ scp -P 22222 jill@127.0.0.1:<remote_file> <local_path>
+
+To recursively copy a directory FROM the server to the local client:
+
+    $ scp -P 22222 -r jill@127.0.0.1:<remote_dir> <local_path>
+
+
+PORT FORWARDING
+===============
+
+wolfSSH provides support for port forwarding. This allows the user
+to set up an encrypted tunnel to another server, where the SSH client listens
+on a socket and forwards connections on that socket to another socket on
+the server.
+
+To compile wolfSSH with port forwarding support, use the `--enable-fwd` build
+option or define `WOLFSSH_FWD`:
+
+    $ ./configure --enable-fwd
+    $ make
+
+For full API usage and implementation details, please see the wolfSSH User
+Manual.
+
+The portfwd example tool will create a "direct-tcpip" style channel. These
+directions assume you have OpenSSH's server running in the background with
+port forwarding enabled. This example forwards the port for the wolfSSL
+client to the server as the application. It assumes that all programs are run
+on the same machine in different terminals.
+
+    src/wolfssl$ ./examples/server/server
+    src/wolfssh$ ./examples/portfwd/portfwd -p 22 -u <username> \
+                 -f 12345 -t 11111
+    src/wolfssl$ ./examples/client/client -p 12345
+
+By default, the wolfSSL server listens on port 11111. The client is set to
+try to connect to port 12345. The portfwd logs in as user "username", opens
+a listener on port 12345 and connects to the server on port 11111. Packets
+are routed back and forth between the client and server. "Hello, wolfSSL!"
+
+The source for portfwd provides an example on how to set up and use the
+port forwarding support in wolfSSH.
+
+The echoserver will handle local and remote port forwarding. To connect with
+the ssh tool, using one of the following command lines. You can run either of
+the ssh command lines from anywhere:
+
+    src/wolfssl$ ./examples/server/server
+    src/wolfssh$ ./examples/echoserver/echoserver
+    anywhere 1$ ssh -p 22222 -L 12345:localhost:11111 jill@localhost
+    anywhere 2$ ssh -p 22222 -R 12345:localhost:11111 jill@localhost
+    src/wolfssl$ ./examples/client/client -p 12345
+
+This will allow port forwarding between the wolfSSL client and server like in
+the previous example.
+
+
+SFTP
+====
+
+wolfSSH provides server and client side support for SFTP version 3. This
+allows the user to set up an encrypted connection for managing file systems.
+
+To compile wolfSSH with SFTP support, use the `--enable-sftp` build option or
+define `WOLFSSH_SFTP`:
+
+    $ ./configure --enable-sftp
+    $ make
+
+For full API usage and implementation details, please see the wolfSSH User
+Manual.
+
+The SFTP client created is located in the directory examples/sftpclient/ and the
+server is ran using the same echoserver as with wolfSSH.
+
+    src/wolfssh$ ./examples/sftpclient/wolfsftp
+
+A full list of supported commands can be seen with typeing "help" after a
+connection.
+
+
+    wolfSSH sftp> help
+
+    Commands :
+        cd  <string>                      change directory
+        chmod <mode> <path>               change mode
+        get <remote file> <local file>    pulls file(s) from server
+        ls                                list current directory
+        mkdir <dir name>                  creates new directory on server
+        put <local file> <remote file>    push file(s) to server
+        pwd                               list current path
+        quit                              exit
+        rename <old> <new>                renames remote file
+        reget <remote file> <local file>  resume pulling file
+        reput <remote file> <local file>  resume pushing file
+        <crtl + c>                        interrupt get/put cmd
+
+An example of connecting to another system would be
+
+    src/wolfssh$ ./examples/sftpclient/wolfsftp -p 22 -u user -h 192.168.1.111
+
+
+SHELL SUPPORT
+=============
+
+wolfSSH's example echoserver can now fork a shell for the user trying to log
+in. This currently has only been tested on Linux and macOS. The file
+echoserver.c must be modified to have the user's credentials in the user
+authentication callback, or the user authentication callback needs to be
+changed to verify the provided password.
+
+To compile wolfSSH with shell support, use the `--enable-shell` build option
+or define `WOLFSSH_SHELL`:
+
+    $ ./configure --enable-shell
+    $ make
+
+By default, the echoserver will try to start a shell. To use the echo testing
+behavior, give the echoserver the command line option `-f`.
+
+    $ ./examples/echoserver/echoserver -f
+
+
+POST-QUANTUM
+============
+
+wolfSSH now supports the post-quantum algorithm Kyber. It uses the NIST
+submission's Level 1 parameter set implemented by liboqs via an integration
+with wolfSSH. It is hybridized with ECDHE over the P-256 ECC curve.
+
+In order be able to use liboqs, you must have it built and installed on your
+system. We support the 0.7.0 release of liboqs. You can download it from the
+following link:
+
+    https://github.com/open-quantum-safe/liboqs/archive/refs/tags/0.7.0.tar.gz
+
+Once unpacked, this would be sufficient:
+
+    $ cd liboqs-0.7.0
+    $ mkdir build
+    $ cd build
+    $ cmake -DOQS_USE_OPENSSL=0 ..
+    $ make all
+    $ sudo make install
+
+
+In order to enable support for Kyber Level1 hybridized with ECDHE over the P-256
+ECC curve in wolfSSH, use the `--with-liboqs` build option during configuration:
+
+    $ ./configure --with-liboqs
+
+The wolfSSH client and server will automatically negotiate using Kyber Level1
+hybridized with ECDHE over the P-256 ECC curve if this feature is enabled.
+
+    $ ./examples/echoserver/echoserver -f
+
+    $ ./examples/client/client -u jill -P upthehill
+
+On the client side, you will see the following output:
+
+Server said: Hello, wolfSSH!
+
+If you want to see inter-operability with OpenQauntumSafe's fork of OpenSSH, you
+can build and execute the fork while the echoserver is running. Download the
+release from here:
+
+    https://github.com/open-quantum-safe/openssh/archive/refs/tags/OQS-OpenSSH-snapshot-2021-08.tar.gz
+
+The following is sufficient for build and execution:
+
+    $ tar xmvf openssh-OQS-OpenSSH-snapshot-2021-08.tar.gz
+    $ cd openssh-OQS-OpenSSH-snapshot-2021-08/
+    $ ./configure --with-liboqs-dir=/usr/local
+    $ make all
+    $ ./ssh -o"KexAlgorithms=ecdh-nistp256-kyber-512r3-sha256-d00@openquantumsafe.org" \
+      -o"PubkeyAcceptedAlgorithms +ssh-rsa" \
+      -o"HostkeyAlgorithms +ssh-rsa" \
+      jill@localhost -p 22222
+
+NOTE: when prompted, enter the password which is "upthehill".
+
+You can type a line of text and when you press enter, the line will be echoed
+back. Use CTRL-C to terminate the connection.
+
+
+CERTIFICATE SUPPORT
+===================
+
+wolfSSH can accept X.509 certificates in place of just public keys when
+authenticating a user.
+
+To compile wolfSSH with X.509 support, use the `--enable-certs` build option
+or define `WOLFSSH_CERTS`:
+
+    $ ./configure --enable-certs
+    $ make
+
+To provide a CA root certificate to validate a user's certificate, give the
+echoserver the command line option `-a`.
+
+    $ ./examples/echoserver/echoserver -a ./keys/ca-cert-ecc.pem
+
+The echoserver and client have a fake user named "john" whose certificate
+will be used for authentication.
+
+An example echoserver / client connection using the example certificate
+john-cert.der would be:
+
+    $ ./examples/echoserver/echoserver -a ./keys/ca-cert-ecc.pem -K john:./keys/john-cert.der
+
+    $ ./examples/client/client -u john -J ./keys/john-cert.der -i ./keys/john-key.der
+

--- a/ide/Espressif/component-manager/README_DIST.md
+++ b/ide/Espressif/component-manager/README_DIST.md
@@ -1,0 +1,61 @@
+# Espressif Component Manager
+
+This directory does not need to be included in any wolfSSL distributions. The files
+contained herein are used only to publish wolfSSL as a managed component to the [ESP Registry](https://components.espressif.com/).
+
+When managing a component:
+
+* Do not edit files in the local `./dist/` directory. Those are file sets previously published.
+
+* Do not edit files in the local `./[project]/managed_components/` directory. Those are files fetched from ESP Registry.
+
+Be sure to edit the [idf_component.yml](./idf_component.yml) version text, _and_ the 
+[README_REGISTRY_PREPEND.md](./README_REGISTRY_PREPEND.md) version text. Versions must match between these files.
+Values are checked at publish time.
+
+Search for other instances of versions in the format `^1.0.`. Visual Studio File Types: `*.*;!*/dist/*;!*/managed_components/*;!*/.git/*`.
+Consider editing older examples.
+
+See the local [wolfssl_component_publish.sh script](./wolfssl_component_publish.sh) for the steps used to copy wolfSSL
+source files locally.
+
+The wolfSSL [README.md](https://github.com/wolfSSL/wolfssl/blob/master/README.md) is stripped of an embedded HTML
+anchor tags that do not render well.
+
+The local [README_REGISTRY_PREPEND.md](./README_REGISTRY_PREPEND.md) text is prepended to the 
+wolfSSL [README.md](https://github.com/wolfSSL/wolfssl/blob/master/README.md) before being published to the registry.
+
+Other README.md files for the examples are appended automatically by the ESP Registry at pubish time.
+As such example REAME files must _not_ contain any relative links.
+
+A working Internet connection is required to build the samples.
+
+Any new examples should have a manifest file in the `[project]/main` directory:
+
+```bash
+## IDF Component Manager Manifest File
+dependencies:
+  wolfssl/wolfssl: "^5.6.0-stable"
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true
+```
+
+  To publish, the ESP-IDF needs to be installed.
+
+```bash
+cd /mnt/c/workspace/wolfssl-gojimmypi/IDE/Espressif/component-manager
+. /mnt/c/SysGCC/esp32/esp-idf/v5.1/export.sh
+
+```

--- a/ide/Espressif/component-manager/README_REGISTRY_PREPEND.md
+++ b/ide/Espressif/component-manager/README_REGISTRY_PREPEND.md
@@ -1,0 +1,91 @@
+This is the Espressif Component Version of wolfSSH 1.0.11-test, Release #11 (version ^1.0.11-test)
+
+For questions or beta test of this library, please send a message to support@wolfssl.com
+
+For details on how wolfSSL is published to the ESP Component Registry, see the
+[INSTALL.md](https://github.com/wolfssl/wolfssl/tree/master/IDE/Espressif/component-manager/INSTALL.md) file.
+
+See the [wolfSSH Manual](https://www.wolfssl.com/documentation/manuals/wolfssh/index.html).
+
+The [wolfSSL embedded TLS library](https://www.wolfssl.com/products/wolfssl/) is a lightweight, portable, 
+C-language-based SSL/TLS library targeted at IoT, embedded, and RTOS environments primarily because of its size, 
+speed, and feature set. It works seamlessly in desktop, enterprise, and cloud environments as well. 
+wolfSSL supports industry standards up to the current [TLS 1.3](https://www.wolfssl.com/tls13) and DTLS 1.3, 
+is up to 20 times smaller than OpenSSL, offers a simple API, an OpenSSL compatibility layer,
+OCSP and CRL support, is backed by the robust [wolfCrypt cryptography library](https://github.com/wolfssl/wolfssl/tree/master/wolfcrypt), 
+and much more.
+
+The CMVP has issued FIPS 140-2 Certificates #3389 and #2425 for the wolfCrypt Module developed by wolfSSL Inc.  
+For more information, see our [FIPS FAQ](https://www.wolfssl.com/license/fips/) or contact fips@wolfssl.com.
+
+# Getting Started
+
+Check out the Examples on the right pane of the [wolfssl component page](https://components.espressif.com/components/wolfssl/wolfssl/).
+
+Typically you need only 4 lines to run an example from scratch in the EDP-IDF environment:
+
+```
+. ~/esp/esp-idf/export.sh
+idf.py create-project-from-example "wolfssl/wolfssl^5.6.0-stable:wolfssl_benchmark"
+cd wolfssl_benchmark
+idf.py -b 115200 flash monitor
+```
+
+or for VisualGDB:
+
+```
+. /mnt/c/SysGCC/esp32/esp-idf/v5.0/export.sh
+```
+
+
+### Espressif Component Notes
+
+Here are some ESP Registry-specific details of the wolfssl component.
+
+#### Component Name
+
+The naming convention of the build-system name of a dependency installed by the component manager
+is always `namespace__component`. The namespace for wolfSSL is `wolfssl`. The build-system name
+is thus `wolfssl__wolfssl`. We'll soon be publishing `wolfssl__wolfssh`, `wolfssl__wolfmqtt` and more.
+
+A project `cmakelists.txt` doesn't need to mention it at all when using wolfSSL as a managed component.
+
+
+#### Component Manager
+
+To check which version of the [Component Manager](https://docs.espressif.com/projects/idf-component-manager/en/latest/getting_started/index.html#checking-the-idf-component-manager-version) 
+is currently available, use the command:
+
+```
+python -m idf_component_manager -h
+```
+
+The Component Manager should have been installed during the [installation of the ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/#installation). 
+If your version of ESP-IDF doesn't come with the IDF Component Manager, 
+you can [install it](https://docs.espressif.com/projects/idf-component-manager/en/latest/guides/updating_component_manager.html#installing-and-updating-the-idf-component-manager):
+
+```
+python -m pip install --upgrade idf-component-manager
+```
+
+For further details on the Espressif Component Manager, see the [idf-component-manager repo](https://github.com/espressif/idf-component-manager/).
+
+#### Contact
+
+Have a specific request or questions? We'd love to hear from you! Please contact us at 
+[support@wolfssl.com](mailto:support@wolfssl.com?subject=Espressif%20Component%20Question) or 
+[open an issue on GitHub](https://github.com/wolfSSL/wolfssl/issues/new/choose).
+
+# Licensing and Support
+
+wolfSSL (formerly known as CyaSSL) and wolfCrypt are either licensed for use
+under the GPLv2 (or at your option any later version) or a standard commercial
+license. For our users who cannot use wolfSSL under GPLv2
+(or any later version), a commercial license to wolfSSL and wolfCrypt is
+available. 
+
+See the [LICENSE.txt](./LICENSE.txt), visit [wolfssl.com/license](https://www.wolfssl.com/license/),
+contact us at [licensing@wolfssl.com](mailto:licensing@wolfssl.com?subject=Espressif%20Component%20License%20Question) 
+or call +1 425 245 8247
+
+View Commercial Support Options: [wolfssl.com/products/support-and-maintenance](https://www.wolfssl.com/products/support-and-maintenance/)

--- a/ide/Espressif/component-manager/README_STAGING.md
+++ b/ide/Espressif/component-manager/README_STAGING.md
@@ -1,0 +1,26 @@
+# Espressif Component Staging Notes
+
+Thank you Sergei for these notes:
+
+Recently added: You can add a license field to the manifest:
+See [docs](https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/manifest_file.html#manifest-file-idf-component-yml-format-reference)
+The description in the docs is not fully correct, it doesn't have to be SPDX string.
+The server side is not deployed yet, but it will be there in a couple of days.
+
+Espressif has the test registry at this URL:
+
+https://components-staging.espressif.com/
+
+It's not well reflected in the docs, how to use it, the simplest way is to set “IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com/" environment variable.
+
+Or set it in the [config file](https://docs.espressif.com/projects/idf-component-manager/en/latest/guides/packaging_components.html#authentication-with-a-config-file)
+
+FAQ for the documentation portal WIP, and this topic will be covered there. It should be published this week. (8/14/2023)
+
+Just like on the main server, every version can be uploaded only once. 
+You can still delete whatever you want using `compote component delete`, but still,
+you cannot re-upload with the same version number. Usually, it's not a limitation because
+during development you can use pre-release versions and for fixes of the component with the
+same upstream version, "revision" component can be added to the name.
+
+https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/versioning.html#versioning-scheme

--- a/ide/Espressif/component-manager/README_STAGING_PREPEND.md
+++ b/ide/Espressif/component-manager/README_STAGING_PREPEND.md
@@ -1,0 +1,13 @@
+This is a staging experimental version!
+
+When testing staging components, be sure to set `IDF_COMPONENT_REGISTRY_URL`:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components-staging.espressif.com
+```
+
+Set the value when not testing:
+
+```
+export IDF_COMPONENT_REGISTRY_URL=https://components.espressif.com
+```

--- a/ide/Espressif/component-manager/component_manifest.txt
+++ b/ide/Espressif/component-manager/component_manifest.txt
@@ -1,0 +1,34 @@
+# component_manifest.txt
+#
+# Copy Template project
+#
+
+wolfssh_template/CMakeLists.txt
+wolfssh_template/README.md
+wolfssh_template/main/CMakeLists.txt
+wolfssh_template/main/main.c
+wolfssh_template/main/include/main.h
+wolfssh_template/VisualGDB/wolfssh_template_IDF_v5.1_ESP32.sln
+wolfssh_template/VisualGDB/wolfssh_template_IDF_v5.1_ESP32.vgdbproj
+
+#
+# Copy Server Project
+#
+
+wolfssh_server/CMakeLists.txt
+wolfssh_server/README.md
+wolfssh_server/sdkconfig.defaults
+wolfssh_server/main/CMakeLists.txt
+wolfssh_server/main/main.c
+wolfssh_server/main/server.c
+wolfssh_server/main/server.h
+wolfssh_server/main/time_helper.c
+wolfssh_server/main/wifi_connect.c
+wolfssh_server/main/include/main.h
+wolfssh_server/main/include/time_helper.h
+wolfssh_server/main/include/wifi_connect.h
+wolfssh_server/VisualGDB/wolfssh_server_IDF_v5.1_ESP32.sln
+wolfssh_server/VisualGDB/wolfssh_server_IDF_v5.1_ESP32.vgdbproj
+
+#
+# End of component manifest

--- a/ide/Espressif/component-manager/idf_component.yml
+++ b/ide/Espressif/component-manager/idf_component.yml
@@ -1,0 +1,36 @@
+version: "1.0.11-test"
+description: wolfSSL wolfSSH Library
+url: https://www.wolfssl.com
+repository: https://github.com/wolfSSL/wolfssh.git
+documentation: https://www.wolfssl.com/documentation/manuals/wolfssh/index.html
+issues: https://github.com/wolfSSL/wolfssh/issues
+discussion: https://www.wolfssl.com/forums
+files:
+  exclude:
+  - '**/*'  # exclude everything, so next lines are redundant / reminder only:
+  - 'INSTALL.md'
+  - '*.py'
+  - '**/*.list'
+  - '**/.vs/**/*'
+  - '**/build/**/*'
+  - '**/dist/**/*'
+  - '**/dist.bak/**/*'
+  - '**/out/**/*'
+  - '*.sh'
+  - '*.bak'
+  - 'sdkconfig'
+  - 'README_DIST.md'
+  - 'README_REGISTRY_PREPEND.md'
+  - 'README_STAGING_PREPEND.md'
+  - 'README_STAGING.md'
+  include: # only explicitly include things we actually want to publish:
+  - './README.md'
+  - './LICENSE.txt'
+  - './idf_component.yml'
+  - './CMakeLists.txt'
+  - './Kconfig'
+  - './install_log.txt'
+  - './src/**/*'
+  - './include/**/*'
+  - './wolfssh/**/*'
+  - './examples/**/*'

--- a/ide/Espressif/component-manager/lib/idf_component-staging-gojimmypi.yml
+++ b/ide/Espressif/component-manager/lib/idf_component-staging-gojimmypi.yml
@@ -1,0 +1,18 @@
+## STAGING SITE: IDF Component Manager Manifest File for Examples (component author user=gojimmypi)
+dependencies:
+  gojimmypi/mywolfssl: "^5.6.3-Staging01-237d10a.3"
+  gojimmypi/mywolfssh: "^1.0.11-test"
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true

--- a/ide/Espressif/component-manager/lib/idf_component.yml
+++ b/ide/Espressif/component-manager/lib/idf_component.yml
@@ -1,0 +1,18 @@
+## IDF Component Manager Manifest File For Examples
+dependencies:
+  gojimmypi/mywolfssl: "^5.6.3-Staging01-237d10a.3"
+  gojimmypi/mywolfssh: "^1.0.11-test"
+  ## Required IDF version
+  idf:
+    version: ">=4.1.0"
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true

--- a/ide/Espressif/component-manager/lib/winmerge_wolfssl_filter.flt
+++ b/ide/Espressif/component-manager/lib/winmerge_wolfssl_filter.flt
@@ -1,0 +1,66 @@
+## This is a directory/file filter template for WinMerge
+name: my wolfssl filter
+desc: Longer description
+
+## Select if filter is inclusive or exclusive
+## Inclusive (loose) filter lets through all items not matching rules
+## Exclusive filter lets through only items that match to rule
+## include or exclude
+def: include
+
+## Filters for filenames begin with f:
+## Filters for directories begin with d:
+## To exclude some of the files that match the f: pattern, specify f!:
+## To exclude some of the folders that match the d: pattern, specify d!:
+## (Inline comments begin with " ##" and extend to the end of the line)
+
+f: \.ext$ ## Filter for filename
+
+f: \\\*.la
+
+## d: \\subdir$ ## Filter for directory
+
+## Exclude source control
+
+f: \.bzrignore$ ## Bazaar ignore file
+f: \.cvsignore$ ## CVS ignore file
+f: \.hgignore$ ## Mercurial ignore file
+f: \.svnignore$ ## Subversion ignore file
+
+f: \.(vs[sp])?scc$  ## Visual SourceSafe files
+
+d: \\\.svn$ ## Subversion working copy
+d: \\_svn$  ## Subversion working copy ASP.NET Hack
+d: \\cvs$   ## CVS control directory
+d: \\\.git$ ## Git directory
+d: \\\.bzr$ ## Bazaar branch
+d: \\\.hg$ ## Mercurial repository
+d: \\\.github ## Git directory
+
+## autom4te.cache
+d: \\\autom4te.cache$
+
+## any backup files
+f: \\*.bak
+
+## Any cmake out directories
+d: \\out$
+
+## exclude Espressif builds
+d: \\build$
+
+## Exclude Visual Studio
+d: \\.vs ## Visual Studio directory
+
+## Exclude VisualGDB
+d: \\.visualgdb$
+
+
+d: \\\.deps$
+d: \\\.libs$
+
+## 
+d: \\\out$ ## CMake default
+
+## d: \\\$component-manager/dist$ ## 
+

--- a/ide/Espressif/component-manager/wolfssl_build_example.sh
+++ b/ide/Espressif/component-manager/wolfssl_build_example.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# wolfssl_build_example.sh
+#
+# Script to build wolfSSL examples for publish to Espressif ESP Registry.
+# This file is not needed by end users.
+#
+
+# the first parameter is expected to be a examples/project-name
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <examples/directory_name>"
+    exit 1
+else
+    THIS_EXAMPLE="$1"
+fi
+
+# make sure the provided parameter directory exists
+if [ ! -d "$THIS_EXAMPLE" ]; then
+    echo "Directory not found: $THIS_EXAMPLE"
+    exit 1
+fi
+# we impose a requirement to have a sdkconfig.defaults file
+if [ ! -e "$THIS_EXAMPLE/sdkconfig.defaults" ]; then
+    echo "File not found: $THIS_EXAMPLE/sdkconfig.defaults"
+    exit 1
+fi
+
+# check if IDF_PATH is set
+if [ -z "$IDF_PATH" ]; then
+    echo "Please follow the instruction of ESP-IDF installation and set IDF_PATH."
+    exit 1
+fi
+
+# make sure it actually exists
+if [ ! -d "$IDF_PATH" ]; then
+    echo "ESP-IDF Development Framework doesn't exist.: $IDF_PATH"
+    exit 1
+fi
+
+# is export.sh in the IDF path?
+if [ ! -e "$IDF_PATH/export.sh" ]; then
+    echo "ESP-IDF export.sh: $IDF_PATH/export.sh"
+    exit 1
+fi
+
+# Ready to build; prep.
+pushd "$THIS_EXAMPLE"
+
+export NEED_YML_RESTORE=
+if [ -e "./main/idf_component.yml" ]; then
+    echo "Temporarily disabling ESP Component by renaming idf_component.yml"
+    mv ./main/idf_component.yml ./main/idf_component.yml.bak
+    export NEED_YML_RESTORE=Y
+fi
+
+export NEED_DIR_RESTORE=
+if [ -e "./managed_components" ]; then
+    echo "Temporarily renaming managed_components"
+    mv ./managed_components ./managed_components.bak
+    export NEED_DIR_RESTORE=Y
+fi
+
+#**************************************************************************************************
+# Build
+#**************************************************************************************************
+# put in a woldSSL component directory to act like the managed component published version
+cp -r ../../lib/components ./
+
+idf.py build
+THIS_ERROR_CODE=$?
+
+rm -r ./components/
+
+#**************************************************************************************************
+# Restore managed components
+#**************************************************************************************************
+if [ "${NEED_YML_RESTORE^}" == "Y" ]; then
+    echo "Restoring ./main/idf_component.yml"
+    mv ./main/idf_component.yml.bak ./main/idf_component.yml
+fi
+
+if [ "${NEED_DIR_RESTORE^}" == "Y" ]; then
+    echo "Restoring ./managed_components"
+    mv ./managed_components.bak ./managed_components
+fi
+
+popd
+
+#**************************************************************************************************
+# Done
+#**************************************************************************************************
+
+if [ $THIS_ERROR_CODE -ne 0 ]; then
+    echo ""
+    echo "Failed to build"
+    exit 1
+else
+    echo ""
+    echo "Build successful."
+    echo ""
+fi

--- a/ide/Espressif/component-manager/wolfssl_component_publish.sh
+++ b/ide/Espressif/component-manager/wolfssl_component_publish.sh
@@ -1,0 +1,818 @@
+#!/bin/bash
+#
+# wolfssl_component_publish.sh [optional directory source to publish]
+#
+# Script to publish wolfSSL, wolfMQTT, and wolfSSH to Espressif ESP Registry.
+# This file is duplicated across repositories. It is not needed by end users.
+#
+#                              NOTICE
+#
+#       ***** PRODUCTION DEPLOYMENT MUST BE MANUALLY ENABLED *****
+#
+#    export $IDF_COMPONENT_REGISTRY_URL=https://components.espressif.com
+#
+# Version:  1.0
+#
+# For usage, see INSTALL.md
+#
+# TODO: config file settings not yet supported here. See:
+# https://docs.espressif.com/projects/idf-component-manager/en/latest/guides/packaging_components.html#authentication-with-a-config-file
+#
+# set our known production and staging links. No trailing "/" char. Edit with caution:
+export PRODUCTION_URL="https://components.espressif.com"
+export STAGING_URL="https://components-staging.espressif.com"
+
+# Unlike the default operation, is not explicitly set to production
+# we assume the publish is staging.
+echo "--------------------------------------------------------------------------------------------"
+if [ -z "$IDF_COMPONENT_REGISTRY_URL" ]; then
+    export IDF_COMPONENT_REGISTRY_URL="$STAGING_URL"
+    echo "Setting default publishing location to ESP Registry: $STAGING_URL"
+    echo ""
+fi
+
+#**************************************************************************************************
+# copy_wolfssl_source()
+#
+# A function to copy a given wolfSSL root: $1
+# for a given subdirectory: $2
+# for a file type specification: $3
+# optionally append files with: $4
+#
+# Example: copy wolfssl/src/*.c to the local ./src directory:
+#   copy_wolfssl_source /workspace/wolfssl  "src"  "*.c"
+#
+# Files in this local directory, typically called "component-manager"
+# will be published to the Espressif ESP Registry.
+#
+# Contents of $dst will be DELETED unless $4 == "APPEND"
+copy_wolfssl_source() {
+  local src="$1"
+  local dst="$2"
+  local file_type="$3"
+  local append="$4"
+
+  # uncomment for verbose output:
+  # echo ""
+  # echo "Copying files: $file_type"
+
+  if [[ -d "$dst" && "$append" != "APPEND" ]]; then
+    # uncomment for verbose output:
+    # echo "Deleting files in directory: $dst"
+    find "$dst" -type f -delete
+  fi
+
+  # uncomment for verbose output:
+  # echo "Copying files from $src/$dst to $(pwd)/$dst"
+  mkdir -p "$dst"
+
+  if find "$src"/"$dst" -type f -name "$file_type" -print -quit | grep -q '^'; then
+      # this gives a shellcheck warning:
+      # cp -u "$src"/"$dst"/$file_type "./$dst/"
+      #
+      # this does not work: (gives cp: cannot stat .. No such file or directory)
+      # cp -u "$src"/"$dst"/""$file_type" "./$dst/"
+      #
+      # so we'll assemble a local command var:
+      local cp_command="cp -u $src/$dst/$file_type ./$dst/"
+      # uncomment for verbose output:
+      echo "Executing command: $cp_command"
+      eval "$cp_command"
+      echo "Copied $dst/$file_type"
+  else
+    echo "ERROR: Not Found: $dst"
+  fi
+} # copy_wolfssl_source()
+
+#**************************************************************************************************
+#
+# The first parameter, when present, is expected to be the path to the component to install:
+#
+#       wolfssl_component_publish.sh  /mnt/c/workspace/wolfssl-master
+#
+# The only acceptable names MUST contain the component name. (e.g. don't clone wolfssl into OtherName)
+#
+# Source directory names may contain a "-" delimiter: (e.g. wolfssl-username, wolfssl-master)
+#
+# If a parameter is not specified, this script is expected to be in [repo]/IDE/Espressif/component-manager
+#
+#    e.g. /some/directory/path/wolfssl/IDE/Espressif/component-manager:
+#
+#    The root to publish is 3 directories up from `component-manager` in `wolfssl`.
+#
+if [ $# -lt 1 ]; then
+    # This script directory is the source, assumed 3 levels down:
+    THIS_DIRECTORY_PARAMETER=$(dirname "$(dirname "$(dirname "$PWD")")")
+else
+    # If a parameter was supplied, we'll use that, instead.
+    THIS_DIRECTORY_PARAMETER="$1"
+fi
+
+# Whether specified or inferred, the directory must exist to proceed.
+if [ ! -d "$THIS_DIRECTORY_PARAMETER" ]; then
+    echo "Directory Parameter doesn't exist.: $THIS_DIRECTORY_PARAMETER"
+    exit 1
+fi
+
+echo "Source to publish:  $THIS_DIRECTORY_PARAMETER"
+# get the directory name, e.g. wolfssl-master
+COMPONENT_NAME_GUESS=$(basename "$THIS_DIRECTORY_PARAMETER")
+
+# Set the in field separator to "-"
+IFS="-"
+
+# Read the directory name into an array. We only want the first part (e.g. wolfssl)
+read -a COMPONENT_GUESS_PARTS <<< "$COMPONENT_NAME_GUESS"
+
+# Get just the wolfssl part if "wolfssl-username"
+export THIS_DIRECTORY_COMPONENT="${COMPONENT_GUESS_PARTS[0]}"
+
+# Regardless of source text, we want lower case name components.
+export THIS_DIRECTORY_COMPONENT="${THIS_DIRECTORY_COMPONENT,,}"
+
+echo "THIS_DIRECTORY_COMPONENT = $THIS_DIRECTORY_COMPONENT"
+
+# Need to set IFS if using it elsewhere:
+IFS=
+
+#**************************************************************************************************
+#**************************************************************************************************
+# Begin script
+#**************************************************************************************************
+#**************************************************************************************************
+#
+# Reminder this script may be running from a development repo, but publishing source code from a
+# *different* specified directory (see above). However, the GitHub component name must match.
+# For example, if we are in `wolfMQTT-username`, we must only publish the wolfmqtt component.
+echo "Searching for component name (this script must run in a github repo directory)"
+THIS_COMPONENT_CONFIG="$(git config --get remote.origin.url)"
+export THIS_COMPONENT
+THIS_COMPONENT="$(basename -s .git "$THIS_COMPONENT_CONFIG")" || exit 1
+
+# Our component names are all lower case, regardless of repo name:
+THIS_COMPONENT="${THIS_COMPONENT,,}"
+
+# Check that we actually found a repository component name.
+if [ -z "$THIS_COMPONENT" ]; then
+    echo "Could not find component name."
+    echo "Please run this script from a github repo directory."
+    exit 1
+else
+    echo "Found component to publish: $THIS_COMPONENT"
+fi
+
+# Check that this repo and the source directory are for the same component name
+if [ "$THIS_COMPONENT" == "$THIS_DIRECTORY_COMPONENT" ]; then
+    echo "Will publish $THIS_COMPONENT from $THIS_DIRECTORY_PARAMETER"
+else
+    echo "ERROR: Not a $THIS_COMPONENT component in $THIS_DIRECTORY_PARAMETER"
+    exit 1
+fi
+
+export THIS_SOURCE="$THIS_DIRECTORY_PARAMETER"
+
+# Define the source directory and destination directory.
+# We start in           IDE/Espressif/component-manager
+# We want examples from IDE/Espressif/ESP-IDF/examples
+#
+# EXAMPLE_SOURCE_DIR="$THIS_SOURCE/IDE/Espressif/ESP-IDF/examples"
+
+export EXAMPLE_SOURCE_DIR="missing"
+
+case "$THIS_COMPONENT" in
+    "wolfssl")
+        export COMPONENT_VERSION_STRING="LIBWOLFSSL_VERSION_STRING"
+        export EXAMPLE_SOURCE_DIR="$THIS_SOURCE/IDE/Espressif/ESP-IDF/examples"
+        ;;
+    "wolfssh")
+        export COMPONENT_VERSION_STRING="LIBWOLFSSH_VERSION_STRING"
+        export EXAMPLE_SOURCE_DIR="$THIS_SOURCE/ide/Espressif/ESP-IDF/examples"
+        ;;
+    "wolfmqtt")
+        export COMPONENT_VERSION_STRING="LIBWOLFMQTT_VERSION_STRING"
+        export EXAMPLE_SOURCE_DIR="$THIS_SOURCE/IDE/Espressif/ESP-IDF/examples"
+        ;;
+    *)
+    export COMPONENT_VERSION_STRING=""
+    echo "Not a supported component: $THIS_COMPONENT"
+    exit 1
+    ;;
+esac
+
+# check if there's an unsupported idf_component_manager.yml file.
+if [ -e "./idf_component_manager.yml" ]; then
+    # There may be contradictory settings in idf_component_manager.yml vs environment variables,
+    # Which takes priority? Check not performed at this time.
+    echo "ERROR: This script does not yet support idf_component_manager.yml."
+    exit 1
+fi
+
+# check if IDF_PATH is set
+if [ -z "$IDF_PATH" ]; then
+    echo "Please follow the instruction of ESP-IDF installation and set IDF_PATH."
+    exit 1
+fi
+
+# make sure it actually exists
+if [ ! -d "$IDF_PATH" ]; then
+    echo "ESP-IDF Development Framework doesn't exist.: $IDF_PATH"
+    exit 1
+fi
+
+# is export.sh in the IDF path?
+if [ ! -e "$IDF_PATH/export.sh" ]; then
+    echo "ESP-IDF export.sh: $IDF_PATH/export.sh"
+    exit 1
+fi
+
+# check if IDF_COMPONENT_API_TOKEN is set
+if [ -z "$IDF_COMPONENT_API_TOKEN" ]; then
+    echo "Please follow the instructions and set IDF_COMPONENT_API_TOKEN value."
+    exit 1
+fi
+
+# there needs to be a version in the yml file
+THIS_VERSION=$(grep "version:" ./idf_component.yml | awk -F'"' '{print $2}')
+if [ -z "$THIS_VERSION" ]; then
+    echo "Quoted version: value not found in ./idf_component.yml"
+    exit 1
+fi
+
+# We need to have determined the published name before getting here (e.g. if called mywolfssl for staging)
+if [ "$IDF_COMPONENT_REGISTRY_URL" == "$PRODUCTION_URL" ]; then
+    echo "WARNING: The live $THIS_COMPONENT will be replaced upon completion."
+    echo ""
+    export THIS_NAMESPACE=wolfssl
+    export THIS_COMPONENT_NAME="$THIS_COMPONENT"
+else
+    if [ "$IDF_COMPONENT_REGISTRY_URL" == "$STAGING_URL" ]; then
+        # check if USER is set
+        if [ -z "$USER" ]; then
+            echo "Could not detect USER environment variable needed for staging"
+            exit 1
+        fi
+        export THIS_NAMESPACE="$USER"
+        export THIS_COMPONENT_NAME="my$THIS_COMPONENT"
+        echo ""
+        echo "WARNING: The staging $THIS_COMPONENT_NAME component will be replaced upon completion:"
+        echo ""
+        echo "   $IDF_COMPONENT_REGISTRY_URL/components/$THIS_NAMESPACE/$THIS_COMPONENT_NAME"
+        echo ""
+    else
+        echo ""
+        echo "WARNING: unexpected IDF_COMPONENT_REGISTRY_URL value = $IDF_COMPONENT_REGISTRY_URL"
+        echo "Expected blank or $STAGING_URL or $PRODUCTION_URL"
+        exit 1
+    fi
+fi
+
+# check if prior version tgz file already published.
+FOUND_LOCAL_DIST=
+if [ -f "./dist/${THIS_COMPONENT_NAME}_${THIS_VERSION}.tgz" ]; then
+    echo "Found file ${THIS_COMPONENT_NAME}_${THIS_VERSION}.tgz"
+    echo "Duplicate versions cannot be published. By proceeding, you will overwrite the local source."
+    echo ""
+    FOUND_LOCAL_DIST=true
+fi
+
+# check if prior version directory already published
+if [ -d "./dist/${THIS_COMPONENT_NAME}_${THIS_VERSION}" ]; then
+    echo "Found directory: ${THIS_COMPONENT_NAME}_${THIS_VERSION}"
+    echo "Duplicate versions cannot be published. By proceeding, you will overwrite the local source."
+    echo ""
+    FOUND_LOCAL_DIST=true
+fi
+
+# check if this version distribution already exists, and if so, if it should be overwritten
+if [ -z "$FOUND_LOCAL_DIST" ]; then
+    echo "Confirmed a prior local distribution file set does not exist for ${THIS_COMPONENT_NAME}_${THIS_VERSION}."
+else
+    OK_TO_OVERWRITE_DIST=
+    until [ "${OK_TO_OVERWRITE_DIST^}" == "Y" ] || [ "${OK_TO_OVERWRITE_DIST^}" == "N" ]; do
+        read -r -n1 -p "Proceed? (Y/N) " OK_TO_OVERWRITE_DIST
+        OK_TO_OVERWRITE_DIST=${OK_TO_OVERWRITE_DIST^};
+        echo;
+    done
+
+    if [ "${OK_TO_OVERWRITE_DIST^}" == "Y" ]; then
+        echo ""
+        echo "Proceeding. Choosing to publish will OVERWRITE EXISTING DISTRIBUTION..."
+        echo ""
+    else
+        echo "Exiting..."
+        exit 1
+    fi
+fi
+
+
+#**************************************************************************************************
+# Show Ready Summary before step that will copy all source files related to the ESP Component Registry
+#**************************************************************************************************
+echo ""
+
+
+echo "--------------------------------------------------------------------------------------------"
+echo ""
+echo "Current source directory:"
+echo ""
+pwd
+echo ""
+echo "Version to publish in local idf_component.yml (version numbers cannot be reused!)"
+echo ""
+grep "version:" idf_component.yml
+echo ""
+
+#**************************************************************************************************
+# copy all source files related to the ESP Component Registry
+#**************************************************************************************************
+
+# Optionally specify an alternative source of wolfSSL to publish:
+
+# TODO REMOVE this line if not using /test/wolfssl-master
+
+# if [ "wolfmqtt" == "$THIS_COMPONENT" ]; then
+#     THIS_SOURCE=/mnt/c/workspace/wolfMQTT-master
+# else
+#     if [ "wolfssl" == "$THIS_COMPONENT" ]; then
+#         THIS_SOURCE=/mnt/c/workspace/wolfssl-master
+#     else
+#         if [ "wolfssh" == "$THIS_COMPONENT" ]; then
+#             THIS_SOURCE=/mnt/c/workspace/wolfssh-master
+#         else
+#             echo "Error: not a supported component: $THIS_COMPONENT"
+#             exit 1
+#         fi
+#     fi
+# fi
+# END TODO REMOVE
+
+# copy_wolfssl_source $THIS_SOURCE
+echo "------------------------------------------------------------------------"
+echo "Copying source to publish from $THIS_SOURCE"
+echo "------------------------------------------------------------------------"
+echo ""
+echo "git status:"
+pushd "$THIS_SOURCE" || exit 1
+git status
+popd || exit 1
+
+#**************************************************************************************************
+# Confirm we actually want to proceed to copy.
+#**************************************************************************************************
+echo "Existing component-manager/examples files will be deleted and copied from $EXAMPLE_SOURCE_DIR"
+OK_TO_COPY=
+until [ "${OK_TO_COPY^}" == "Y" ] || [ "${OK_TO_COPY^}" == "N" ]; do
+    read -r -n1 -p "Proceed? (Y/N) " OK_TO_COPY
+    OK_TO_COPY=${OK_TO_COPY^};
+    echo;
+done
+
+echo ""
+
+if [ "${OK_TO_COPY^}" == "Y" ]; then
+    echo "Proceeding to copy..."
+else
+    echo "Exiting..."
+    exit 1
+fi
+
+#**************************************************************************************************
+# Copy root README.md file, clean it, and prepend README_REGISTRY_PREPEND.md text.
+# Also prepend a staging note as appropriate.
+#**************************************************************************************************
+# Copy a fresh repository source README.md
+cp                                       $THIS_SOURCE/README.md      ./README.md
+
+# strip any HTML anchor tags, that are irrelevant and don't look pretty
+echo "Removing HTML anchor tags from README..."
+sed -i '/<a href/,/<\/a>/d' ./README.md
+
+if [ -e "./README_REGISTRY_PREPEND.md" ]; then
+    if [ "$IDF_COMPONENT_REGISTRY_URL" == "$STAGING_URL" ]; then
+        echo "Prepend README_STAGING_PREPEND.md and README_REGISTRY_PREPEND.md to README.md"
+        cat ./README_STAGING_PREPEND.md ./README_REGISTRY_PREPEND.md  ./README.md  >  ./NEW_README.md
+    else
+    echo "Prepend README_REGISTRY_PREPEND.md to README.md"
+        cat                             ./README_REGISTRY_PREPEND.md  ./README.md  >  ./NEW_README.md
+    fi
+    THIS_ENCODING=$(file -b --mime-encoding ./NEW_README.md)
+    echo "Found encoding: $THIS_ENCODING"
+
+    iconv  --to-code=UTF-8//ignore  --output=./README.md  "./NEW_README.md"
+    THIS_ERROR_CODE=$?
+
+    if [ $THIS_ERROR_CODE -ne 0 ]; then
+        echo ""
+        echo "Warning! Bad encoding in README.md file. Removing bad chars and converting to UTF-8"
+        iconv  --to-code=UTF-8//ignore -c  --output=./README.md "./NEW_README.md"
+    else
+        echo ""
+        echo "Confirmed README.md contains no bad encoding chars."
+        echo ""
+    fi
+else
+    echo "ERROR: README_REGISTRY_PREPEND.md not found to prepend to README.md"
+    exit 1
+fi
+
+# Ensure there's a comment in the README.md for this specific version being published!
+#
+# grep "version:" idf_component.yml
+#   will typically return a value such as:  version: "1.0.7-dev"
+#
+# we'll want to look for the 1.0.7-dev part in the README.md
+#
+
+echo "Checking README.md for Version $THIS_VERSION"
+grep "$THIS_VERSION" README.md
+THIS_ERROR_CODE=$?
+
+if [ $THIS_ERROR_CODE -ne 0 ]; then
+    echo ""
+    echo "Version text not found in the README.md file. Please edit and try again."
+    echo "  See file: README_REGISTRY_PREPEND.md that is used to create README.md"
+    exit 1
+else
+    echo ""
+    echo "Confirmed README.md contains the version text: $THIS_VERSION"
+    echo ""
+fi
+
+# We need a user_settings.h in the include directory,
+# However we'll keep a default Espressif locally, and *not* copy here:
+#
+# copy_wolfssl_source $THIS_SOURCE  "include"                           "*.h"
+#
+# See also IDE/Espressif/ESP-IDF/user_settings.h
+#
+#**************************************************************************************************
+# Copy C source files
+# Reminder: each component must specify a value for EXAMPLE_SOURCE_DIR (above)
+#**************************************************************************************************
+
+# wolfMQTT Files
+if [ "wolfmqtt" == "$THIS_COMPONENT" ]; then
+
+    echo "Copying wolfMQTT C Source files... $THIS_SOURCE"
+    copy_wolfssl_source  $THIS_SOURCE  "src"                                "*.c"
+
+    # Copy C header files
+    echo "Copying wolfMQTT C Header files..."
+    copy_wolfssl_source  $THIS_SOURCE  "wolfmqtt"                           "*.h"
+
+    # wolfMQTT looks for an options.h file
+    echo "Copying wolfMQTT options.h"
+    cp ./lib/options.h "./wolfmqtt/options.h"
+fi
+
+# wolfSSH Files
+if [ "wolfssh" == "$THIS_COMPONENT" ]; then
+    echo "Copying wolfSSH C Source files... $THIS_SOURCE"
+    copy_wolfssl_source  $THIS_SOURCE  "src"                                "*.c"
+
+    # Copy C header files
+    echo "Copying wolfSSH C Header files..."
+    copy_wolfssl_source  $THIS_SOURCE  "wolfssh"                           "*.h"
+fi
+
+# wolfSSL Files
+if [ "wolfssl" == "$THIS_COMPONENT" ]; then
+
+    echo "Copying wolfSSL C Source files... $THIS_SOURCE"
+    copy_wolfssl_source  $THIS_SOURCE  "src"                                "*.c"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/src"                      "*.c"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/benchmark"                "*.c"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/src/port/atmel"           "*.c"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/src/port/Espressif"       "*.c"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/test"                     "*.c"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/user-crypto/src"          "*.c"
+
+    # Copy C header files
+    echo "Copying wolfSSL C Header files..."
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/benchmark"                "*.h"  APPEND
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/test"                     "*.h"  APPEND
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/user-crypto/include"      "*.h"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfssl"                            "*.h"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfssl/openssl"                    "*.h"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfssl/wolfcrypt"                  "*.h"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfssl/wolfcrypt/port/atmel"       "*.h"
+    copy_wolfssl_source  $THIS_SOURCE  "wolfssl/wolfcrypt/port/Espressif"   "*.h"
+
+    # Note that for example apps, the ESP Registry will append the these README files to
+    # the main README.md at publish time, and generate anchor text hyperlinks.
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/benchmark"                "README.md"  APPEND
+    copy_wolfssl_source  $THIS_SOURCE  "wolfcrypt/test"                     "README.md"  APPEND
+
+    # TODO remove
+    # Files known to need attention
+    # The current examples expect user_settings in the root include directory
+    # this can be removed once subsequent PR updates are accepted for examples
+    cp ./lib/user_settings.h ./include/user_settings.h
+
+    # The component registry needs a newer version of esp32-crypt.h
+    # cp ./lib/esp32-crypt.h   ./wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+    # End TODO
+fi
+echo ""
+
+#**************************************************************************************************
+# make sure the version found in ./$THIS_COMPONENT/version.h matches  that in ./idf_component.yml
+#**************************************************************************************************
+if [ -e "./$THIS_COMPONENT/version.h" ]; then
+    WOLFSSL_VERSION=$(grep "${COMPONENT_VERSION_STRING}" ./"${THIS_COMPONENT}"/version.h | awk '{print $3}' | tr -d '"')
+    grep "$WOLFSSL_VERSION" ./idf_component.yml
+    THIS_ERROR_CODE=$?
+    if [ $THIS_ERROR_CODE -ne 0 ]; then
+        echo ""
+        echo "Version text in idf_component.yml does not match ./$THIS_COMPONENT/version.h ($WOLFSSL_VERSION). Please edit and try again."
+        # optionally exit TODO?
+
+        # exit 1
+    else
+        echo ""
+        echo "Confirmed idf_component.yml matches ./$THIS_COMPONENT/version.h the version text: $WOLFSSL_VERSION"
+        echo ""
+    fi
+else
+    echo "ERROR: ./$THIS_COMPONENT/version.h not found"
+    exit 1
+fi
+
+#**************************************************************************************************
+# All files from the wolfssl/IDE/Espressif/ESP-IDF/examples
+# will be copied to the local ESP Registry ./examples/ directory
+#
+# Define the source directory and destination directory.
+# We start in           IDE/Espressif/component-manager
+# We want examples from IDE/Espressif/ESP-IDF/examples
+#
+# We'll copy examples to publish into our local examples
+# We start in           IDE/Espressif/component-manager
+# Copy example files to IDE/Espressif/component-manager/examples
+destination_dir="examples"
+
+# Check if the destination directory exists, and create it if it doesn't
+if [ ! -d "$destination_dir" ]; then
+    mkdir -p "$destination_dir"
+else
+    rm -rf ../component-manager/examples
+    mkdir -p "$destination_dir"
+fi
+
+# Check that we have a manifest for examples.
+if [ -f "component_manifest.txt" ]; then
+    echo "Using manifest file: component_manifest.txt"
+else
+    echo "Error: component_manifest.txt not found and is needed for examples."
+    exit 1
+fi
+
+MISSING_FILES=N
+# Read the list of files from component_manifest.txt and copy them
+while IFS= read -r file_path; do
+
+    if [[ "$file_path" == "#"* ]]; then
+        echo "$file_path"
+    else
+        # Remove leading and trailing whitespace from the file path
+        file_path=$(echo "$file_path" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+        # Check if the file path is empty (blank line)
+        if [ -z "$file_path" ]; then
+            continue
+        fi
+
+        # Construct the full source and destination paths
+        full_source_path="$EXAMPLE_SOURCE_DIR/$file_path"
+        full_destination_path="$destination_dir/$file_path"
+
+        # Create the directory structure in the destination if it doesn't exist
+        mkdir -p "$(dirname "$full_destination_path")"
+
+        # Copy the file to the destination
+        cp "$full_source_path" "$full_destination_path"
+        THIS_ERROR_CODE=$?
+        if [ $THIS_ERROR_CODE -eq 0 ]; then
+            echo "Copied: $full_source_path -> $full_destination_path"
+        else
+            MISSING_FILES=Y
+            # echo "WARNING: File not copied:  $full_source_path"
+        fi
+    fi # comment or file check
+done < "component_manifest.txt" # loop through each of the lines in component_manifest.txt
+echo ""
+
+#**************************************************************************************************
+# Each project will be initialized with idf_component.yml in the project directory.
+#**************************************************************************************************
+echo "------------------------------------------------------------------------"
+echo "Initialize projects with idf_component.yml"
+echo "------------------------------------------------------------------------"
+if [ "$IDF_COMPONENT_REGISTRY_URL" == "$PRODUCTION_URL" ]; then
+    export IDF_EXAMPLE_SOURCE="./lib/idf_component.yml"
+else
+    if [ "$IDF_COMPONENT_REGISTRY_URL" == "$STAGING_URL" ]; then
+        export IDF_EXAMPLE_SOURCE="./lib/idf_component-staging-$USER.yml"
+    else
+        echo ""
+        echo "WARNING: unexpected IDF_COMPONENT_REGISTRY_URL value = $IDF_COMPONENT_REGISTRY_URL"
+        echo "Expected blank or $STAGING_URL or $PRODUCTION_URL"
+        exit 1
+    fi
+fi
+echo ""
+
+#**************************************************************************************************
+# make sure the idf_component.yml (or idf_component-staging-[user name].yml) file exists
+#**************************************************************************************************
+if [ -f "$IDF_EXAMPLE_SOURCE" ]; then
+    echo "Examples will use: $IDF_EXAMPLE_SOURCE"
+else
+    echo "Error: staging environment found, but required example component yml file does not exist: $IDF_EXAMPLE_SOURCE"
+    exit 1
+fi
+
+#**************************************************************************************************
+# each example needs a idf_component.yml from  ./lib copied into [example]/name/
+#**************************************************************************************************
+find ./examples/ -maxdepth 1 -mindepth 1 -type d -print0 | xargs -0 -I {} sh -c "echo 'Copying $IDF_EXAMPLE_SOURCE to {}/main/idf_component.yml ' && cp $IDF_EXAMPLE_SOURCE {}/main/idf_component.yml" || exit 1
+
+#**************************************************************************************************
+# Check if we detected any missing example files that did not successfully copy.
+#**************************************************************************************************
+if [ "${MISSING_FILES^}" == "Y" ]; then
+    echo "Some example files not copied. Continue?"
+    #**************************************************************************************************
+    # Confirm we actually want to proceed to publish if there were missing example source files.
+    #**************************************************************************************************
+    COMPONENT_MANAGER_CONTINUE=
+    until [ "${COMPONENT_MANAGER_CONTINUE^}" == "Y" ] || [ "${COMPONENT_MANAGER_CONTINUE^}" == "N" ]; do
+        read -r -n1 -p "Proceed? (Y/N) " COMPONENT_MANAGER_CONTINUE
+        COMPONENT_MANAGER_CONTINUE=${COMPONENT_MANAGER_CONTINUE^};
+        echo;
+    done
+
+    if [ "${COMPONENT_MANAGER_CONTINUE}" == "Y" ]; then
+        echo "Continuing with missing files..."
+    else
+        echo "Exiting..."
+        exit 1
+    fi
+fi
+
+echo "Copy operation completed for examples."
+
+# Check to see if we failed to previously build:
+if [ -e "./build_failed.txt" ]; then
+    echo "Removing semaphore file: build_failed.txt"
+    rm ./build_failed.txt
+fi
+# end of prep
+
+#**************************************************************************************************
+# Build all the projects in ./examples/
+# if an error is encountered, create a semaphore file called build_failed.txt
+#
+# NOTE: this checks if the *current* examples build with the *CURRENT* (already published) ESP Registry version.
+# Run this script a second time (don't publish) to ensure the examples build with freshly-published wolfSSL code.
+# Reminder that there may be a delay of several minutes or more between the time of publish, and the time
+# when the files are actually available.
+
+# This build is for the *prior* version of ESP Component (the one *already* published)
+# find  ./examples/ -maxdepth 1 -mindepth 1 -type d | xargs -I {} sh -c 'cd {} && echo "\n\nBuilding {} for minimum component version: " && grep "wolfssl/wolfssl:" main/idf_component.yml && echo "\n\n" && idf.py build || touch ../../build_failed.txt'
+
+# we'll do a test build of the current to-be-published version of wolfSSL
+#
+# get a list of all directory names ---------------------| (SC2038 Use -print0/-0 or -exec + to allow for non-alphanumeric filenames.)
+# send to xargs -----------------------------------------|-----------|
+# use each directory name found as a parameter "{}" -----|-----------|-|
+# run each as a shell script command --------------------|-----------|----|
+# print a progress message for each example being built -|-----------|------------|
+# send each directory found as a parameter to wolfssl_build_example.sh to build the project -------------------------------------------|
+# The build_failed.txt will exist when one or more of the builds has failed -----------------------------------------------------------|------|
+#
+# TODO build disabled
+#find ./examples/ -maxdepth 1 -mindepth 1 -type d -print0 | xargs -0 -I {} sh -c 'echo "\n\nBuilding {} " && ./wolfssl_build_example.sh {} || touch ../../build_failed.txt'
+
+echo ""
+echo "Warning: build check for examples not yet in place."
+echo ""
+
+# Check to see if we failed on this build:
+if [ -e "./build_failed.txt" ]; then
+    echo "Build failed!"
+    exit 1
+fi
+#**************************************************************************************************
+
+# Delete any managed components and build directories before uploading.
+# The files *should* be excluded by default, so this is just local housekeeping.
+# if not excluded, the upload will typically be 10x larger. Expected size = 10MB.
+echo "Removing managed_components and build directories: (errors ok here)"
+find  ./examples/ -maxdepth 1 -mindepth 1 -type d -print0 | xargs -0 -I {} rm -r {}/managed_components/
+find  ./examples/ -maxdepth 1 -mindepth 1 -type d -print0 | xargs -0 -I {} rm -r {}/build/
+
+echo ""
+echo "Samples files to publish:"
+echo ""
+find ./examples/ -print
+echo ""
+
+# Check to see if we failed on this build:
+if [ -e "./build_failed.txt" ]; then
+    echo "Build of 1 or more examples failed!"
+else
+    echo "Build success for examples!"
+fi
+
+echo ""
+echo "Important: Review the list of files above to confirm they should ALL be published with the component."
+echo ""
+echo "Ready to publish..."
+
+if [ "${OK_TO_OVERWRITE_DIST^}" == "Y" ]; then
+    echo ""
+    echo "  WARNING: The local distribution files have been updated."
+    echo ""
+    echo "  By proceeding, you confirm this version has not been previously published."
+    echo ""
+    echo "  If this version has been published, you will likely see an error when proceeding."
+    echo ""
+fi
+
+echo ""
+grep "version:" idf_component.yml
+echo ""
+
+#**************************************************************************************************
+# Confirm we actually want to proceed to publish.
+#**************************************************************************************************
+if [ -z "$IDF_COMPONENT_REGISTRY_URL" ]; then
+    echo "ERROR: IDF_COMPONENT_REGISTRY_URL should have been set."
+    echo ""
+    exit 1
+else
+    echo "Publishing local $THIS_COMPONENT source to ESP Registry: $IDF_COMPONENT_REGISTRY_URL"
+    echo ""
+    echo "======================================================================================="
+    echo "======================================================================================="
+    echo ""
+    echo "WARNING: The specified $THIS_COMPONENT_NAME component will be replaced upon completion."
+    echo ""
+    echo "======================================================================================="
+    echo "======================================================================================="
+    echo ""
+fi
+
+COMPONENT_MANAGER_PUBLISH=
+until [ "${COMPONENT_MANAGER_PUBLISH^}" == "Y" ] || [ "${COMPONENT_MANAGER_PUBLISH^}" == "N" ]; do
+    read -r -n1 -p "Proceed to publish $THIS_COMPONENT? (Y/N) " COMPONENT_MANAGER_PUBLISH
+    COMPONENT_MANAGER_PUBLISH=${COMPONENT_MANAGER_PUBLISH^};
+    echo;
+done
+
+if [ "${COMPONENT_MANAGER_PUBLISH}" == "Y" ]; then
+    echo;
+    echo "Here we go!"
+    echo ""
+    pwd
+    echo ""
+    echo "Creating files in ./dist/ then creating .tgz to upload. Please be patient..."
+    #
+    # The component will be called "wolfssl__wolfssl". There's no way to change that at this time.
+    # Unfortunately, there is no way to change the build-system name of a dependency installed
+    # by the component manager. It's always `namespace__component`.
+    #
+    # In the case of staging, the component will be called "[username]__mywolfssl"
+    #
+
+    if [ "$IDF_COMPONENT_REGISTRY_URL" == "$PRODUCTION_URL" ]; then
+        # echo "WARNING: The live wolfSSL will be replaced upon completion."
+        echo "DISABLED: "
+        echo "compote component upload --namespace wolfssl --name $THIS_COMPONENT_NAME" || exit 1
+    else
+        if [ "$IDF_COMPONENT_REGISTRY_URL" == "$STAGING_URL" ]; then
+            echo "Running: compote component upload --namespace $USER --name $THIS_COMPONENT_NAME"
+            echo ""
+            compote component upload --namespace "$THIS_NAMESPACE" --name "$THIS_COMPONENT_NAME" || exit 1
+        else
+            echo ""
+            echo "WARNING: unexpected IDF_COMPONENT_REGISTRY_URL value = $IDF_COMPONENT_REGISTRY_URL"
+            echo "Expected blank or $STAGING_URL or $PRODUCTION_URL"
+            exit 1
+        fi
+    fi
+
+    echo ""
+    if [ -z "$IDF_COMPONENT_REGISTRY_URL" ]; then
+        echo "View the new component at https://components.espressif.com/components/wolfssl/wolfssl"
+    else
+        echo "View the new component at $IDF_COMPONENT_REGISTRY_URL/$THIS_NAMESPACE/$THIS_COMPONENT"
+    fi
+    echo ""
+    echo "Done!"
+    echo ""
+else
+    echo;
+    echo "No files published!"
+fi

--- a/ide/Espressif/include.am
+++ b/ide/Espressif/include.am
@@ -1,0 +1,23 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+#
+
+# Component Manager
+
+EXTRA_DIST+= ide\Espressif\component-manager\CMakeLists.txt
+EXTRA_DIST+= ide\Espressif\component-manager\component_manifest.txt
+EXTRA_DIST+= ide\Espressif\component-manager\idf_component.yml
+EXTRA_DIST+= ide\Espressif\component-manager\INSTALL.md
+EXTRA_DIST+= ide\Espressif\component-manager\LICENSE.txt
+EXTRA_DIST+= ide\Espressif\component-manager\NEW_README.md
+EXTRA_DIST+= ide\Espressif\component-manager\README.md
+EXTRA_DIST+= ide\Espressif\component-manager\README_DIST.md
+EXTRA_DIST+= ide\Espressif\component-manager\README_REGISTRY_PREPEND.md
+EXTRA_DIST+= ide\Espressif\component-manager\README_STAGING.md
+EXTRA_DIST+= ide\Espressif\component-manager\README_STAGING_PREPEND.md
+EXTRA_DIST+= ide\Espressif\component-manager\wolfssl_build_example.sh
+EXTRA_DIST+= ide\Espressif\component-manager\wolfssl_component_publish.sh
+EXTRA_DIST+= ide\Espressif\component-manager\lib\idf_component-staging-gojimmypi.yml
+EXTRA_DIST+= ide\Espressif\component-manager\lib\idf_component.yml
+EXTRA_DIST+= ide\Espressif\component-manager\lib\winmerge wolfssl filter.flt


### PR DESCRIPTION
Similar to https://github.com/wolfSSL/wolfssl/pull/6708 these are the files used to publish wolfSSH as a component to the Espressif Component Registry.

These files are not part of wolfSSH library and are only needed to publish  wolfSSH to the [Espressif ESP Registry](https://components.espressif.com/):

https://components.espressif.com/components?q=namespace:wolfssl  (wolfSSH not yet deployed to production site).

The staging site is at:

https://components-staging.espressif.com/components/gojimmypi/mywolfssh

Note that for the staging site, I have implemented user-specific namespace support in the install script (in my case: `gojimmypi` and detected with the `$USER` variable). Additionally, on the staging site components are renamed with a `my` prefix, to distinguish from production libraries. This allows multiple publishers to publish their own test components individually before using the single production `wolfssl` namespace and component names. This also aids in support identification if a customer is using experimental staging components.

Only Linux bash script is implemented at this time for publishing.

See the `README.md` for details. See also https://github.com/wolfSSL/wolfssh/issues/588 and https://github.com/wolfSSL/wolfMQTT/issues/352

The recent updates here include support for the staging site and passing a parameter as to the source code to install:

```bash
./wolfssl_component_publish.sh /mnt/c/workspace/wolfssl-master
```

See the `INSTALL.md` for files to edit for published version specification and other details. 

Closes https://github.com/wolfSSL/wolfssh/issues/588 and partially addresses https://github.com/wolfSSL/wolfssh/issues/428 (a different `CMakeLists.txt` is needed for non-managed components). PR for that soon in separate examples.