### PR TITLE
Prepare Release v1.4.17

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,7 +24,7 @@
   functions to inspect which algorithms are set or are available to use.
 * In v1.4.15, we had disabled SHA-1 in the build by default. SHA-1 has been
   re-enabled in the build and is now "soft" disabled, where algorithms using
-  it can put configured for KEX.
+  it can be configured for KEX.
 * Add Curve25519 KEX support for server/client key agreement.
 
 ## Improvements

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,55 @@
+# wolfSSH v1.4.17 (March 22, 2024)
+
+## Vulnerabilities
+
+* Fixes a vulnerability where a properly crafted SSH client can bypass user
+  authentication in the wolfSSH server code. The added fix filters the
+  messages that are allowed during different operational states.
+
+## Notes
+
+* When building wolfSSL/wolfCrypt versions before v5.6.6 with CMake,
+  wolfSSH may have a problem with RSA keys. This is due to wolfSSH not
+  checking on the size of `___uint128_t`. wolfSSH sees the RSA structure
+  as the wrong size. You will have to define `HAVE___UINT128_T` if you
+  know you have it and are using it in wolfSSL. wolfSSL v5.6.6 exports that
+  define in options.h when using CMake.
+* The example server in directory examples/server/server.c has been removed.
+  It was never kept up to date, the echoserver did its job as an example and
+  test server.
+
+## New Features
+
+* Added functions to set algorithms lists for KEX at run-time, and some
+  functions to inspect which algorithms are set or are available to use.
+* In v1.4.15, we had disabled SHA-1 in the build by default. SHA-1 has been
+  re-enabled in the build and is now "soft" disabled, where algorithms using
+  it can put configured for KEX.
+* Add Curve25519 KEX support for server/client key agreement.
+
+## Improvements
+
+* Clean up some issues when building for Nucleus.
+* Clean up some issues when building for Windows.
+* Clean up some issues when building for QNX.
+* Added more wolfSSHd testing.
+* Added more appropriate build option guard checking.
+* General improvements for the ESP32 builds.
+* Better terminal support in Windows.
+* Better I/O pipes and return codes when running commands or scripts over an
+  SSH connection.
+
+## Fixes
+
+* Fix shell terminal window resizing and it sets up the environment better.
+* Fix some corner cases with the SFTP testing.
+* Fix some corner cases with SFTP in general.
+* Fix verifying RSA signatures.
+* Add masking of file mode bits for Zephyr.
+* Fix leak of terminal modes cache.
+
+---
+
 # wolfSSH v1.4.15 (December 22, 2023)
 
 ## Vulnerabilities

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# wolfSSH v1.4.17 (March 22, 2024)
+# wolfSSH v1.4.17 (March 25, 2024)
 
 ## Vulnerabilities
 

