### PR TITLE
Cipher List Configuration

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -69,6 +69,11 @@ Flags:
     use of the function if the flag isn't set. If using wolfCrypt v4.5.0 or
     later, and not building with configure, set this flag.
     default: off
+  WOLFSSH_NO_SHA1_SOFT_DISABLE
+    SHA-1 is normally soft-disabled. The default configuration will not
+    advertise the availability of SHA-1 based algorithms during KEX. SHA-1
+    algorithms still work. Setting this flag will advertise SHA-1 based
+    algorithms during KEX by default.
   WOLFSSH_NO_SHA1
     Set when SHA1 is disabled. Set to disable use of SHA1 in HMAC and digital
     signature support.
@@ -3025,29 +3030,33 @@ static const byte cannedMacAlgo[] = {
 #ifndef WOLFSSH_NO_HMAC_SHA2_256
     ID_HMAC_SHA2_256,
 #endif
-#ifndef WOLFSSH_NO_HMAC_SHA1_96
-    ID_HMAC_SHA1_96,
-#endif
-#ifndef WOLFSSH_NO_HMAC_SHA1
-    ID_HMAC_SHA1,
-#endif
+#ifdef WOLFSSH_NO_SHA1_SOFT_DISABLE
+    #ifndef WOLFSSH_NO_HMAC_SHA1_96
+        ID_HMAC_SHA1_96,
+    #endif
+    #ifndef WOLFSSH_NO_HMAC_SHA1
+        ID_HMAC_SHA1,
+    #endif
+#endif /* WOLFSSH_NO_SHA1_SOFT_DISABLE */
 };
 
 static const byte  cannedKeyAlgoClient[] = {
 #ifdef WOLFSSH_CERTS
-#ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP521
-    ID_X509V3_ECDSA_SHA2_NISTP521,
-#endif
-#ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP384
-    ID_X509V3_ECDSA_SHA2_NISTP384,
-#endif
-#ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP256
-    ID_X509V3_ECDSA_SHA2_NISTP256,
-#endif
-#ifndef WOLFSSH_NO_SSH_RSA_SHA1
-    ID_X509V3_SSH_RSA,
-#endif
-#endif
+    #ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP521
+        ID_X509V3_ECDSA_SHA2_NISTP521,
+    #endif
+    #ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP384
+        ID_X509V3_ECDSA_SHA2_NISTP384,
+    #endif
+    #ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP256
+        ID_X509V3_ECDSA_SHA2_NISTP256,
+    #endif
+    #ifdef WOLFSSH_NO_SHA1_SOFT_DISABLE
+        #ifndef WOLFSSH_NO_SSH_RSA_SHA1
+            ID_X509V3_SSH_RSA,
+        #endif /* WOLFSSH_NO_SSH_RSA_SHA1 */
+    #endif /* WOLFSSH_NO_SHA1_SOFT_DISABLE */
+#endif /* WOLFSSH_CERTS */
 #ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP521
     ID_ECDSA_SHA2_NISTP521,
 #endif
@@ -3063,9 +3072,11 @@ static const byte  cannedKeyAlgoClient[] = {
 #ifndef WOLFSSH_NO_RSA_SHA2_256
     ID_RSA_SHA2_256,
 #endif
-#ifndef WOLFSSH_NO_SSH_RSA_SHA1
-    ID_SSH_RSA,
-#endif
+#ifdef WOLFSSH_NO_SHA1_SOFT_DISABLE
+    #ifndef WOLFSSH_NO_SSH_RSA_SHA1
+        ID_SSH_RSA,
+    #endif /* WOLFSSH_NO_SSH_RSA_SHA1 */
+#endif /* WOLFSSH_NO_SHA1_SOFT_DISABLE */
 };
 
 static const byte cannedKexAlgo[] = {
@@ -3084,12 +3095,14 @@ static const byte cannedKexAlgo[] = {
 #ifndef WOLFSSH_NO_DH_GEX_SHA256
     ID_DH_GEX_SHA256,
 #endif
-#ifndef WOLFSSH_NO_DH_GROUP14_SHA1
-    ID_DH_GROUP14_SHA1,
-#endif
-#ifndef WOLFSSH_NO_DH_GROUP1_SHA1
-    ID_DH_GROUP1_SHA1,
-#endif
+#ifdef WOLFSSH_NO_SHA1_SOFT_DISABLE
+    #ifndef WOLFSSH_NO_DH_GROUP14_SHA1
+        ID_DH_GROUP14_SHA1,
+    #endif
+    #ifndef WOLFSSH_NO_DH_GROUP1_SHA1
+        ID_DH_GROUP1_SHA1,
+    #endif
+#endif /* WOLFSSH_NO_SHA1_SOFT_DISABLE */
 };
 
 static const word32 cannedEncAlgoSz = (word32)sizeof(cannedEncAlgo);
@@ -8865,12 +8878,14 @@ static const char cannedMacAlgoNames[] =
 #if !defined(WOLFSSH_NO_HMAC_SHA2_256)
     "hmac-sha2-256,"
 #endif
-#if !defined(WOLFSSH_NO_HMAC_SHA1_96)
-    "hmac-sha1-96,"
-#endif
-#if !defined(WOLFSSH_NO_HMAC_SHA1)
-    "hmac-sha1,"
-#endif
+#if defined(WOLFSSH_NO_SHA1_SOFT_DISABLE)
+    #if !defined(WOLFSSH_NO_HMAC_SHA1_96)
+        "hmac-sha1-96,"
+    #endif
+    #if !defined(WOLFSSH_NO_HMAC_SHA1)
+        "hmac-sha1,"
+    #endif
+#endif /* WOLFSSH_NO_SHA1_SOFT_DISABLE */
     "";
 
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -722,6 +722,7 @@ WOLFSSH_CTX* CtxInit(WOLFSSH_CTX* ctx, byte side, void* heap)
     }
     ctx->algoListCipher = cannedEncAlgoNames;
     ctx->algoListMac = cannedMacAlgoNames;
+    ctx->algoListKeyAccepted = cannedKeyAlgoNames;
 
     count = (word32)(sizeof(ctx->privateKey)
             / sizeof(ctx->privateKey[0]));
@@ -894,6 +895,7 @@ WOLFSSH* SshInit(WOLFSSH* ssh, WOLFSSH_CTX* ctx)
     ssh->algoListKey = ctx->algoListKey;
     ssh->algoListCipher = ctx->algoListCipher;
     ssh->algoListMac = ctx->algoListMac;
+    ssh->algoListKeyAccepted = ctx->algoListKeyAccepted;
 #ifdef WOLFSSH_SCP
     ssh->scpRequestState = SCP_PARSE_COMMAND;
     ssh->scpConfirmMsg   = NULL;
@@ -11232,7 +11234,7 @@ int SendExtInfo(WOLFSSH* ssh)
 {
     byte* output;
     word32 idx;
-    word32 cannedKeyAlgoNamesSz = 0;
+    word32 keyAlgoNamesSz = 0;
     word32 serverSigAlgsNameSz = 0;
     int ret = WS_SUCCESS;
 
@@ -11243,10 +11245,10 @@ int SendExtInfo(WOLFSSH* ssh)
     }
 
     if (ret == WS_SUCCESS) {
-        cannedKeyAlgoNamesSz = AlgoListSz(cannedKeyAlgoNames);
+        keyAlgoNamesSz = AlgoListSz(ssh->algoListKeyAccepted);
         serverSigAlgsNameSz = AlgoListSz(serverSigAlgsName);
         ret = PreparePacket(ssh, MSG_ID_SZ + UINT32_SZ + (LENGTH_SZ * 2)
-                + serverSigAlgsNameSz + cannedKeyAlgoNamesSz);
+                + serverSigAlgsNameSz + keyAlgoNamesSz);
     }
 
     if (ret == WS_SUCCESS) {
@@ -11262,10 +11264,10 @@ int SendExtInfo(WOLFSSH* ssh)
         WMEMCPY(output + idx, serverSigAlgsName, serverSigAlgsNameSz);
         idx += serverSigAlgsNameSz;
 
-        c32toa(cannedKeyAlgoNamesSz, output + idx);
+        c32toa(keyAlgoNamesSz, output + idx);
         idx += LENGTH_SZ;
-        WMEMCPY(output + idx, cannedKeyAlgoNames, cannedKeyAlgoNamesSz);
-        idx += cannedKeyAlgoNamesSz;
+        WMEMCPY(output + idx, ssh->algoListKeyAccepted, keyAlgoNamesSz);
+        idx += keyAlgoNamesSz;
 
         ssh->outputBuffer.length = idx;
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1932,21 +1932,6 @@ int wolfSSH_ReadKey_file(const char* name,
 #endif
 
 
-int wolfSSH_CheckAlgoName(const char* name)
-{
-    int ret = WS_INVALID_ALGO_ID;
-
-    if (name) {
-        word32 nameSz = (word32)WSTRLEN(name);
-        if (NameToId(name, nameSz) != ID_UNKNOWN) {
-            ret = WS_SUCCESS;
-        }
-    }
-
-    return ret;
-}
-
-
 int wolfSSH_CTX_SetAlgoListKex(WOLFSSH_CTX* ctx, const char* list)
 {
     int ret = WS_SSH_CTX_NULL_E;
@@ -2144,6 +2129,21 @@ const char* wolfSSH_GetAlgoListMac(WOLFSSH* ssh)
     }
 
     return list;
+}
+
+
+int wolfSSH_CheckAlgoName(const char* name)
+{
+    int ret = WS_INVALID_ALGO_ID;
+
+    if (name) {
+        word32 nameSz = (word32)WSTRLEN(name);
+        if (NameToId(name, nameSz) != ID_UNKNOWN) {
+            ret = WS_SUCCESS;
+        }
+    }
+
+    return ret;
 }
 
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -2132,6 +2132,56 @@ const char* wolfSSH_GetAlgoListMac(WOLFSSH* ssh)
 }
 
 
