### PR TITLE
Nucleus Patch

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -54,7 +54,11 @@
     #include <wolfssh/misc.h>
 #else
     #define WOLFSSH_MISC_INCLUDED
-    #include "src/misc.c"
+    #if defined(WOLFSSL_NUCLEUS)
+        #include "src/wolfssh_misc.c"
+    #else
+        #include "src/misc.c"
+    #endif
 #endif
 
 
@@ -13849,6 +13853,8 @@ int wolfSSH_CleanPath(WOLFSSH* ssh, char* in)
         if (path[sz - 1] == ':') {
             path[sz] = WS_DELIM;
             path[sz + 1] = '\0';
+            in[sz] = WS_DELIM;
+            in[sz + 1] = '\0';
         }
 
         /* clean up any multiple drive listed i.e. A:/A: */

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -39,7 +39,11 @@
     #include <wolfssh/misc.h>
 #else
     #define WOLFSSH_MISC_INCLUDED
-    #include "src/misc.c"
+    #if defined(WOLFSSL_NUCLEUS)
+        #include "src/wolfssh_misc.c"
+    #else
+        #include "src/misc.c"
+    #endif
 #endif
 
 #ifdef HAVE_FIPS


### PR DESCRIPTION
1. Nucleus builds changed the source file names to have a wolfssh_ prefix. Take that into account for misc.c.
2. Change CleanPath to add a delimiter to the input string.
3. Reorganize the WS_GETtime macros to clean up adding specific items for Nucleus.
4. Add some typecasting on some sizeof.
5. Some whitespace cleanup, and removing a redundant include.

(ZD: 14607, 16671, 16791, 17236)