### PR TITLE
Made setting file modes portable

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -5099,7 +5099,7 @@ static int SFTP_SetMode(void* fs, char* name, word32 mode) {
 }
 #endif
 
-#if !defined(USE_WINDOWS_API) && !defined(WOLFSSH_SFTP_SETMODEHANDLE)
+#if !defined(USE_WINDOWS_API) && !defined(WOLFSSH_ZEPHYR) && !defined(WOLFSSH_SFTP_SETMODEHANDLE)
 /* Set the files mode
  * return WS_SUCCESS on success */
 static int SFTP_SetModeHandle(void* fs, WFD handle, word32 mode) {

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -5091,7 +5091,7 @@ int wolfSSH_SFTP_RecvLSTAT(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
 /* Set the files mode
  * return WS_SUCCESS on success */
 static int SFTP_SetMode(void* fs, char* name, word32 mode) {
-    WOLFSSH_UNUSED(fs)
+    WOLFSSH_UNUSED(fs);
     if (WCHMOD(fs, name, mode) != 0) {
         return WS_BAD_FILE_E;
     }
@@ -5103,7 +5103,7 @@ static int SFTP_SetMode(void* fs, char* name, word32 mode) {
 /* Set the files mode
  * return WS_SUCCESS on success */
 static int SFTP_SetModeHandle(void* fs, WFD handle, word32 mode) {
-    WOLFSSH_UNUSED(fs)
+    WOLFSSH_UNUSED(fs);
     if (WFCHMOD(fs, handle, mode) != 0) {
         return WS_BAD_FILE_E;
     }


### PR DESCRIPTION
Made setting file modes portable, by means of defining the WOLFSSH_SFTP_SETMODE and WOLFSSH_SFTP_SETMODEHANDLE macros, in which case the functions SFTP_SetMode and SFTP_SetModeHandle will have to be externally defined for the platform the library is being ported to.