### PR TITLE
Guards Update: cannedKeyAlgoNames

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -738,17 +738,25 @@ static const char cannedKexAlgoNames[] =
 #endif
 
 static const char cannedKeyAlgoNames[] =
+#ifndef WOLFSSH_NO_ED25519
     "ssh-ed25519,"
+#endif /* WOLFSSH_NO_ED25519 */
+#ifndef WOLFSSH_NO_RSA_SHA2_256
     "rsa-sha2-256,"
+#endif/* WOLFSSH_NO_RSA_SHA2_256 */
+#ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP256
     "ecdsa-sha2-nistp256,"
+#endif /* WOLFSSH_NO_ECDSA_SHA2_NISTP256 */
 #ifdef WOLFSSH_CERTS
-    "x509v3-ecdsa-sha2-nistp256,"
+    #ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP256
+        "x509v3-ecdsa-sha2-nistp256,"
+    #endif /* WOLFSSH_NO_ECDSA_SHA2_NISTP256 */
     #ifdef WOLFSSH_NO_SHA1_SOFT_DISABLE
         "x509v3-ssh-rsa,"
     #endif /* WOLFSSH_NO_SHA1_SOFT_DISABLE */
 #endif /* WOLFSSH_CERTS */
 #ifdef WOLFSSH_NO_SHA1_SOFT_DISABLE
-        "ssh-rsa,"
+    "ssh-rsa,"
 #endif /* WOLFSSH_NO_SHA1_SOFT_DISABLE */
     "";
 


### PR DESCRIPTION
# Description

1. Update the guards around the strings used to make the cannedKeyAlgoNames. If any algorithm is disabled, leave it out of the list. (I'm looking at you Ed25519!)
2. Added comments to those guards.
3. Reflow the alignment.

# Testing

## Build wolfSSL

    ./configure --enable-wolfssh --enable-cryptonly && make clean && make
    sudo make install

## Build and test wolfSSH

    ./configure --enable-debug && make clean && make
    ./examples/client/client -u $USER -p 22

For the failure case, this client connection attempt should indicate a -1051 error occurred.