--- a/apps/wolfssh/common.c
+++ b/apps/wolfssh/common.c
@@ -1,6 +1,6 @@
 /* common.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/apps/wolfssh/common.c
+++ b/apps/wolfssh/common.c
@@ -451,7 +451,8 @@ int ClientPublicKeyCheck(const byte* pubKey, word32 pubKeySz, void* ctx)
                                 current->ipString);
                             WLOG(WS_LOG_DEBUG,
                                 "\texpecting host IP : %s", (char*)ctx);
-                            if (XSTRCMP(ctx, current->ipString) == 0) {
+                            if (XSTRCMP((const char*)ctx,
+                                        current->ipString) == 0) {
                                 WLOG(WS_LOG_DEBUG, "\tmatched!");
                                 ipMatch = 1;
                             }

--- a/apps/wolfssh/common.h
+++ b/apps/wolfssh/common.h
@@ -1,6 +1,6 @@
 /* common.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -794,7 +794,7 @@ static int config_parse_command_line(struct config* config,
                 free(config->user);
             }
             sz = WSTRLEN(cursor);
-            config->user = WMALLOC(sz + 1, NULL, 0);
+            config->user = (char*)WMALLOC(sz + 1, NULL, 0);
             strcpy(config->user, cursor);
             cursor = found + 1;
         }

--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -1,6 +1,6 @@
 /* wolfssh.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -1,6 +1,6 @@
 /* auth.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/apps/wolfsshd/auth.h
+++ b/apps/wolfsshd/auth.h
@@ -1,6 +1,6 @@
 /* auth.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/apps/wolfsshd/configuration.c
+++ b/apps/wolfsshd/configuration.c
@@ -1,6 +1,6 @@
 /* configuration.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/apps/wolfsshd/configuration.h
+++ b/apps/wolfsshd/configuration.h
@@ -1,6 +1,6 @@
 /* configuration.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1391,8 +1391,9 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
 #if defined(HAVE_SYS_IOCTL_H)
     wolfSSH_DoModes(ssh->modes, ssh->modesSz, childFd);
     {
-        struct winsize s = {0};
+        struct winsize s;
 
+        WMEMSET(&s, 0, sizeof(s));
         s.ws_col = ssh->widthChar;
         s.ws_row = ssh->heightRows;
         s.ws_xpixel = ssh->widthPixels;

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1,6 +1,6 @@
 /* wolfsshd.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # All right reserved.
 
 AC_COPYRIGHT([Copyright (C) 2014-2024 wolfSSL Inc.])
-AC_INIT([wolfssh],[1.4.16],[support@wolfssl.com],[wolfssh],[https://www.wolfssl.com])
+AC_INIT([wolfssh],[1.4.17],[support@wolfssl.com],[wolfssh],[https://www.wolfssl.com])
 AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -18,18 +18,19 @@ AC_ARG_PROGRAM
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 
-WOLFSSH_LIBRARY_VERSION=15:3:8
-#                       | | |
-#                +------+ | +---+
-#                |        |     |
+WOLFSSH_LIBRARY_VERSION=16:0:9
+#                        | | |
+#                  +-----+ | +----+
+#                  |       |      |
 #               current:revision:age
-#                |        |     |
-#                |        |     +- increment if interfaces have been added
-#                |        |        set to zero if interfaces have been removed
-#                |        |        or changed
-#                |        +- increment if source code has changed
-#                |           set to zero if current is incremented
-#                +- increment if interfaces have been added, removed or changed
+#                  |       |      |
+#                  |       |      +- increment if interfaces have been added
+#                  |       |      +- set to zero if interfaces have been
+#                  |       |           removed or changed
+#                  |       +- increment if source code has changed
+#                  |       +- set to zero if current is incremented
+#                  +- increment if interfaces have been added, removed
+#                       or changed
 AC_SUBST([WOLFSSH_LIBRARY_VERSION])
 
 LT_PREREQ([2.2])

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 # wolfssh
-# Copyright (C) 2014-2023 wolfSSL Inc.
+# Copyright (C) 2014-2024 wolfSSL Inc.
 # All right reserved.
 
-AC_COPYRIGHT([Copyright (C) 2014-2023 wolfSSL Inc.])
+AC_COPYRIGHT([Copyright (C) 2014-2024 wolfSSL Inc.])
 AC_INIT([wolfssh],[1.4.16],[support@wolfssl.com],[wolfssh],[https://www.wolfssl.com])
 AC_PREREQ([2.63])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1,6 +1,6 @@
 /* client.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/client/client.h
+++ b/examples/client/client.h
@@ -1,6 +1,6 @@
 /* client.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -1,6 +1,6 @@
 /* common.c
  *
- * Copyright (C) 2014-2022 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -403,7 +403,8 @@ int ClientPublicKeyCheck(const byte* pubKey, word32 pubKeySz, void* ctx)
                                 current->ipString);
                             WLOG(WS_LOG_DEBUG,
                                 "\texpecting host IP : %s", (char*)ctx);
-                            if (XSTRCMP(ctx, current->ipString) == 0) {
+                            if (XSTRCMP((const char*)ctx,
+                                        current->ipString) == 0) {
                                 WLOG(WS_LOG_DEBUG, "\tmatched!");
                                 ipMatch = 1;
                             }

--- a/examples/client/common.h
+++ b/examples/client/common.h
@@ -1,6 +1,6 @@
 /* common.h
  *
- * Copyright (C) 2014-2022 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1,6 +1,6 @@
 /* echoserver.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/echoserver/echoserver.h
+++ b/examples/echoserver/echoserver.h
@@ -1,6 +1,6 @@
 /* echoserver.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/portfwd/portfwd.c
+++ b/examples/portfwd/portfwd.c
@@ -1,6 +1,6 @@
 /* portfwd.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/portfwd/wolfssh_portfwd.h
+++ b/examples/portfwd/wolfssh_portfwd.h
@@ -1,6 +1,6 @@
 /* wolfssh_portfwd.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -1,6 +1,6 @@
 /* scpclient.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/scpclient/scpclient.h
+++ b/examples/scpclient/scpclient.h
@@ -1,6 +1,6 @@
 /* scpclient.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1,6 +1,6 @@
 /* sftpclient.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/examples/sftpclient/sftpclient.h
+++ b/examples/sftpclient/sftpclient.h
@@ -1,6 +1,6 @@
 /* sftpclient.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/default_espressif_options.h
+++ b/ide/Espressif/ESP-IDF/default_espressif_options.h
@@ -1,7 +1,7 @@
 /* wolfssl options.h
  * generated from configure options
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/CMakeLists.txt
@@ -1,22 +1,21 @@
 #  [wolfSSL Project]/CMakeLists.txt
 #
-#  Copyright (C) 2006-2023 WOLFSSL Inc.
+#  Copyright (C) 2014-2024 wolfSSL Inc.
 #
-#  This file is part of WOLFSSH.
+#  This file is part of wolfSSH.
 #
-#  WOLFSSH is free software; you can redistribute it and/or modify
+#  wolfSSH is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
+#  the Free Software Foundation; either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  WOLFSSH is distributed in the hope that it will be useful,
+#  wolfSSH is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
 #
 # cmake for WOLFSSH Espressif projects
 #

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssh/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssh/CMakeLists.txt
@@ -1,22 +1,21 @@
 #  [wolfSSL Project]/components/wolfssh/CMakeLists.txt
 #
-#  Copyright (C) 2006-2023 WOLFSSL Inc.
+#  Copyright (C) 2014-2024 wolfSSL Inc.
 #
-#  This file is part of WOLFSSH.
+#  This file is part of wolfSSH.
 #
-#  WOLFSSH is free software; you can redistribute it and/or modify
+#  wolfSSH is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
+#  the Free Software Foundation; either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  WOLFSSH is distributed in the hope that it will be useful,
+#  wolfSSH is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
 #
 # cmake for WOLFSSH Espressif projects v5.6.6 r1
 #

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/CMakeLists.txt
@@ -1,21 +1,20 @@
 #
-#  Copyright (C) 2006-2023 wolfSSL Inc.
+#  Copyright (C) 2014-2024 wolfSSL Inc.
 #
-#  This file is part of wolfSSL.
+#  This file is part of wolfSSH.
 #
-#  wolfSSL is free software; you can redistribute it and/or modify
+#  wolfSSH is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
+#  the Free Software Foundation; either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  wolfSSL is distributed in the hope that it will be useful,
+#  wolfSSH is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
 #
 # cmake for wolfssl Espressif projects
 #

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/include/user_settings.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/include/user_settings.h
@@ -1,22 +1,21 @@
 /* user_settings.h
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <sdkconfig.h> /* essential to chip set detection */

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/CMakeLists.txt
@@ -1,22 +1,21 @@
 #  [wolfSSL Project]/main/CMakeLists.txt
 #
