### PR TITLE
SFTP Test Maintenance

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -974,7 +974,7 @@ static void test_wolfSSH_SFTP_SendReadPacket(void)
     ser.signal = &ready;
     InitTcpReady(ser.signal);
     ThreadStart(echoserver_test, (void*)&ser, &serThread);
-    WaitTcpReady(&ser);
+    WaitTcpReady(&ready);
 
     sftp_client_connect(&ctx, &ssh, ready.port);
     AssertNotNull(ctx);

--- a/tests/sftp.c
+++ b/tests/sftp.c
@@ -216,10 +216,10 @@ int wolfSSH_SftpTest(int flag)
     args[argsCount++] = "jill";
     args[argsCount++] = "-P";
     args[argsCount++] = "upthehill";
-    args[argsCount++] = "-p";
 
 #ifndef USE_WINDOWS_API
     /* use port that server has found */
+    args[argsCount++] = "-p";
     snprintf(portNumber, sizeof(portNumber), "%d", ready.port);
     args[argsCount++] = portNumber;
 #endif
@@ -240,6 +240,7 @@ int wolfSSH_SftpTest(int flag)
 
     ThreadJoin(serThread);
     wolfSSH_Cleanup();
+    FreeTcpReady(&ready);
 
     return ret;
 }

--- a/tests/sftp.c
+++ b/tests/sftp.c
@@ -208,7 +208,7 @@ int wolfSSH_SftpTest(int flag)
     ser.signal = &ready;
     InitTcpReady(ser.signal);
     ThreadStart(echoserver_test, (void*)&ser, &serThread);
-    WaitTcpReady(&ser);
+    WaitTcpReady(&ready);
 
     argsCount = 0;
     args[argsCount++] = ".";

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -145,7 +145,7 @@ int wolfSSH_TestsuiteTest(int argc, char** argv)
     serverArgs.signal = &ready;
     serverArgs.user_auth = NULL;
     ThreadStart(echoserver_test, &serverArgs, &serverThread);
-    WaitTcpReady(&serverArgs);
+    WaitTcpReady(&ready);
 
     WSTRNCPY(cA[clientArgc++], "client", ARGLEN);
     WSTRNCPY(cA[clientArgc++], "-u", ARGLEN);


### PR DESCRIPTION
There is a frequent intermittent failure with the Zephyr test. Added a 300ms timeout to the client after waiting for the server ready semaphore, seems to let the server get ready in the failure case for the client to connect.

Made a few changes to clean up the test a little. 