### PR TITLE
Gate PrivBeginPrefix/PrivSuffix; init typeSz in ssh.c

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1488,10 +1488,13 @@ union wolfSSH_key {
 
 static const char* PrivBeginOpenSSH = "-----BEGIN OPENSSH PRIVATE KEY-----";
 static const char* PrivEndOpenSSH = "-----END OPENSSH PRIVATE KEY-----";
-static const char* PrivBeginPrefix = "-----BEGIN ";
-/* static const char* PrivEndPrefix = "-----END "; */
-static const char* PrivSuffix = " PRIVATE KEY-----";
 
+#if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
+    /* currently only used in wolfSSH_ReadKey_file() */
+    static const char* PrivBeginPrefix = "-----BEGIN ";
+    /* static const char* PrivEndPrefix = "-----END "; */
+    static const char* PrivSuffix = " PRIVATE KEY-----";
+#endif
 
 static int DoSshPubKey(const byte* in, word32 inSz, byte** out,
         word32* outSz, const byte** outType, word32* outTypeSz,
@@ -1503,7 +1506,7 @@ static int DoSshPubKey(const byte* in, word32 inSz, byte** out,
     char* type = NULL;
     char* key = NULL;
     int ret = WS_SUCCESS;
-    word32 newKeySz, typeSz;
+    word32 newKeySz, typeSz = 0;
 
     WOLFSSH_UNUSED(inSz);
     WOLFSSH_UNUSED(heap);


### PR DESCRIPTION
The `PrivBeginPrefix` and `PrivSuffix` are only [used](https://github.com/wolfSSL/wolfssh/blob/60a29602e5893fd4e2ca0f4b6e2e05c6324154ed/src/ssh.c#L1835) in `wolfSSH_ReadKey_file()` which is [gated](https://github.com/wolfSSL/wolfssh/blob/60a29602e5893fd4e2ca0f4b6e2e05c6324154ed/src/ssh.c#L1770) with:

```
#if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
```

... thus otherwise there's a compiler warning about them not being used on a no-filesystem target.

There's also a `typeSz = 0` initialization that was failing as the Espressif compiler was complaining it was not initialized.

* Edit: see https://github.com/wolfSSL/wolfssh/issues/633