### PR TITLE
Unused Heap

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -1553,7 +1553,7 @@ void wolfSSH_AGENT_ID_free(WOLFSSH_AGENT_ID* id, void* heap)
             WFREE(id->keyBuffer, heap, DYNTYPE_STRING);
         }
         WMEMSET(id, 0, sizeof(WOLFSSH_AGENT_ID));
-        WFREE(id, heap, DYNATYPE_AGENT_ID);
+        WFREE(id, heap, DYNTYPE_AGENT_ID);
     }
 
     WLOG(WS_LOG_AGENT, "Leaving wolfSSH_AGENT_ID_free()");

--- a/src/internal.c
+++ b/src/internal.c
@@ -1516,7 +1516,7 @@ static int SetHostCertificate(WOLFSSH_CTX* ctx,
 
         if (pvtKey->publicKeyFmt == certId) {
             if (pvtKey->cert != NULL) {
-                WFREE(pvtKey->cert, heap, dynamicType);
+                WFREE(pvtKey->cert, ctx->heap, dynamicType);
             }
         }
         else {
@@ -2210,17 +2210,19 @@ int ChannelUpdateForward(WOLFSSH_CHANNEL* channel,
                                 const char* origin, word32 originPort,
                                 int isDirect)
 {
+    void* heap = NULL;
     int ret = WS_SUCCESS;
     char* hostCopy = NULL;
     char* originCopy = NULL;
     word32 hostSz;
     word32 originSz;
 
+    WOLFSSH_UNUSED(heap);
+
     if (channel == NULL || host == NULL || origin == NULL)
         ret = WS_BAD_ARGUMENT;
     else {
-        void* heap = channel->ssh->ctx->heap;
-
+        heap = channel->ssh->ctx->heap;
         hostSz = (word32)WSTRLEN(host) + 1;
         originSz = (word32)WSTRLEN(origin) + 1;
         hostCopy = (char*)WMALLOC(hostSz, heap, DYNTYPE_STRING);
@@ -5614,7 +5616,7 @@ static int DoUserAuthRequestRsa(WOLFSSH* ssh, WS_UserAuthData_PublicKey* pk,
     if (checkDigest)
         WFREE(checkDigest, ssh->ctx->heap, DYNTYPE_BUFFER);
     if (encDigest)
-        WFREE(encDigest, ssh->ctx_heap, DYNTYPE_BUFFER);
+        WFREE(encDigest, ssh->ctx->heap, DYNTYPE_BUFFER);
 #endif
     WLOG(WS_LOG_DEBUG, "Leaving DoUserAuthRequestRsa(), ret = %d", ret);
     return ret;


### PR DESCRIPTION
1. Moved the heap variable declaration to the top of the function
   ChannelUpdateForward().
2. Only set heap if channel is non-null.
3. Tag heap as unused. Depending on the build environment, it might be
   left out by the preprocessor.
4. Fix a bad memory type name used in a malloc in the agent.
5. Fix a use of heap when ctx->heap was intended.
6. Fix a typo where ssh->ctx->heap was intended.