+int wolfSSH_CTX_SetAlgoListKeyAccepted(WOLFSSH_CTX* ctx, const char* list)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx) {
+        ctx->algoListKeyAccepted = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_CTX_GetAlgoListKeyAccepted(WOLFSSH_CTX* ctx)
+{
+    const char* list = NULL;
+
+    if (ctx) {
+        list = ctx->algoListKeyAccepted;
+    }
+
+    return list;
+}
+
+
+int wolfSSH_SetAlgoListKeyAccepted(WOLFSSH* ssh, const char* list)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh) {
+        ssh->algoListKeyAccepted = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_GetAlgoListKeyAccepted(WOLFSSH* ssh)
+{
+    const char* list = NULL;
+
+    if (ssh) {
+        list = ssh->algoListKeyAccepted;
+    }
+
+    return list;
+}
+
+
 int wolfSSH_CheckAlgoName(const char* name)
 {
     int ret = WS_INVALID_ALGO_ID;

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1903,10 +1903,6 @@ int wolfSSH_ReadKey_file(const char* name,
             format = WOLFSSH_FORMAT_SSH;
             in[inSz] = 0;
         }
-#if 0
-        else if (WSTRNSTR((const char*)in, PrivBeginOpenSSH, inSz) != NULL &&
-                WSTRNSTR((const char*)in, PrivEndOpenSSH, inSz) != NULL) {
-#endif
         else if (WSTRNSTR((const char*)in, PrivBeginOpenSSH, inSz) != NULL) {
             *isPrivate = 1;
             format = WOLFSSH_FORMAT_OPENSSH;
@@ -1934,6 +1930,246 @@ int wolfSSH_ReadKey_file(const char* name,
 }
 
 #endif
+
+
+int wolfSSH_CheckAlgoName(const char* name)
+{
+    int ret = WS_INVALID_ALGO_ID;
+
+    if (name) {
+        word32 nameSz = (word32)WSTRLEN(name);
+        if (NameToId(name, nameSz) != ID_UNKNOWN) {
+            ret = WS_SUCCESS;
+        }
+    }
+
+    return ret;
+}
+
+
+int wolfSSH_CTX_SetAlgoListKex(WOLFSSH_CTX* ctx, const char* list)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx) {
+        ctx->algoListKex = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_CTX_GetAlgoListKex(WOLFSSH_CTX* ctx)
+{
+    const char* list = NULL;
+
+    if (ctx) {
+        list = ctx->algoListKex;
+    }
+
+    return list;
+}
+
+
+int wolfSSH_SetAlgoListKex(WOLFSSH* ssh, const char* list)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh) {
+        ssh->algoListKex = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_GetAlgoListKex(WOLFSSH* ssh)
+{
+    const char* list = NULL;
+
+    if (ssh) {
+        list = ssh->algoListKex;
+    }
+
+    return list;
+}
+
+
+int wolfSSH_CTX_SetAlgoListKey(WOLFSSH_CTX* ctx, const char* list)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx) {
+        ctx->algoListKey = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_CTX_GetAlgoListKey(WOLFSSH_CTX* ctx)
+{
+    const char* list = NULL;
+
+    if (ctx) {
+        list = ctx->algoListKey;
+    }
+
+    return list;
+}
+
+
+int wolfSSH_SetAlgoListKey(WOLFSSH* ssh, const char* list)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh) {
+        ssh->algoListKey = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_GetAlgoListKey(WOLFSSH* ssh)
+{
+    const char* list = NULL;
+
+    if (ssh) {
+        list = ssh->algoListKey;
+    }
+
+    return list;
+}
+
+
+int wolfSSH_CTX_SetAlgoListCipher(WOLFSSH_CTX* ctx, const char* list)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx) {
+        ctx->algoListCipher = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_CTX_GetAlgoListCipher(WOLFSSH_CTX* ctx)
+{
+    const char* list = NULL;
+
+    if (ctx) {
+        list = ctx->algoListCipher;
+    }
+
+    return list;
+}
+
+
+int wolfSSH_SetAlgoListCipher(WOLFSSH* ssh, const char* list)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh) {
+        ssh->algoListCipher = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_GetAlgoListCipher(WOLFSSH* ssh)
+{
+    const char* list = NULL;
+
+    if (ssh) {
+        list = ssh->algoListCipher;
+    }
+
+    return list;
+}
+
+
+int wolfSSH_CTX_SetAlgoListMac(WOLFSSH_CTX* ctx, const char* list)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx) {
+        ctx->algoListMac = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_CTX_GetAlgoListMac(WOLFSSH_CTX* ctx)
+{
+    const char* list = NULL;
+
+    if (ctx) {
+        list = ctx->algoListMac;
+    }
+
+    return list;
+}
+
+
+int wolfSSH_SetAlgoListMac(WOLFSSH* ssh, const char* list)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh) {
+        ssh->algoListMac = list;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+const char* wolfSSH_GetAlgoListMac(WOLFSSH* ssh)
+{
+    const char* list = NULL;
+
+    if (ssh) {
+        list = ssh->algoListMac;
+    }
+
+    return list;
+}
+
+
+const char* wolfSSH_QueryKex(word32* index)
+{
+    return NameByIndexType(TYPE_KEX, index);
+}
+
+
+const char* wolfSSH_QueryKey(word32* index)
+{
+    return NameByIndexType(TYPE_KEY, index);
+}
+
+
+const char* wolfSSH_QueryCipher(word32* index)
+{
+    return NameByIndexType(TYPE_CIPHER, index);
+}
+
+
+const char* wolfSSH_QueryMac(word32* index)
+{
+    return NameByIndexType(TYPE_MAC, index);
+}
+
 
 int wolfSSH_CTX_SetBanner(WOLFSSH_CTX* ctx,
                           const char* newBanner)

--- a/tests/api.c
+++ b/tests/api.c
@@ -120,13 +120,13 @@ char* myoptarg = NULL;
 #define AssertStrLE(x, y) AssertStr(x, y, <=,  >)
 
 #define AssertPtr(x, y, op, er) do {                                           \
-    PRAGMA_GCC_DIAG_PUSH;                                                      \
+    PRAGMA_GCC_DIAG_PUSH                                                       \
       /* remarkably, without this inhibition, */                               \
       /* the _Pragma()s make the declarations warn. */                         \
-    PRAGMA_GCC("GCC diagnostic ignored \"-Wdeclaration-after-statement\"");    \
+    PRAGMA_GCC("GCC diagnostic ignored \"-Wdeclaration-after-statement\"")     \
       /* inhibit "ISO C forbids conversion of function pointer */              \
       /* to object pointer type [-Werror=pedantic]" */                         \
-    PRAGMA_GCC("GCC diagnostic ignored \"-Wpedantic\"");                       \
+    PRAGMA_GCC("GCC diagnostic ignored \"-Wpedantic\"")                        \
     void* _x = (void*)(x);                                                     \
     void* _y = (void*)(y);                                                     \
     Assert(_x op _y, ("%s " #op " %s", #x, #y), ("%p " #er " %p", _x, _y));    \

--- a/tests/api.c
+++ b/tests/api.c
@@ -1309,82 +1309,248 @@ static void test_wolfSSH_RealPath(void) { ; }
 
 static void test_wolfSSH_SetAlgoList(void)
 {
-    const char* list = "aes128-ctr,aes128-cbc";
-    const char* checkList = NULL;
+    const char* newKexList = "diffie-hellman-group1-sha1,ecdh-sha2-nistp521";
+    const char* newKeyList = "rsa-sha2-512,ecdsa-sha2-nistp521";
+    const char* newCipherList = "aes128-ctr,aes128-cbc";
+    const char* newMacList = "hmac-sha1";
+    const char* newKeyAccList = "ssh-rsa";
+    const char* defaultKexList = NULL;
+    const char* defaultKeyList = NULL;
+    const char* defaultCipherList = NULL;
+    const char* defaultMacList = NULL;
+    const char* defaultKeyAccList = NULL;
+    const char* checkKexList = NULL;
+    const char* checkKeyList = NULL;
+    const char* checkCipherList = NULL;
+    const char* checkMacList = NULL;
+    const char* checkKeyAccList = NULL;
+    const char* rawKey = NULL;
     WOLFSSH_CTX* ctx;
     WOLFSSH* ssh;
+    byte* key;
+    word32 keySz;
 
+    /* Create a ctx object. */
     ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_CLIENT, NULL);
+    AssertNotNull(ctx);
+
+    /* Check that the ctx's default algo lists are not null */
+    defaultKexList = wolfSSH_CTX_GetAlgoListKex(ctx);
+    AssertNotNull(defaultKexList);
+
+    defaultKeyList = wolfSSH_CTX_GetAlgoListKey(ctx);
+    AssertNotNull(defaultKeyList);
+
+    defaultCipherList = wolfSSH_CTX_GetAlgoListCipher(ctx);
+    AssertNotNull(defaultCipherList);
+
+    defaultMacList = wolfSSH_CTX_GetAlgoListMac(ctx);
+    AssertNotNull(defaultMacList);
+
+    defaultKeyAccList = wolfSSH_CTX_GetAlgoListKeyAccepted(ctx);
+    AssertNotNull(defaultKeyAccList);
+
+    /* Create a new ssh object. */
     ssh = wolfSSH_new(ctx);
+    AssertNotNull(ssh);
 
-    wolfSSH_SetAlgoListCipher(ssh, list);
-    checkList = wolfSSH_GetAlgoListCipher(ssh);
+    /* Check that the ssh's default algo lists match the ctx's algo lists. */
+    checkKexList = wolfSSH_GetAlgoListKex(ssh);
+    AssertPtrEq(checkKexList, defaultKexList);
 
-    if (checkList != list) {
-        printf("Didn't get back the correct list.\n");
-    }
+    checkKeyList = wolfSSH_GetAlgoListKey(ssh);
+    AssertPtrEq(checkKeyList, defaultKeyList);
 
+    checkCipherList = wolfSSH_GetAlgoListCipher(ssh);
+    AssertPtrEq(checkCipherList, defaultCipherList);
+
+    checkMacList = wolfSSH_GetAlgoListMac(ssh);
+    AssertPtrEq(checkMacList, defaultMacList);
+
+    checkKeyAccList = wolfSSH_GetAlgoListKeyAccepted(ssh);
+    AssertPtrEq(checkKeyAccList, defaultKeyAccList);
+
+    /* Set the ssh's algo lists, check they match new value. */
+    wolfSSH_SetAlgoListKex(ssh, newKexList);
+    checkKexList = wolfSSH_GetAlgoListKex(ssh);
+    AssertPtrEq(checkKexList, newKexList);
+
+    wolfSSH_SetAlgoListKey(ssh, newKeyList);
+    checkKeyList = wolfSSH_GetAlgoListKey(ssh);
+    AssertPtrEq(checkKeyList, newKeyList);
+
+    wolfSSH_SetAlgoListCipher(ssh, newCipherList);
+    checkCipherList = wolfSSH_GetAlgoListCipher(ssh);
+    AssertPtrEq(checkCipherList, newCipherList);
+
+    wolfSSH_SetAlgoListMac(ssh, newMacList);
+    checkMacList = wolfSSH_GetAlgoListMac(ssh);
+    AssertPtrEq(checkMacList, newMacList);
+
+    wolfSSH_SetAlgoListKeyAccepted(ssh, newKeyAccList);
+    checkKeyAccList = wolfSSH_GetAlgoListKeyAccepted(ssh);
+    AssertPtrEq(checkKeyAccList, newKeyAccList);
+
+    /* Delete the ssh. */
+    wolfSSH_free(ssh);
+
+    /* Set new algo lists on the ctx. */
+    wolfSSH_CTX_SetAlgoListKex(ctx, newKexList);
+    defaultKexList = wolfSSH_CTX_GetAlgoListKex(ctx);
+    AssertPtrEq(defaultKexList, newKexList);
+
+    wolfSSH_CTX_SetAlgoListKey(ctx, newKeyList);
+    defaultKeyList = wolfSSH_CTX_GetAlgoListKey(ctx);
+    AssertPtrEq(checkKeyList, newKeyList);
+
+    wolfSSH_CTX_SetAlgoListCipher(ctx, newCipherList);
+    defaultCipherList = wolfSSH_CTX_GetAlgoListCipher(ctx);
+    AssertNotNull(defaultCipherList);
+
+    wolfSSH_CTX_SetAlgoListMac(ctx, newMacList);
+    defaultMacList = wolfSSH_CTX_GetAlgoListMac(ctx);
+    AssertNotNull(defaultMacList);
+
+    wolfSSH_CTX_SetAlgoListKeyAccepted(ctx, newKeyAccList);
+    defaultKeyAccList = wolfSSH_CTX_GetAlgoListKeyAccepted(ctx);
+    AssertNotNull(defaultKeyAccList);
+
+    /* Create a new ssh object. */
+    ssh = wolfSSH_new(ctx);
+    AssertNotNull(ssh);
+
+    /* Check that the ssh's default algo lists match the ctx's algo lists. */
+    checkKexList = wolfSSH_GetAlgoListKex(ssh);
+    AssertPtrEq(checkKexList, defaultKexList);
+
+    checkKeyList = wolfSSH_GetAlgoListKey(ssh);
+    AssertPtrEq(checkKeyList, defaultKeyList);
+
+    checkCipherList = wolfSSH_GetAlgoListCipher(ssh);
+    AssertPtrEq(checkCipherList, defaultCipherList);
+
+    checkMacList = wolfSSH_GetAlgoListMac(ssh);
+    AssertPtrEq(checkMacList, defaultMacList);
+
+    checkKeyAccList = wolfSSH_GetAlgoListKeyAccepted(ssh);
+    AssertPtrEq(checkKeyAccList, defaultKeyAccList);
+
+    /* Cleanup */
     wolfSSH_free(ssh);
     wolfSSH_CTX_free(ctx);
+
+    /* Create a ctx object. */
+    ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
+    AssertNotNull(ctx);
+
+    /* Check server ctx's key list is NULL. */
+    defaultKeyList = wolfSSH_CTX_GetAlgoListKey(ctx);
+    AssertNull(defaultKeyList);
+    defaultKeyAccList = wolfSSH_CTX_GetAlgoListKeyAccepted(ctx);
+    AssertNotNull(defaultKeyAccList);
+
+    /* Create a new ssh object. */
+    ssh = wolfSSH_new(ctx);
+    AssertNotNull(ssh);
+
+    /* Check server ssh's key list is NULL. */
+    checkKeyList = wolfSSH_GetAlgoListKey(ssh);
+    AssertNull(checkKeyList);
+
+    /* Delete the ssh. */
+    wolfSSH_free(ssh);
+
+    /* Set key on ctx. */
+#if !defined(WOLFSSH_NO_ECDSA)
+    rawKey = serverKeyEccDer;
+#elif !defined(WOLFSSH_NO_RSA)
+    rawKey = serverKeyRsaDer;
+#endif
+    AssertNotNull(rawKey);
+    AssertIntEQ(0,
+            ConvertHexToBin(rawKey, &key, &keySz,
+                NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL));
+    AssertIntEQ(WS_SUCCESS,
+            wolfSSH_CTX_UsePrivateKey_buffer(ctx,
+                key, keySz, WOLFSSH_FORMAT_ASN1));
+
+    /* Check ctx's key algo list is still null. */
+    checkKeyList = wolfSSH_CTX_GetAlgoListKey(ctx);
+    AssertNull(checkKeyList);
+
+    /* Create a new ssh object. */
+    ssh = wolfSSH_new(ctx);
+    AssertNotNull(ssh);
+
+    /* Check ssh's key algo list is null. */
+    checkKeyList = wolfSSH_GetAlgoListKey(ssh);
+    AssertNull(checkKeyList);
+
+    /* Set a new list on ssh. */
+    wolfSSH_SetAlgoListKey(ssh, newKeyList);
+    checkKeyList = wolfSSH_GetAlgoListKey(ssh);
+    AssertPtrEq(checkKeyList, newKeyList);
+
+    /* Cleanup */
+    wolfSSH_free(ssh);
+    wolfSSH_CTX_free(ctx);
+    FreeBins(key, NULL, NULL, NULL);
 }
 
 
 static void test_wolfSSH_QueryAlgoList(void)
 {
-    word32 i;
     const char* name;
+    word32 i, j;
+    int k;
 
     i = 0;
     name = NULL;
-    printf("KEX:\n");
     do {
-        if (name != NULL) {
-            printf("\t%s\n", name);
-        }
         name = wolfSSH_QueryKex(&i);
+        AssertIntNE(i, 0);
     } while (name != NULL);
 
     i = 0;
     name = NULL;
-    printf("Public key:\n");
     do {
-        if (name != NULL) {
-            printf("\t%s\n", name);
-        }
         name = wolfSSH_QueryKey(&i);
+        AssertIntNE(i, 0);
     } while (name != NULL);
 
     i = 0;
     name = NULL;
-    printf("Cipher:\n");
     do {
-        if (name != NULL) {
-            printf("\t%s\n", name);
-        }
         name = wolfSSH_QueryCipher(&i);
+        AssertIntNE(i, 0);
     } while (name != NULL);
 
     i = 0;
     name = NULL;
-    printf("MAC:\n");
     do {
-        if (name != NULL) {
-            printf("\t%s\n", name);
-        }
         name = wolfSSH_QueryMac(&i);
+        AssertIntNE(i, 0);
     } while (name != NULL);
 
     /* This test case picks up where the index left off. */
+    j = i;
     name = wolfSSH_QueryKex(&i);
-    if (name != NULL) {
-        printf("That's not right.\n");
-    }
+    AssertNull(name);
+    i = j;
+    name = wolfSSH_QueryKey(&i);
+    AssertNull(name);
+    i = j;
+    name = wolfSSH_QueryCipher(&i);
+    AssertNull(name);
+    i = j;
+    name = wolfSSH_QueryMac(&i);
+    AssertNull(name);
 
-    if (wolfSSH_CheckAlgoName("ssh-rsa"))
-        printf("Don't know ssh-rsa.\n");
+    k = wolfSSH_CheckAlgoName("ssh-rsa");
+    AssertIntEQ(WS_SUCCESS, k);
 
-    if (!wolfSSH_CheckAlgoName("foofarah"))
-        printf("Fake algo name found.\n");
+    k = wolfSSH_CheckAlgoName("not-an-algo@wolfssl.com");
+    AssertIntEQ(WS_INVALID_ALGO_ID, k);
 }
 
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -1305,7 +1305,91 @@ static void test_wolfSSH_RealPath(void)
 #else
 static void test_wolfSSH_RealPath(void) { ; }
 #endif
+
+
+static void test_wolfSSH_SetAlgoList(void)
+{
+    const char* list = "aes128-ctr,aes128-cbc";
+    const char* checkList = NULL;
+    WOLFSSH_CTX* ctx;
+    WOLFSSH* ssh;
+
+    ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_CLIENT, NULL);
+    ssh = wolfSSH_new(ctx);
+
+    wolfSSH_SetAlgoListCipher(ssh, list);
+    checkList = wolfSSH_GetAlgoListCipher(ssh);
+
+    if (checkList != list) {
+        printf("Didn't get back the correct list.\n");
+    }
+
+    wolfSSH_free(ssh);
+    wolfSSH_CTX_free(ctx);
+}
+
+
+static void test_wolfSSH_QueryAlgoList(void)
+{
+    word32 i;
+    const char* name;
+
+    i = 0;
+    name = NULL;
+    printf("KEX:\n");
+    do {
+        if (name != NULL) {
+            printf("\t%s\n", name);
+        }
+        name = wolfSSH_QueryKex(&i);
+    } while (name != NULL);
+
+    i = 0;
+    name = NULL;
+    printf("Public key:\n");
+    do {
+        if (name != NULL) {
+            printf("\t%s\n", name);
+        }
+        name = wolfSSH_QueryKey(&i);
+    } while (name != NULL);
+
+    i = 0;
+    name = NULL;
+    printf("Cipher:\n");
+    do {
+        if (name != NULL) {
+            printf("\t%s\n", name);
+        }
+        name = wolfSSH_QueryCipher(&i);
+    } while (name != NULL);
+
+    i = 0;
+    name = NULL;
+    printf("MAC:\n");
+    do {
+        if (name != NULL) {
+            printf("\t%s\n", name);
+        }
+        name = wolfSSH_QueryMac(&i);
+    } while (name != NULL);
+
+    /* This test case picks up where the index left off. */
+    name = wolfSSH_QueryKex(&i);
+    if (name != NULL) {
+        printf("That's not right.\n");
+    }
+
+    if (wolfSSH_CheckAlgoName("ssh-rsa"))
+        printf("Don't know ssh-rsa.\n");
+
+    if (!wolfSSH_CheckAlgoName("foofarah"))
+        printf("Fake algo name found.\n");
+}
+
+
 #endif /* WOLFSSH_TEST_BLOCK */
+
 
 int wolfSSH_ApiTest(int argc, char** argv)
 {
@@ -1337,6 +1421,8 @@ int wolfSSH_ApiTest(int argc, char** argv)
     test_wolfSSH_CTX_UseCert_buffer();
     test_wolfSSH_CertMan();
     test_wolfSSH_ReadKey();
+    test_wolfSSH_QueryAlgoList();
+    test_wolfSSH_SetAlgoList();
 
     /* SCP tests */
     test_wolfSSH_SCP_CB();

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -351,6 +351,11 @@ enum {
 };
 
 
+enum NameIdType {
+    TYPE_KEX, TYPE_KEY, TYPE_CIPHER, TYPE_MAC, TYPE_OTHER
+};
+
+
 #define WOLFSSH_MAX_NAMESZ 32
 
 #ifndef WOLFSSH_MAX_CHN_NAMESZ
@@ -425,8 +430,10 @@ enum {
     #define WOLFSSH_KEY_QUANTITY_REQ 1
 #endif
 
-WOLFSSH_LOCAL byte NameToId(const char*, word32);
-WOLFSSH_LOCAL const char* IdToName(byte);
+
+WOLFSSH_LOCAL byte NameToId(const char* name, word32 nameSz);
+WOLFSSH_LOCAL const char* IdToName(byte id);
+WOLFSSH_LOCAL const char* NameByIndexType(byte type, word32* index);
 
 
 #define STATIC_BUFFER_LEN AES_BLOCK_SIZE
@@ -502,6 +509,10 @@ struct WOLFSSH_CTX {
     word32 highwaterMark;
     const char* banner;
     const char* sshProtoIdStr;
+    const char* algoListKex;
+    const char* algoListKey;
+    const char* algoListCipher;
+    const char* algoListMac;
     word32 bannerSz;
     word32 windowSz;
     word32 maxPacketSz;
@@ -638,6 +649,10 @@ struct WOLFSSH {
     word32 seq;
     word32 peerSeq;
     word32 packetStartIdx; /* Current send packet start index */
+    const char* algoListKex;
+    const char* algoListKey;
+    const char* algoListCipher;
+    const char* algoListMac;
     byte acceptState;
     byte connectState;
     byte clientState;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -67,14 +67,9 @@ extern "C" {
 
 
 /*
- * Force some options. Do not want ssh-rsa with SHA1 at anymore. Not ready
- * for rsa-sha2-512 yet.
+ * Not ready for rsa-sha2-512 yet.
  */
 
-#undef WOLFSSH_NO_SSH_RSA_SHA1
-#ifndef WOLFSSH_YES_SSH_RSA_SHA1
-    #define WOLFSSH_NO_SSH_RSA_SHA1
-#endif
 #undef WOLFSSH_NO_RSA_SHA2_512
 #ifndef WOLFSSH_YES_RSA_SHA2_512
     #define WOLFSSH_NO_RSA_SHA2_512

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -513,6 +513,7 @@ struct WOLFSSH_CTX {
     const char* algoListKey;
     const char* algoListCipher;
     const char* algoListMac;
+    const char* algoListKeyAccepted;
     word32 bannerSz;
     word32 windowSz;
     word32 maxPacketSz;
@@ -653,6 +654,7 @@ struct WOLFSSH {
     const char* algoListKey;
     const char* algoListCipher;
     const char* algoListMac;
+    const char* algoListKeyAccepted;
     byte acceptState;
     byte connectState;
     byte clientState;

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -90,6 +90,34 @@ WOLFSSH_API int wolfSSH_ReadKey_file(const char* name,
         byte** out, word32* outSz, const byte** outType, word32* outTypeSz,
         byte* isPrivate, void* heap);
 
+WOLFSSH_API int wolfSSH_CheckAlgoName(const char* name);
+
+WOLFSSH_API int wolfSSH_CTX_SetAlgoListKex(WOLFSSH_CTX* ctx, const char* list);
+WOLFSSH_API const char* wolfSSH_CTX_GetAlgoListKex(WOLFSSH_CTX* ctx);
+WOLFSSH_API int wolfSSH_SetAlgoListKex(WOLFSSH* ssh, const char* list);
+WOLFSSH_API const char* wolfSSH_GetAlgoListKex(WOLFSSH* ssh);
+
+WOLFSSH_API int wolfSSH_CTX_SetAlgoListKey(WOLFSSH_CTX* ctx, const char* list);
+WOLFSSH_API const char* wolfSSH_CTX_GetAlgoListKey(WOLFSSH_CTX* ctx);
+WOLFSSH_API int wolfSSH_SetAlgoListKey(WOLFSSH* ssh, const char* list);
+WOLFSSH_API const char* wolfSSH_GetAlgoListKey(WOLFSSH* ssh);
+
+WOLFSSH_API int wolfSSH_CTX_SetAlgoListCipher(WOLFSSH_CTX* ctx,
+        const char* list);
+WOLFSSH_API const char* wolfSSH_CTX_GetAlgoListCipher(WOLFSSH_CTX* ctx);
+WOLFSSH_API int wolfSSH_SetAlgoListCipher(WOLFSSH* ssh, const char* list);
+WOLFSSH_API const char* wolfSSH_GetAlgoListCipher(WOLFSSH* ssh);
+
+WOLFSSH_API int wolfSSH_CTX_SetAlgoListMac(WOLFSSH_CTX* ctx, const char* list);
+WOLFSSH_API const char* wolfSSH_CTX_GetAlgoListMac(WOLFSSH_CTX* ctx);
+WOLFSSH_API int wolfSSH_SetAlgoListMac(WOLFSSH* ssh, const char* list);
+WOLFSSH_API const char* wolfSSH_GetAlgoListMac(WOLFSSH* ssh);
+
+WOLFSSH_API const char* wolfSSH_QueryKex(word32* index);
+WOLFSSH_API const char* wolfSSH_QueryKey(word32* index);
+WOLFSSH_API const char* wolfSSH_QueryCipher(word32* index);
+WOLFSSH_API const char* wolfSSH_QueryMac(word32* index);
+
 
 #define WS_CHANNEL_ID_SELF 0
 #define WS_CHANNEL_ID_PEER 1

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -90,8 +90,6 @@ WOLFSSH_API int wolfSSH_ReadKey_file(const char* name,
         byte** out, word32* outSz, const byte** outType, word32* outTypeSz,
         byte* isPrivate, void* heap);
 
-WOLFSSH_API int wolfSSH_CheckAlgoName(const char* name);
-
 WOLFSSH_API int wolfSSH_CTX_SetAlgoListKex(WOLFSSH_CTX* ctx, const char* list);
 WOLFSSH_API const char* wolfSSH_CTX_GetAlgoListKex(WOLFSSH_CTX* ctx);
 WOLFSSH_API int wolfSSH_SetAlgoListKex(WOLFSSH* ssh, const char* list);
@@ -112,6 +110,8 @@ WOLFSSH_API int wolfSSH_CTX_SetAlgoListMac(WOLFSSH_CTX* ctx, const char* list);
 WOLFSSH_API const char* wolfSSH_CTX_GetAlgoListMac(WOLFSSH_CTX* ctx);
 WOLFSSH_API int wolfSSH_SetAlgoListMac(WOLFSSH* ssh, const char* list);
 WOLFSSH_API const char* wolfSSH_GetAlgoListMac(WOLFSSH* ssh);
+
+WOLFSSH_API int wolfSSH_CheckAlgoName(const char* name);
 
 WOLFSSH_API const char* wolfSSH_QueryKex(word32* index);
 WOLFSSH_API const char* wolfSSH_QueryKey(word32* index);

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -111,6 +111,12 @@ WOLFSSH_API const char* wolfSSH_CTX_GetAlgoListMac(WOLFSSH_CTX* ctx);
 WOLFSSH_API int wolfSSH_SetAlgoListMac(WOLFSSH* ssh, const char* list);
 WOLFSSH_API const char* wolfSSH_GetAlgoListMac(WOLFSSH* ssh);
 
+WOLFSSH_API int wolfSSH_CTX_SetAlgoListKeyAccepted(WOLFSSH_CTX* ctx,
+        const char* list);
+WOLFSSH_API const char* wolfSSH_CTX_GetAlgoListKeyAccepted(WOLFSSH_CTX* ctx);
+WOLFSSH_API int wolfSSH_SetAlgoListKeyAccepted(WOLFSSH* ssh, const char* list);
+WOLFSSH_API const char* wolfSSH_GetAlgoListKeyAccepted(WOLFSSH* ssh);
+
 WOLFSSH_API int wolfSSH_CheckAlgoName(const char* name);
 
 WOLFSSH_API const char* wolfSSH_QueryKex(word32* index);


### PR DESCRIPTION
1. Add APIs to change the cipher lists used in the KEX init messages.
2. Add APIs to query the possible built in algorithms.
3. Reinstate the SHA-1 algorithm, but soft-disable it. It isn't offered by default but the user can set it for use.
(ZD 17568, Issue #659)