### PR TITLE
Static Memory Pools

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -780,7 +780,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         err_sys("If setting priv key, need pub key.");
     }
 
-    ret = ClientSetPrivateKey(privKeyName, userEcc);
+    ret = ClientSetPrivateKey(privKeyName, userEcc, NULL);
     if (ret != 0) {
         err_sys("Error setting private key");
     }
@@ -788,12 +788,12 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
 #ifdef WOLFSSH_CERTS
     /* passed in certificate to use */
     if (certName) {
-        ret = ClientUseCert(certName);
+        ret = ClientUseCert(certName, NULL);
     }
     else
 #endif
     if (pubKeyName) {
-        ret = ClientUsePubKey(pubKeyName, userEcc);
+        ret = ClientUsePubKey(pubKeyName, userEcc, NULL);
     }
     if (ret != 0) {
         err_sys("Error setting public key");
@@ -1079,7 +1079,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         err_sys("Closing client stream failed");
     }
 
-    ClientFreeBuffers(pubKeyName, privKeyName);
+    ClientFreeBuffers(pubKeyName, privKeyName, NULL);
 #if !defined(WOLFSSH_NO_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)
     wc_ecc_fp_free();  /* free per thread cache */
 #endif

--- a/examples/client/common.h
+++ b/examples/client/common.h
@@ -21,16 +21,17 @@
 #ifndef WOLFSSH_COMMON_H
 #define WOLFSSH_COMMON_H
 int ClientLoadCA(WOLFSSH_CTX* ctx, const char* caCert);
-int ClientUsePubKey(const char* pubKeyName, int userEcc);
-int ClientSetPrivateKey(const char* privKeyName, int userEcc);
-int ClientUseCert(const char* certName);
+int ClientUsePubKey(const char* pubKeyName, int userEcc, void* heap);
+int ClientSetPrivateKey(const char* privKeyName, int userEcc, void* heap);
+int ClientUseCert(const char* certName, void* heap);
 int ClientSetEcho(int type);
 int ClientUserAuth(byte authType,
                       WS_UserAuthData* authData,
                       void* ctx);
 int ClientPublicKeyCheck(const byte* pubKey, word32 pubKeySz, void* ctx);
 void ClientIPOverride(int flag);
-void ClientFreeBuffers(const char* pubKeyName, const char* privKeyName);
+void ClientFreeBuffers(const char* pubKeyName, const char* privKeyName,
+        void* heap);
 
 #endif /* WOLFSSH_COMMON_H */
 

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -623,10 +623,10 @@ static int termios_show(int fd)
       * and distList items and summing (32*64 + 128*118 + ...) and adding
       * the sum of the distList values times the sizeof wc_Memory (rounded up
       * to a word, 24). This total was 288kb plus change, rounded up to 289. */
-    const word32 static_sizeList[] =
+    static const word32 static_sizeList[] =
             {32,128,384,800,3120,8400,17552,32846,131072};
