### PR TITLE
RSA Verify Check

### DIFF
--- a/src/agent.c
+++ b/src/agent.c
@@ -701,6 +701,10 @@ static int SignHashRsa(WOLFSSH_AGENT_KEY_RSA* rawKey, enum wc_HashType hashType,
             WLOG(WS_LOG_DEBUG, "Bad RSA Sign");
             ret = WS_RSA_E;
         }
+        else {
+            ret = wolfSSH_RsaVerify(sig, *sigSz,
+                    encSig, encSigSz, &key, heap, "SignHashRsa");
+        }
     }
 
     wc_FreeRsaKey(&key);

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -36,6 +36,7 @@
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/dh.h>
 #include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/rsa.h>
 #ifdef WOLFSSH_SCP
     #include <wolfssh/wolfscp.h>
 #endif
@@ -1195,6 +1196,9 @@ WOLFSSH_LOCAL int wsScpSendCallback(WOLFSSH*, int, const char*, char*, word32,
 
 
 WOLFSSH_LOCAL int wolfSSH_CleanPath(WOLFSSH* ssh, char* in);
+WOLFSSH_LOCAL int wolfSSH_RsaVerify(byte *sig, word32 sigSz,
+        const byte* digest, word32 digestSz,
+        RsaKey* key, void* heap, const char* loc);
 WOLFSSH_LOCAL void DumpOctetString(const byte*, word32);
 WOLFSSH_LOCAL int wolfSSH_oct2dec(WOLFSSH* ssh, byte* oct, word32 octSz);
 WOLFSSH_LOCAL void AddAssign64(word32*, word32);


### PR DESCRIPTION
1. Added function wolfSSH_RsaVerify() which verifies the provided RSA signature with the provided key.
2. Call wolfSSH_RsaVerify() after all calls to wc_RsaSSL_Sign().
3. Changed a comparison between an unsigned and 0 to == from <=.

This fixes a potential but unconfirmed vulnerability in wolfSSH described in the paper "Passive SSH Key Compromise via Lattices" by Keegan Ryan, et al, at UCSD.