### PR TITLE
Fix index of signature part in case of RSA

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4303,7 +4303,7 @@ static int DoKexDhReply(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
         /* Verify h with the server's public key. */
         if (ret == WS_SUCCESS) {
 #ifndef WOLFSSH_NO_RSA
-        int tmpIdx = begin;
+        int tmpIdx = begin - sigSz;
 #endif
             /* Skip past the sig name. Check it, though. Other SSH
              * implementations do the verify based on the name, despite what


### PR DESCRIPTION
This PR is to address the issue reported in ZD#16867.

This issue occurs because the index value, which is initialized to point to the signature part of the data, is pointing after the signature part, resulting in a buffer error(-1004). This index value must be initialized correctly.
This failure occurs when the server host key algorithm is RSA.

How to reproduce the issue:
1. configure wolfSSH with following options
     ./configure --enable-debug --enable-sftp CFLAGS="-DWOLFSSH_YES_SSH_RSA_SHA1"
2. comment out ID_ECDSA_SHA2_NISTP256 entry from cannedKeyAlgoClient[].
    This is to ensure that only rsa-sha2-256 and ssh-rsa are listed in the Server-host-key algorithm list. The 　　WOLFSSH_NO_ECDSA macro could not be used because it would generate a build error.
4. build and run echoserver as a sever and run wolfsftp with -u jill -P upthehill
5. wolfsftp prints out " connect error: CLIENT_KEXDH_INIt_SENT,  -1004"