-    const word32 static_distList[] = {64,118,3,4,6,2,2,2,1};
-    byte static_buffer[289*1024];
+    static const word32 static_distList[] = {64,118,3,4,6,2,2,2,1};
+    static byte static_buffer[289*1024];
 
     static void wolfSSH_MemoryPrintStats(ES_HEAP_HINT* hint)
     {

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -623,10 +623,21 @@ static int termios_show(int fd)
       * and distList items and summing (32*64 + 128*118 + ...) and adding
       * the sum of the distList values times the sizeof wc_Memory (rounded up
       * to a word, 24). This total was 288kb plus change, rounded up to 289. */
-    static const word32 static_sizeList[] =
-            {32,128,384,800,3120,8400,17552,32846,131072};
-    static const word32 static_distList[] = {64,118,3,4,6,2,2,2,1};
-    static byte static_buffer[289*1024];
+    #ifndef ES_STATIC_SIZES
+        #define ES_STATIC_SIZES 32,128,384,800,3120,8400,17552,32846,131072
+    #endif
+    #ifndef ES_STATIC_DISTS
+        #define ES_STATIC_DISTS 64,118,3,4,6,2,2,2,1
+    #endif
+    #ifndef ES_STATIC_LISTSZ
+        #define ES_STATIC_LISTSZ 9
+    #endif
+    #ifndef ES_STATIC_BUFSZ
+        #define ES_STATIC_BUFSZ (289*1024)
+    #endif
+    static const word32 static_sizeList[] = {ES_STATIC_SIZES};
+    static const word32 static_distList[] = {ES_STATIC_DISTS};
+    static byte static_buffer[ES_STATIC_BUFSZ];
 
     static void wolfSSH_MemoryPrintStats(ES_HEAP_HINT* hint)
     {
@@ -2410,7 +2421,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
         int ret;
 
         ret = wc_LoadStaticMemory_ex(&heap,
-                9, static_sizeList, static_distList,
+                ES_STATIC_LISTSZ, static_sizeList, static_distList,
                 static_buffer, sizeof(static_buffer),
                 WOLFMEM_GENERAL|WOLFMEM_TRACK_STATS, 0);
         if (ret != 0) {

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -609,6 +609,76 @@ static int termios_show(int fd)
 #endif /* SHELL_DEBUG */
 
 
+#ifdef WOLFSSH_STATIC_MEMORY
+    #ifndef WOLFSSL_STATIC_MEMORY
+        #error Requires the static memory functions from wolfSSL
+    #endif
+    #if defined(WOLFSSH_SCP) || defined(WOLFSSH_SHELL) || defined(WOLFSSH_FWD)
+        #warning Static memory configuration for SFTP, results may vary.
+    #endif
+    typedef WOLFSSL_HEAP_HINT ES_HEAP_HINT;
+
+     /* This static buffer is tuned for building with SFTP only. The static
+      * buffer size is calulated by multiplying the pairs of sizeList items
+      * and distList items and summing (32*64 + 128*118 + ...) and adding
+      * the sum of the distList values times the sizeof wc_Memory (rounded up
+      * to a word, 24). This total was 288kb plus change, rounded up to 289. */
+    const word32 static_sizeList[] =
+            {32,128,384,800,3120,8400,17552,32846,131072};
+    const word32 static_distList[] = {64,118,3,4,6,2,2,2,1};
+    byte static_buffer[289*1024];
+
+    static void wolfSSH_MemoryPrintStats(ES_HEAP_HINT* hint)
+    {
+        if (hint != NULL) {
+            word16 i;
+            WOLFSSL_MEM_STATS stats;
+
+            wolfSSL_GetMemStats(hint->memory, &stats);
+
+            /* print to stderr so is on the same pipe as WOLFSSL_DEBUG */
+            fprintf(stderr, "Total mallocs        = %d\n", stats.totalAlloc);
+            fprintf(stderr, "Total frees          = %d\n", stats.totalFr);
+            fprintf(stderr, "Current mallocs      = %d\n", stats.curAlloc);
+            fprintf(stderr, "Available IO         = %d\n", stats.avaIO);
+            fprintf(stderr, "Max con. handshakes  = %d\n", stats.maxHa);
+            fprintf(stderr, "Max con. IO          = %d\n", stats.maxIO);
+            fprintf(stderr, "State of memory blocks: size : available\n");
+            for (i = 0; i < WOLFMEM_MAX_BUCKETS; i++) {
+                fprintf(stderr, "                    %8d : %d\n",
+                        stats.blockSz[i], stats.avaBlock[i]);
+            }
+        }
+    }
+
+    static void wolfSSH_MemoryConnPrintStats(ES_HEAP_HINT* hint)
+    {
+        if (hint != NULL) {
+            WOLFSSL_MEM_CONN_STATS* stats = hint->stats;
+
+            /* fill out statistics if wanted and WOLFMEM_TRACK_STATS flag */
+            if (hint->memory->flag & WOLFMEM_TRACK_STATS
+                    && hint->stats != NULL) {
+                fprintf(stderr, "peak connection memory    = %d\n",
+                        stats->peakMem);
+                fprintf(stderr, "current memory in use     = %d\n",
+                        stats->curMem);
+                fprintf(stderr, "peak connection allocs    = %d\n",
+                        stats->peakAlloc);
+                fprintf(stderr, "current connection allocs = %d\n",
+                        stats->curAlloc);
+                fprintf(stderr, "total connection allocs   = %d\n",
+                        stats->totalAlloc);
+                fprintf(stderr, "total connection frees    = %d\n\n",
+                        stats->totalFr);
+            }
+        }
+    }
+#else
+    typedef void ES_HEAP_HINT;
+#endif
+
+
 int ChildRunning = 0;
 
 #ifdef WOLFSSH_SHELL
@@ -1419,6 +1489,11 @@ static THREAD_RETURN WOLFSSH_THREAD server_worker(void* vArgs)
         threadCtx->fwdCbCtx.originName = NULL;
     }
 #endif
+
+#ifdef WOLFSSH_STATIC_MEMORY
+    wolfSSH_MemoryConnPrintStats(threadCtx->ssh->ctx->heap);
+#endif
+
     wolfSSH_free(threadCtx->ssh);
 
     if (ret != 0) {
@@ -2192,6 +2267,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
     word32 defaultHighwater = EXAMPLE_HIGHWATER_MARK;
     word32 threadCount = 0;
     const char* keyList = NULL;
+    ES_HEAP_HINT* heap = NULL;
     int multipleConnections = 1;
     int userEcc = 0;
     int peerEcc = 0;
@@ -2329,7 +2405,21 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
         ES_ERROR("Couldn't initialize wolfSSH.\n");
     }
 
-    ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
+    #ifdef WOLFSSH_STATIC_MEMORY
+    {
+        int ret;
+
+        ret = wc_LoadStaticMemory_ex(&heap,
+                9, static_sizeList, static_distList,
+                static_buffer, sizeof(static_buffer),
+                WOLFMEM_GENERAL|WOLFMEM_TRACK_STATS, 0);
+        if (ret != 0) {
+            ES_ERROR("Couldn't set up static memory pool.\n");
+        }
+    }
+    #endif /* WOLFSSH_STATIC_MEMORY */
+
+    ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, heap);
     if (ctx == NULL) {
         ES_ERROR("Couldn't allocate SSH CTX data.\n");
     }
@@ -2573,6 +2663,9 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
             WFREE(threadCtx, NULL, 0);
             ES_ERROR("Couldn't allocate SSH data.\n");
         }
