### PR TITLE
Fix state in DoUserAuthRequestPublicKey

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6783,11 +6783,8 @@ static int DoUserAuthRequestPublicKey(WOLFSSH* ssh, WS_UserAuthData* authData,
                         WLOG(WS_LOG_DEBUG, "DUARPK: user overriding success");
                         authFailure = 1;
                     }
-                    else {
-                        ssh->clientState = CLIENT_USERAUTH_DONE;
-                    }
                 }
-                else {
+                if (!authFailure && !partialSuccess) {
                     ssh->clientState = CLIENT_USERAUTH_DONE;
                 }
             }


### PR DESCRIPTION
In `DoUserAuthRequestPublicKey` function there is a case in which `partialSuccess` is returned by the auth callback. When a public key passes the signature test and the auth result callback, the state of the authentication state machine gets set to `CLIENT_USERAUTH_DONE` even in case `partialSuccess` were to be true.

Fixes zd17917