-#  Copyright (C) 2006-2023 WOLFSSL Inc.
+#  Copyright (C) 2014-2024 wolfSSL Inc.
 #
-#  This file is part of WOLFSSH.
+#  This file is part of wolfSSH.
 #
-#  WOLFSSH is free software; you can redistribute it and/or modify
+#  wolfSSH is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
+#  the Free Software Foundation; either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  WOLFSSH is distributed in the hope that it will be useful,
+#  wolfSSH is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
 #
 # cmake for WOLFSSH Espressif projects
 #

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
@@ -1,6 +1,6 @@
 /* echoserver.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/echoserver.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/echoserver.h
@@ -1,6 +1,6 @@
 /* echoserver.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/main.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/main.h
@@ -1,22 +1,21 @@
 /* template main.h
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef _MAIN_H_
 #define _MAIN_H_

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/time_helper.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/time_helper.h
@@ -1,21 +1,20 @@
 /*
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /* common Espressif time_helper v5.6.3.001 */

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/wifi_connect.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/wifi_connect.h
@@ -1,22 +1,21 @@
 /* wifi_connect.h
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef _WIFI_CONNECT_H_
 #define _WIFI_CONNECT_H_

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/main.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/main.c
@@ -1,22 +1,21 @@
 /* main.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "sdkconfig.h"
 #include "main.h"

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/time_helper.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/time_helper.c
@@ -1,22 +1,21 @@
 /* time_helper.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /* common Espressif time_helper v5.6.3.002 */

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/wifi_connect.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/wifi_connect.c
@@ -1,22 +1,21 @@
 /* wifi_connect.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
  #include "wifi_connect.h"
 

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssh/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssh/CMakeLists.txt
@@ -1,22 +1,21 @@
 #  Espressif component/wolfssh/CMakeLists.txt
 #
-#  Copyright (C) 2006-2023 WOLFSSL Inc.
+#  Copyright (C) 2014-2024 wolfSSL Inc.
 #
-#  This file is part of WOLFSSH.
+#  This file is part of wolfSSH.
 #
-#  WOLFSSH is free software; you can redistribute it and/or modify
+#  wolfSSH is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
+#  the Free Software Foundation; either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  WOLFSSH is distributed in the hope that it will be useful,
+#  wolfSSH is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
 #
 # cmake for WOLFSSH Espressif projects
 #

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/CMakeLists.txt
@@ -1,21 +1,20 @@
 #
-#  Copyright (C) 2006-2023 wolfSSL Inc.
+#  Copyright (C) 2014-2024 wolfSSL Inc.
 #
-#  This file is part of wolfSSL.
+#  This file is part of wolfSSH.
 #
-#  wolfSSL is free software; you can redistribute it and/or modify
+#  wolfSSH is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
+#  the Free Software Foundation; either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  wolfSSL is distributed in the hope that it will be useful,
+#  wolfSSH is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
 #
 # cmake for wolfssl Espressif projects
 #

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/include/user_settings.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/include/user_settings.h
@@ -1,22 +1,21 @@
 /* user_settings.h
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include <sdkconfig.h> /* essential to chip set detection */

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/CMakeLists.txt
@@ -1,22 +1,21 @@
 #  [wolfSSL Project]/main/CMakeLists.txt
 #