+    #ifdef WOLFSSH_STATIC_MEMORY
+        wolfSSH_MemoryConnPrintStats(heap);
+    #endif
         wolfSSH_SetUserAuthCtx(ssh, &pwMapList);
         /* Use the session object for its own highwater callback ctx */
         if (defaultHighwater > 0) {
@@ -2649,6 +2742,10 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
     wc_FreeMutex(&doneLock);
     PwMapListDelete(&pwMapList);
     wolfSSH_CTX_free(ctx);
+#ifdef WOLFSSH_STATIC_MEMORY
+    wolfSSH_MemoryPrintStats(heap);
+#endif
+
     if (wolfSSH_Cleanup() != WS_SUCCESS) {
         ES_ERROR("Couldn't clean up wolfSSH.\n");
     }

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -217,7 +217,7 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
         err_sys("Empty path values");
     }
 
-    ret = ClientSetPrivateKey(privKeyName, 0);
+    ret = ClientSetPrivateKey(privKeyName, 0, NULL);
     if (ret != 0) {
         err_sys("Error setting private key");
     }
@@ -225,12 +225,12 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
 #ifdef WOLFSSH_CERTS
     /* passed in certificate to use */
     if (certName) {
-        ret = ClientUseCert(certName);
+        ret = ClientUseCert(certName, NULL);
     }
     else
 #endif
     {
-        ret = ClientUsePubKey(pubKeyName, 0);
+        ret = ClientUsePubKey(pubKeyName, 0, NULL);
     }
     if (ret != 0) {
         err_sys("Error setting public key");
@@ -327,7 +327,7 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
     if (ret != WS_SUCCESS && ret != WS_SOCKET_ERROR_E)
         err_sys("Closing scp stream failed. Connection could have been closed by peer");
 
-    ClientFreeBuffers(pubKeyName, privKeyName);
+    ClientFreeBuffers(pubKeyName, privKeyName, NULL);
 #if !defined(WOLFSSH_NO_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)
     wc_ecc_fp_free();  /* free per thread cache */
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -1155,6 +1155,7 @@ void SshResourceFree(WOLFSSH* ssh, void* heap)
         if (hint->memory->flag & WOLFMEM_TRACK_STATS
                 && hint->stats != NULL) {
             WFREE(hint->stats, heap, DYNTYPE_SSH);
+            hint->stats = NULL;
         }
     }
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -948,6 +948,30 @@ WOLFSSH* SshInit(WOLFSSH* ssh, WOLFSSH_CTX* ctx)
         return ssh;
     heap = ctx->heap;
 
