### PR TITLE
Fix Guards

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4780,16 +4780,16 @@ static int DoKexDhReply(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
         }
 
 #ifdef WOLFSSH_SMALL_STACK
-#ifndef WOLFSSH_NO_ECDSA
+#ifndef WOLFSSH_NO_ECDH
         key_ptr = (ecc_key*)WMALLOC(sizeof(ecc_key), ssh->ctx->heap,
                 DYNTYPE_PRIVKEY);
         if (key_ptr == NULL) {
             ret = WS_MEMORY_E;
         }
-#endif /* WOLFSSH_NO_ECDSA */
+#endif /* WOLFSSH_NO_ECDH */
 
 #else /* ! WOLFSSH_SMALL_STACK */
-#ifndef WOLFSSH_NO_ECDSA
+#ifndef WOLFSSH_NO_ECDH
         key_ptr = &key_s;
 #endif
 #endif

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -595,7 +595,7 @@ typedef struct HandshakeInfo {
 #ifndef WOLFSSH_NO_DH
         DhKey dh;
 #endif
-#if !defined(WOLFSSH_NO_ECDSA) && !defined(WOLFSSH_NO_ECDH)
+#ifndef WOLFSSH_NO_ECDH
         ecc_key ecc;
 #endif
 #ifndef WOLFSSH_NO_CURVE25519_SHA256


### PR DESCRIPTION
1. In `KexDhReply()`, make the ECDH vs ECDSA guards consistent and correct them for ECDH.
2. In the private key agreement handshake info, change the guard for the ecc key to only be on ECDH.
Fixes issue #679.