### PR TITLE
SFTP Fix

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1196,11 +1196,8 @@ static int sftp_worker(thread_ctx_t* threadCtx)
         }
         else if (selected == WS_SELECT_TIMEOUT) {
             timeout = TEST_SFTP_TIMEOUT_LONG;
-            continue;
         }
-
-        if (ret == WS_WANT_READ || ret == WS_WANT_WRITE ||
-                selected == WS_SELECT_RECV_READY) {
+        else if (selected == WS_SELECT_RECV_READY) {
             ret = wolfSSH_worker(ssh, NULL);
             error = wolfSSH_get_error(ssh);
             if (ret == WS_REKEYING) {
@@ -1213,7 +1210,6 @@ static int sftp_worker(thread_ctx_t* threadCtx)
                 error == WS_WINDOW_FULL) {
                 timeout = TEST_SFTP_TIMEOUT;
                 ret = error;
-                continue;
             }
 
             if (error == WS_EOF) {


### PR DESCRIPTION
# Description

The goal is that when there isn't data waiting on the socket, check and process the data in the SFTP channel's buffer, always.

1. Remove the continue from the SFTP worker loop when there's a timeout on the select and when there's a want_read from the wolfSSH_worker.
2. When the select has receive data ready, check it. Don't make it conditional on want read as well.

# Testing

```
./configure --enable-sftp && make clean && make
./examples/echoserver/echoserver
```

From another directory run the SFTP client:

```
sftp -P 22222 jill@localhost
Password: upthehill
get configure
```

I was able to copy the files configure, configure.ac, README.md, and a 6GB iso image I had floating around.