-#  Copyright (C) 2006-2023 WOLFSSL Inc.
+#  Copyright (C) 2014-2024 wolfSSL Inc.
 #
-#  This file is part of WOLFSSH.
+#  This file is part of wolfSSH.
 #
-#  WOLFSSH is free software; you can redistribute it and/or modify
+#  wolfSSH is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation; either version 2 of the License, or
+#  the Free Software Foundation; either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  WOLFSSH is distributed in the hope that it will be useful,
+#  wolfSSH is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
 #
 # cmake for WOLFSSH Espressif projects
 #

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/include/main.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/include/main.h
@@ -1,22 +1,21 @@
 /* template main.h
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef _MAIN_H_
 #define _MAIN_H_

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/main.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/main.c
@@ -1,22 +1,21 @@
 /* main.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
- * This file is part of wolfSSL.
+ * This file is part of wolfSSH.
  *
- * wolfSSL is free software; you can redistribute it and/or modify
+ * wolfSSH is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * wolfSSL is distributed in the hope that it will be useful,
+ * wolfSSH is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "main.h"
 

--- a/ide/IAR-EWARM/Projects/lib/myFilesystem.h
+++ b/ide/IAR-EWARM/Projects/lib/myFilesystem.h
@@ -1,6 +1,6 @@
 /* dummy_filesystem.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Renesas/cs+/common/strings.h
+++ b/ide/Renesas/cs+/common/strings.h
@@ -1,6 +1,6 @@
 /* strings.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Renesas/cs+/common/unistd.h
+++ b/ide/Renesas/cs+/common/unistd.h
@@ -1,6 +1,6 @@
 /* unistd.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Renesas/cs+/common/user_settings.h
+++ b/ide/Renesas/cs+/common/user_settings.h
@@ -1,6 +1,6 @@
 /* user_settings.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Renesas/cs+/common/wolfssh_csplus_usersettings.h
+++ b/ide/Renesas/cs+/common/wolfssh_csplus_usersettings.h
@@ -1,6 +1,6 @@
 /* wolfssh_csplus_usersettings..h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Renesas/cs+/demo_server/wolfssh_demo.c
+++ b/ide/Renesas/cs+/demo_server/wolfssh_demo.c
@@ -1,6 +1,6 @@
 /* wolfssh_demo.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Renesas/cs+/demo_server/wolfssh_demo.h
+++ b/ide/Renesas/cs+/demo_server/wolfssh_demo.h
@@ -1,6 +1,6 @@
 /* wolfssh_demo.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Renesas/cs+/demo_server/wolfssh_dummy.c
+++ b/ide/Renesas/cs+/demo_server/wolfssh_dummy.c
@@ -1,6 +1,6 @@
 /* wolfssh_dummy.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/STM32CUBE/main.c
+++ b/ide/STM32CUBE/main.c
@@ -1,6 +1,6 @@
 /* main.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/STM32CUBE/myFilesystem.h
+++ b/ide/STM32CUBE/myFilesystem.h
@@ -1,6 +1,6 @@
 /* myFilesystem.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/STM32CUBE/userio_template.h
+++ b/ide/STM32CUBE/userio_template.h
@@ -1,6 +1,6 @@
 /* userio_template.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/STM32CUBE/wolfssh_test.c
+++ b/ide/STM32CUBE/wolfssh_test.c
@@ -1,6 +1,6 @@
 /* wolfssh_test.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/STM32CUBE/wolfssh_test.h
+++ b/ide/STM32CUBE/wolfssh_test.h
@@ -1,6 +1,6 @@
 /* wolfssh_test.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/agent.c
+++ b/src/agent.c
@@ -1,6 +1,6 @@
 /* agent.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/certman.c
+++ b/src/certman.c
@@ -1,6 +1,6 @@
 /* certman.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/internal.c
+++ b/src/internal.c
@@ -1,6 +1,6 @@
 /* internal.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/io.c
+++ b/src/io.c
@@ -1,6 +1,6 @@
 /* io.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/keygen.c
+++ b/src/keygen.c
@@ -1,6 +1,6 @@
 /* keygen.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/log.c
+++ b/src/log.c
@@ -1,6 +1,6 @@
 /* log.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/misc.c
+++ b/src/misc.c
@@ -1,6 +1,6 @@
 /* misc.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/port.c
+++ b/src/port.c
@@ -1,6 +1,6 @@
 /* port.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1,6 +1,6 @@
 /* ssh.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -1,6 +1,6 @@
 /* wolfscp.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -1,6 +1,6 @@
 /* wolfsftp.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -2042,7 +2042,8 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
     }
 
     {
-        WS_SFTP_FILEATRB fileAtr = { 0 };
+        WS_SFTP_FILEATRB fileAtr;
+        WMEMSET(&fileAtr, 0, sizeof(fileAtr));
         if (SFTP_GetAttributes(ssh->fs,
                         dir, &fileAtr, 1, ssh->ctx->heap) == WS_SUCCESS) {
             if ((fileAtr.per & FILEATRB_PER_MASK_TYPE) != FILEATRB_PER_FILE) {
@@ -8767,7 +8768,8 @@ int wolfSSH_SFTP_Put(WOLFSSH* ssh, char* from, char* to, byte resume,
                 WLOG(WS_LOG_SFTP, "SFTP PUT STATE: OPEN LOCAL");
             #ifndef USE_WINDOWS_API
                 {
-                    WS_SFTP_FILEATRB fileAtr = { 0 };
+                    WS_SFTP_FILEATRB fileAtr;
+                    WMEMSET(&fileAtr, 0, sizeof(fileAtr));
                     if (SFTP_GetAttributes(ssh->fs,
                                 from, &fileAtr, 1, ssh->ctx->heap)
                             == WS_SUCCESS) {

--- a/src/wolfterm.c
+++ b/src/wolfterm.c
@@ -1,6 +1,6 @@
 /* wolfterm.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/tests/api.c
+++ b/tests/api.c
@@ -1,6 +1,6 @@
 /* api.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/tests/api.h
+++ b/tests/api.h
@@ -1,6 +1,6 @@
 /* api.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/tests/sftp.c
+++ b/tests/sftp.c
@@ -1,6 +1,6 @@
 /* sftp.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/tests/sftp.h
+++ b/tests/sftp.h
@@ -1,6 +1,6 @@
 /* sftp.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -1,6 +1,6 @@
 /* testsuite.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/tests/testsuite.h
+++ b/tests/testsuite.h
@@ -1,6 +1,6 @@
 /* testsuite.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -1,6 +1,6 @@
 /* unit.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -1,6 +1,6 @@
 /* unit.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/agent.h
+++ b/wolfssh/agent.h
@@ -1,6 +1,6 @@
 /* agent.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/certman.h
+++ b/wolfssh/certman.h
@@ -1,6 +1,6 @@
 /* certman.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/certs_test.h
+++ b/wolfssh/certs_test.h
@@ -1,6 +1,6 @@
 /* certs_test.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -1,6 +1,6 @@
 /* error.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1,6 +1,6 @@
 /* internal.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/keygen.h
+++ b/wolfssh/keygen.h
@@ -1,6 +1,6 @@
 /* keygen.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/log.h
+++ b/wolfssh/log.h
@@ -1,6 +1,6 @@
 /* log.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/misc.h
+++ b/wolfssh/misc.h
@@ -1,6 +1,6 @@
 /* misc.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -1,6 +1,6 @@
 /* port.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/settings.h
+++ b/wolfssh/settings.h
@@ -1,6 +1,6 @@
 /* settings.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -1,6 +1,6 @@
 /* ssh.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -1,6 +1,6 @@
 /* test.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/version.h
+++ b/wolfssh/version.h
@@ -35,8 +35,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFSSH_VERSION_STRING "1.4.16"
-#define LIBWOLFSSH_VERSION_HEX 0x01004016
+#define LIBWOLFSSH_VERSION_STRING "1.4.17"
+#define LIBWOLFSSH_VERSION_HEX 0x01004017
 
 #ifdef __cplusplus
 }

--- a/wolfssh/version.h
+++ b/wolfssh/version.h
@@ -1,6 +1,6 @@
 /* version.h.in
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/version.h.in
+++ b/wolfssh/version.h.in
@@ -1,6 +1,6 @@
 /* version.h.in
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/visibility.h
+++ b/wolfssh/visibility.h
@@ -1,6 +1,6 @@
 /* visibility.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/wolfscp.h
+++ b/wolfssh/wolfscp.h
@@ -1,6 +1,6 @@
 /* wolfscp.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/wolfssh/wolfsftp.h
+++ b/wolfssh/wolfsftp.h
@@ -1,6 +1,6 @@
 /* wolfsftp.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/zephyr/samples/tests/tests.c
+++ b/zephyr/samples/tests/tests.c
@@ -1,6 +1,6 @@
 /* tests.c
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/zephyr/samples/tests/user_settings.h
+++ b/zephyr/samples/tests/user_settings.h
@@ -1,6 +1,6 @@
 /* user_settings.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/zephyr/samples/tests/wolfssl_user_settings.h
+++ b/zephyr/samples/tests/wolfssl_user_settings.h
@@ -1,6 +1,6 @@
 /* wolfssl_user_settings.h
  *
- * Copyright (C) 2014-2023 wolfSSL Inc.
+ * Copyright (C) 2014-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *


### PR DESCRIPTION
1. Fixing little issues found during testing, like C++ compiler complaints.
2. Update copyright dates to 2024.
3. Update ChangeLog.