### PR TITLE
Improved "misc.c does not need to be compiled" message

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -53,21 +53,11 @@
 /* Check for if compiling misc.c when not needed. */
 #if !defined(WOLFSSH_MISC_INCLUDED) && !defined(NO_INLINE) && \
     !defined(WOLFSSH_IGNORE_FILE_WARN)
-    #define MISC_WARNING "misc.c does not need to be compiled when using inline (NO_INLINE not defined))"
-    #define MISC_STRINGIFY(x) #x
-    #define MISC_TOSTRING(x) MISC_STRINGIFY(x)
-    #ifdef __STDC_VERSION__
-      #if __STDC_VERSION__ >= 199901L
-        #define PRAGMA_SUPPORTED 1
-      #endif
-    #endif
 
-    #if (defined(__GNUC__) || defined(__clang__)) && defined(PRAGMA_SUPPORTED)
-        _Pragma(MISC_TOSTRING(message(MISC_WARNING)))
-    #elif  defined(_MSC_VER)
-        #pragma message("warning: " MISC_WARNING)
+    #ifndef _MSC_VER
+        #warning "misc.c does not need to be compiled when using inline (NO_INLINE not defined))"
     #else
-        #warning MISC_WARNING
+        #pragma message("warning: misc.c does not need to be compiled when using inline (NO_INLINE not defined))")
     #endif
 
 #else /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE && !WOLFSSH_IGNORE_FILE_WARN */

--- a/src/misc.c
+++ b/src/misc.c
@@ -54,11 +54,20 @@
 #if !defined(WOLFSSH_MISC_INCLUDED) && !defined(NO_INLINE) && \
     !defined(WOLFSSH_IGNORE_FILE_WARN)
     #define MISC_WARNING "misc.c does not need to be compiled when using inline (NO_INLINE not defined))"
+    #define MISC_STRINGIFY(x) #x
+    #define MISC_TOSTRING(x) MISC_STRINGIFY(x)
+    #ifdef __STDC_VERSION__
+      #if __STDC_VERSION__ >= 199901L
+        #define PRAGMA_SUPPORTED 1
+      #endif
+    #endif
 
-    #ifndef _MSC_VER
-        #warning MISC_WARNING
-    #else
+    #if (defined(__GNUC__) || defined(__clang__)) && defined(PRAGMA_SUPPORTED)
+        _Pragma(MISC_TOSTRING(message(MISC_WARNING)))
+    #elif  defined(_MSC_VER)
         #pragma message("warning: " MISC_WARNING)
+    #else
+        #warning MISC_WARNING
     #endif
 
 #else /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE && !WOLFSSH_IGNORE_FILE_WARN */


### PR DESCRIPTION
As noted in https://github.com/wolfSSL/wolfssh/issues/633,  when building with the Espressif ESP-IDF, and the `misc.c` is not excluded in the `CMakeLists.txt`, I see this message:

```
[2/9] Building C object esp-idf/wolfssh/CMakeFiles/__idf_wolfssh.dir/C_/workspace/wolfssh-gojimmypi/src/misc.c.obj
C:/workspace/wolfssh-gojimmypi/src/misc.c:76:10: warning: #warning MISC_WARNING [-Wcpp]
   76 |         #warning MISC_WARNING
      |          ^~~~~~~
```

In particular, note the `MISC_WARNING` was previously defined as a descriptive string, but that string is not displayed at compile time.

This PR adds some macro logic to detect if `_Pragma` is supported, and if so the contents of `MISC_WARNING` is string-ified and displayed as appropriate.

Although this might have been simplified by simply using the same string in multiple places, there may be value in having the single definition of `MISC_WARNING` available elsewhere as needed. 

Using this change, the warning is manifested like this in my environment:

```
[2/9] Building C object esp-idf/wolfssh/CMakeFiles/__idf_wolfssh.dir/C_/workspace/wolfssh-gojimmypi/src/misc.c.obj
C:/workspace/wolfssh-gojimmypi/src/misc.c:83:9: note: '#pragma message: misc.c does not need to be compiled when using inline (NO_INLINE not defined))'
   83 |         _Pragma(MISC_TOSTRING(message(MISC_WARNING)))
      |         ^~~~~~~
[3/9] Building C object esp-idf
```
