### PR TITLE
fix WOLFSSH_NO_RSA

### DIFF
--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -642,7 +642,7 @@ int ClientUseCert(const char* certName)
  * returns 0 on success */
 int ClientSetPrivateKey(const char* privKeyName, int userEcc)
 {
-    int ret;
+    int ret = 0;
 
     if (privKeyName == NULL) {
         if (userEcc) {
@@ -682,7 +682,7 @@ int ClientSetPrivateKey(const char* privKeyName, int userEcc)
  * returns 0 on success */
 int ClientUsePubKey(const char* pubKeyName, int userEcc)
 {
-    int ret;
+    int ret = 0;
 
     if (pubKeyName == NULL) {
         byte* p = userPublicKey;

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1128,6 +1128,7 @@ THREAD_RETURN WOLFSSH_THREAD sftpclient_test(void* args)
     socklen_t clientAddrSz = sizeof(clientAddr);
     int ret;
     int ch;
+    int userEcc = 0;
     /* int peerEcc = 0; */
     word16 port = wolfSshPort;
     char* host = (char*)wolfSshIp;
@@ -1262,7 +1263,7 @@ THREAD_RETURN WOLFSSH_THREAD sftpclient_test(void* args)
     }
 #endif
 
-    ret = ClientSetPrivateKey(privKeyName, 0);
+    ret = ClientSetPrivateKey(privKeyName, userEcc);
     if (ret != 0) {
         err_sys("Error setting private key");
     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -6829,7 +6829,7 @@ static int DoChannelOpen(WOLFSSH* ssh,
     word32 typeSz;
     char type[32];
     byte typeId = ID_UNKNOWN;
-    word32 peerChannelId;
+    word32 peerChannelId = 0;
     word32 peerInitialWindowSz;
     word32 peerMaxPacketSz;
 #ifdef WOLFSSH_FWD

--- a/src/internal.c
+++ b/src/internal.c
@@ -1034,6 +1034,7 @@ int IdentifyAsn1Key(const byte* in, word32 inSz, int isPrivate, void* heap)
 }
 
 
+#ifndef WOLFSSH_NO_RSA
 /*
  * Utility function to read an Mpint from the stream directly into a mp_int.
  */
@@ -1052,7 +1053,6 @@ static INLINE int GetMpintToMp(mp_int* mp,
 }
 
 
-#ifndef WOLFSSH_NO_RSA
 /*
  * For the given RSA key, calculate p^-1 and q^-1. wolfCrypt's RSA
  * code expects them, but the OpenSSH format key doesn't store them.

--- a/tests/api.c
+++ b/tests/api.c
@@ -746,6 +746,7 @@ static void test_wolfSSH_ReadKey(void)
 #ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP256
 
     /* OpenSSH Format, ecdsa-sha2-nistp256, private, need alloc */
+    (void)keyCheck;
     key = NULL;
     keySz = 0;
     keyType = NULL;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1204,9 +1204,11 @@ WOLFSSH_LOCAL int wsScpSendCallback(WOLFSSH*, int, const char*, char*, word32,
 
 
 WOLFSSH_LOCAL int wolfSSH_CleanPath(WOLFSSH* ssh, char* in);
+#ifndef WOLFSSH_NO_RSA
 WOLFSSH_LOCAL int wolfSSH_RsaVerify(byte *sig, word32 sigSz,
         const byte* digest, word32 digestSz,
         RsaKey* key, void* heap, const char* loc);
+#endif
 WOLFSSH_LOCAL void DumpOctetString(const byte*, word32);
 WOLFSSH_LOCAL int wolfSSH_oct2dec(WOLFSSH* ssh, byte* oct, word32 octSz);
 WOLFSSH_LOCAL void AddAssign64(word32*, word32);


### PR DESCRIPTION
Fix WOLFSSH_NO_RSA case
wolfssl
 $ ./configure --enable-ssh --enable-rsa=no

wolfssh
 $ ./configure --with-wolfssl=/usr/local/ CFLAGS="-DWOLFSSH_NO_RSA"
