### PR TITLE
Messaging Filtering

### DIFF
--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -132,8 +132,9 @@ enum WS_ErrorCodes {
     WS_KEY_CHECK_VAL_E      = -1091, /* OpenSSH key check value fail */
     WS_KEY_FORMAT_E         = -1092, /* OpenSSH key format fail */
     WS_SFTP_NOT_FILE_E      = -1093, /* Not a regular file */
+    WS_MSGID_NOT_ALLOWED_E  = -1094, /* Message not allowed before userauth */
     
-    WS_LAST_E               = -1093  /* Update this to indicate last error */
+    WS_LAST_E               = -1094  /* Update this to indicate last error */
 };
 
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1087,6 +1087,20 @@ enum WS_MessageIds {
 };
 
 
+#define MSGID_KEXDH_LIMIT 30
+
+/* The endpoints should not allow message IDs greater than or
+ * equal to msgid 80 before user authentication is complete.
+ * Per RFC 4252 section 6. */
+#define MSGID_USERAUTH_LIMIT 80
+
+/* The client should only send the user auth request message
+ * (50), it should not accept it. The server should only receive
+ * the user auth request message, it should not accept the other
+ * user auth messages, it sends them. (>50) */
+#define MSGID_USERAUTH_RESTRICT 50
+
+
 #define CHANNEL_EXTENDED_DATA_STDERR WOLFSSH_EXT_DATA_STDERR
 
 


### PR DESCRIPTION
1. Add an error code and string for the message filtering fail.
2. Add a function to check incoming message IDs for appropriateness during the client or server handshake.
(ZD 17710)