### PR TITLE
SFTP Test File

### DIFF
--- a/tests/sftp.c
+++ b/tests/sftp.c
@@ -44,17 +44,17 @@ static const char* cmds[] = {
     "pwd",
     "ls",
 #ifdef WOLFSSH_ZEPHYR
-    "put " CONFIG_WOLFSSH_SFTP_DEFAULT_DIR "/configure",
+    "put " CONFIG_WOLFSSH_SFTP_DEFAULT_DIR "/configure.ac",
 #else
-    "put configure",
+    "put configure.ac",
 #endif
     "ls",
 #ifdef WOLFSSH_ZEPHYR
-    "get configure " CONFIG_WOLFSSH_SFTP_DEFAULT_DIR "/test-get",
+    "get configure.ac " CONFIG_WOLFSSH_SFTP_DEFAULT_DIR "/test-get",
 #else
-    "get configure test-get",
+    "get configure.ac test-get",
 #endif
-    "rm configure",
+    "rm configure.ac",
     "cd ../",
     "ls",
     "rename test-get test-get-2",
@@ -116,8 +116,8 @@ static int Expected(int command)
             }
 
         case 6:
-            if (WSTRNSTR(inBuf, "configure", sizeof(inBuf)) == NULL) {
-                fprintf(stderr, "configure not found in %s\n", inBuf);
+            if (WSTRNSTR(inBuf, "configure.ac", sizeof(inBuf)) == NULL) {
+                fprintf(stderr, "configure.ac not found in %s\n", inBuf);
                 return 1;
             }
             else {

--- a/zephyr/samples/tests/tests.c
+++ b/zephyr/samples/tests/tests.c
@@ -81,7 +81,7 @@ int main(void)
     /* Setup the necessary files for the sftp tests */
     fs_file_t_init(&zfp);
     snprintf(filename, sizeof(filename), "%s/%s",
-            CONFIG_WOLFSSH_SFTP_DEFAULT_DIR, "configure");
+            CONFIG_WOLFSSH_SFTP_DEFAULT_DIR, "configure.ac");
     CHECK_TEST_RETURN(fs_open(&zfp, filename, FS_O_WRITE|FS_O_CREATE));
     /* Write some random data to file */
     for (i = 0; i < 10; i++)


### PR DESCRIPTION
Modify the SFTP tests to use the file configure.ac instead of configure. Some environments do not have or use configure. Configure.ac is in the source archive.