+#ifdef WOLFSSH_STATIC_MEMORY
+    if (heap != NULL) {
+        WOLFSSL_HEAP_HINT* hint = (WOLFSSL_HEAP_HINT*)heap;
+
+        if (hint->memory->flag & WOLFMEM_TRACK_STATS) {
+            WOLFSSL_MEM_CONN_STATS* stats = NULL;
+
+            stats = (WOLFSSL_MEM_CONN_STATS*)WMALLOC(
+                    sizeof(WOLFSSL_MEM_CONN_STATS),
+                    heap, DYNTYPE_SSH);
+            if (stats == NULL) {
+                WLOG(WS_LOG_DEBUG, "SshInit: Cannot track memory stats.\n");
+                return NULL;
+            }
+
+            XMEMSET(stats, 0, sizeof(WOLFSSL_MEM_CONN_STATS));
+            if (hint->stats != NULL) {
+                WFREE(hint->stats, heap, DYNTYPE_SSH);
+            }
+            hint->stats = stats;
+        }
+    }
+#endif /* WOLFSSH_STATIC_MEMORY */
+
     handshake = HandshakeInfoNew(heap);
     rng = (WC_RNG*)WMALLOC(sizeof(WC_RNG), heap, DYNTYPE_RNG);
 
@@ -1123,6 +1147,15 @@ void SshResourceFree(WOLFSSH* ssh, void* heap)
     if (ssh->modes) {
         WFREE(ssh->modes, ssh->ctx->heap, DYNTYPE_STRING);
         ssh->modesSz = 0;
+    }
+#endif
+#ifdef WOLFSSH_STATIC_MEMORY
+    if (heap) {
+        WOLFSSL_HEAP_HINT* hint = (WOLFSSL_HEAP_HINT*)heap;
+        if (hint->memory->flag & WOLFMEM_TRACK_STATS
+                && hint->stats != NULL) {
+            WFREE(hint->stats, heap, DYNTYPE_SSH);
+        }
     }
 #endif
 }


### PR DESCRIPTION
Update wolfSSH to use wolfCrypt's static memory allocation pools. Most of wolfSSH already passes around a heap value that is passed into the WOLFSSH_CTX as a NULL. The echoserver and sftpclient examples have been updated with static pool descriptors that work on macOS and Linux builds when only SFTP is available. Some other changes were made in the client common code to include a heap when loading keys, and the other clients were updated for this.
(Fixes 17726)