### PR TITLE
Release v1.4.15: Last Second Fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@
   been observed in wolfSSH, the fix is now implemented. The RSA signature
   is verified before sending to the peer.
   - Keegan Ryan, Kaiwen He, George Arnold Sullivan, and Nadia Heninger. 2023.
-    Passive SSH Key Compormise via Lattices. Cryptology ePrint Archive,
+    Passive SSH Key Compromise via Lattices. Cryptology ePrint Archive,
     Report 2023/1711. https://eprint.iacr.org/2023/1711.
 
 ## Notes
@@ -46,7 +46,7 @@
 * Speed improvements for SFTP. (Fixed unnecessary waiting.)
 * Windows wolfSSHd improvements.
 * The functions `wolfSSH_ReadKey_file()` and `wolfSSH_ReadKey_buffer()`
-  handles more encodings.
+  handle more encodings.
 * Add function to supply new protocol ID string.
 * Support larger RSA keys.
 * MinGW support updates.

--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -41,7 +41,10 @@
 #include <unistd.h>
 #else
 /* avoid macro redefinition warnings on STATUS values when include ntstatus.h */
+#undef UMDF_USING_NTSTATUS
 #define UMDF_USING_NTSTATUS
+#undef UNICODE
+#define UNICODE
 #endif
 
 #include <wolfssh/ssh.h>


### PR DESCRIPTION
1. Added a UNICODE define to the Windows build of the wolfSSHd auth module so it picked the correct strings.
2. Fixed a typo in the ChangeLog.