### PR TITLE
Update Espressif examples for Managed Component publish

### DIFF
--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/README.md
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/README.md
@@ -1,4 +1,4 @@
-# wolfSSL Server Project
+# wolfSSH Server Project
 
 This is an example wolfSSH Server based on the minimally viable wolfSSL [template](../wolfssh_template/README.md)
 
@@ -8,8 +8,6 @@ and the instructions in [wolfssh README.md](https://github.com/wolfSSL/wolfssh#r
 To connect:
 
 ```bash
-TODO
-
 ssh -p 22222 jack@192.168.1.32
 ```
 

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 # cmake for wolfssl Espressif projects
 #
-# Version 5.6.4.016 for improved manual setting of WOLFSSL_ROOT + ESP8266 support; optional esp-timer / driver components
+# Version 5.7.0 template update + THIS_IDF_PATH
 #
 # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
 #
@@ -34,11 +34,18 @@ set(CMAKE_CURRENT_SOURCE_DIR ".")
 # set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
 
 # Optionally set your source to wolfSSL in your project CMakeLists.txt like this:
-# set(WOLFSSL_ROOT "c:/test/blogtest/wolfssl" )
+# set(WOLFSSL_ROOT "c:/test/my_wolfssl" )
 
 if ( "${WOLFSSL_ROOT}" STREQUAL "")
     set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}" )
 endif()
+
+if(  "$ENV{IDF_PATH}" STREQUAL "" )
+     message(FATAL_ERROR "IDF_PATH Environment variable not set!")
+else()
+    string(REPLACE "\\" "/" THIS_IDF_PATH "$ENV{IDF_PATH}")
+endif()
+
 # Optional compiler definitions to help with system name detection (typically printed by app diagnostics)
 if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
@@ -194,16 +201,47 @@ function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
             return()
         endif()
 
+        # Maintain CURRENT_SEARCH_DIR, but check various suffixes with CURRENT_SEARCH_DIR_ALT
         if( THIS_USER )
             # Check for "wolfssl-[username]" subdirectory as we recurse up the directory tree
             set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl-${THIS_USER})
-            message(STATUS "Looking in ${CURRENT_SEARCH_DIR}")
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
 
-            #if(EXISTS ${CURRENT_SEARCH_DIR_ALT} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR_ALT} AND EXISTS "${CURRENT_SEARCH_DIR_ALT}/wolfcrypt/src")
             IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
             if ( FOUND_WOLFSSL )
-               message(STATUS "Found wolfssl in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
-                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR_ALT} PARENT_SCOPE)
+                message(STATUS "Found wolfssl in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
+
+        if ( FOUND_WOLFSSL )
+            # if we already found the source, skip attempt of "wolfssl-master"
+        else()
+            set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl-master)
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
+
+            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+            if ( FOUND_WOLFSSL )
+                message(STATUS "Found wolfssl in master-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
+
+        if ( FOUND_WOLFSSL )
+            # if we already found the source, skip attempt of "wolfssl"
+        else()
+            set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl)
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
+
+            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+            if ( FOUND_WOLFSSL )
+                message(STATUS "Found wolfssl in CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
                 return()
             endif()
         endif()
@@ -223,7 +261,8 @@ function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
         get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" DIRECTORY)
         message(STATUS "Next CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
         if( "${PRIOR_SEARCH_DIR}" STREQUAL "${CURRENT_SEARCH_DIR}" )
-            # when the search directory is empty, we'll give up
+            # When the parent is current directory, cannot go any further. We didn't find wolfssl.
+            # When the search directory is empty, we'll give up.
             set(CURRENT_SEARCH_DIR "")
         endif()
     endwhile()
@@ -239,13 +278,42 @@ endfunction()
 #   FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
 #
 
+message(STATUS "CONFIG_TARGET_PLATFORM = ${CONFIG_TARGET_PLATFORM}")
+
+if (0)
+    get_cmake_property(_variableNames VARIABLES)
+    list (SORT _variableNames)
+    message(STATUS "")
+    message(STATUS "ALL VARIABLES BEGIN")
+    message(STATUS "")
+    foreach (_variableName ${_variableNames})
+        message(STATUS "${_variableName}=${${_variableName}}")
+    endforeach()
+    message(STATUS "")
+    message(STATUS "ALL VARIABLES END")
+    message(STATUS "")
+endif()
+
+if ( ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266") OR ("${IDF_TARGET}" STREQUAL "esp8266") )
+    # There's no esp_timer, no driver components for the ESP8266
+    message(STATUS "Early expansion EXCLUDES esp_timer: ${THIS_INCLUDE_TIMER}")
+    message(STATUS "Early expansion EXCLUDES driver: ${THIS_INCLUDE_DRIVER}")
+    set(THIS_INCLUDE_TIMER "")
+    set(THIS_INCLUDE_DRIVER "")
+else()
+    message(STATUS "Early expansion includes esp_timer: ${THIS_INCLUDE_TIMER}")
+    message(STATUS "Early expansion includes driver: ${THIS_INCLUDE_DRIVER}")
+    set(THIS_INCLUDE_TIMER "esp_timer")
+    set(THIS_INCLUDE_DRIVER "driver")
+endif()
+
 if(CMAKE_BUILD_EARLY_EXPANSION)
     message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
     idf_component_register(
                             REQUIRES "${COMPONENT_REQUIRES}"
                             PRIV_REQUIRES # esp_hw_support
-                                          "${THIS_INCLUDE_TIMER}"
-                                          "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
+                                          ${THIS_INCLUDE_TIMER}
+                                          ${THIS_INCLUDE_DRIVER} # this will typically only be needed for wolfSSL benchmark
                            )
 
 else()
@@ -254,18 +322,8 @@ else()
     message(STATUS "wolfssl component config:")
     message(STATUS "************************************************************************************************")
 
-    if ( "${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266")
-        # There's no esp_timer, no driver components for the ESP8266
-        set(THIS_INCLUDE_TIMER "")
-        set(THIS_INCLUDE_DRIVER "")
-    else()
-        set(THIS_INCLUDE_TIMER "esp_timer")
-        set(THIS_INCLUDE_DRIVER "driver")
-    endif()
-
     # search for wolfSSL
-    # TODO allow for cmake prior def
-
+    FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
     if(WOLFSSL_ROOT)
         IS_WOLFSSL_SOURCE("${WOLFSSL_ROOT}" FOUND_WOLFSSL)
         if(FOUND_WOLFSSL)
@@ -287,8 +345,8 @@ else()
     else()
         message(STATUS "Failed: wolfssl directory not found.")
         # Abort. We need wolfssl _somewhere_.
-        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}.\n"
-                            "Try setting WOLFSSL_ROOT environment variable or git clone.")
+        message(FATAL_ERROR "Could not find wolfssl in any parent directory named wolfssl-${THIS_USER}, wolfssl-master, or wolfssl.\n"
+                            "Try setting WOLFSSL_ROOT environment variable, cmake variable in project, copy source, or use managed components.")
         # Abort CMake after fatal error.
     endif()
 
@@ -326,6 +384,7 @@ else()
 
     # wolfSSL user_settings.h is in the local project.
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    # add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
     add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h")
@@ -484,10 +543,10 @@ else()
             message(STATUS "Could not find RTOS path")
         endif()
     endif()
-
+    message(STATUS "THIS_IDF_PATH = $THIS_IDF_PATH")
     # wolfSSL-specific include directories
     set(COMPONENT_ADD_INCLUDEDIRS
-        "./include" # this is the location of local project wolfssl user_settings.h
+        "./include" # this is the location of wolfssl user_settings.h
         "\"${WOLFSSL_ROOT}/\""
         "\"${WOLFSSL_ROOT}/wolfssl/\""
         "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
@@ -514,9 +573,14 @@ else()
         "\"${WOLFSSL_ROOT}/src/ssl_bn.c\""      # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/ssl_certman.c\"" # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/ssl_crypto.c\""  # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_load.c\""    # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/ssl_misc.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_p7p12.c\""   # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_sess.c\""    # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/x509.c\""
         "\"${WOLFSSL_ROOT}/src/x509_str.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/ext_kyber.c\""     # external Kyber disabled by default
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/ext_kyber.h\"" # external Kyber disabled by default
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_arm32.c\""

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/echoserver.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/echoserver.h
@@ -25,7 +25,7 @@
 #include <types.h>
 
 #ifndef WOLFSSH_THREAD
-    #define WOLFSSH_THREAD
+    #define WOLFSSH_THREAD WOLFSSL_THREAD
 #endif
 
 THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args);

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/main.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/main.c
@@ -34,16 +34,18 @@
     #warning "Check components/wolfssl/include"
 #endif
 
+/* wolfSSH */
+#include <wolfssh/test.h>
+
 /* this project */
 #include "wifi_connect.h"
 #include "time_helper.h"
 
 static const char* const TAG = "My Project";
 
-
 void app_main(void)
 {
-    void*  args = {0};
+    func_args args = {0};
     int ret = ESP_OK;
 
     ESP_LOGI(TAG, "------------ wolfSSL wolfSSH template Example ----------");
@@ -157,6 +159,7 @@ void app_main(void)
     /* TODO: Consider pulling in wolfSSH server.c example source automatically:
      * Keep in mind the nature of this example as an Espressif Component.
      * See https://github.com/wolfSSL/wolfssh/tree/master/examples/server */
+    memset(&args, 0, sizeof(func_args));
     echoserver_test(&args);
 
     ESP_LOGI(TAG, "\n\nDone!"

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/CMakeLists.txt
@@ -18,7 +18,7 @@
 #
 # cmake for wolfssl Espressif projects
 #
-# Version 5.6.4.016 for improved manual setting of WOLFSSL_ROOT + ESP8266 support; optional esp-timer / driver components
+# Version 5.7.0 template update + THIS_IDF_PATH
 #
 # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
 #
@@ -34,11 +34,18 @@ set(CMAKE_CURRENT_SOURCE_DIR ".")
 # set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
 
 # Optionally set your source to wolfSSL in your project CMakeLists.txt like this:
-# set(WOLFSSL_ROOT "c:/test/blogtest/wolfssl" )
+# set(WOLFSSL_ROOT "c:/test/my_wolfssl" )
 
 if ( "${WOLFSSL_ROOT}" STREQUAL "")
     set(WOLFSSL_ROOT "$ENV{WOLFSSL_ROOT}" )
 endif()
+
+if(  "$ENV{IDF_PATH}" STREQUAL "" )
+     message(FATAL_ERROR "IDF_PATH Environment variable not set!")
+else()
+    string(REPLACE "\\" "/" THIS_IDF_PATH "$ENV{IDF_PATH}")
+endif()
+
 # Optional compiler definitions to help with system name detection (typically printed by app diagnostics)
 if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
@@ -194,16 +201,47 @@ function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
             return()
         endif()
 
+        # Maintain CURRENT_SEARCH_DIR, but check various suffixes with CURRENT_SEARCH_DIR_ALT
         if( THIS_USER )
             # Check for "wolfssl-[username]" subdirectory as we recurse up the directory tree
             set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl-${THIS_USER})
-            message(STATUS "Looking in ${CURRENT_SEARCH_DIR}")
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
 
-            #if(EXISTS ${CURRENT_SEARCH_DIR_ALT} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR_ALT} AND EXISTS "${CURRENT_SEARCH_DIR_ALT}/wolfcrypt/src")
             IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
             if ( FOUND_WOLFSSL )
-               message(STATUS "Found wolfssl in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
-                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR_ALT} PARENT_SCOPE)
+                message(STATUS "Found wolfssl in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
+
+        if ( FOUND_WOLFSSL )
+            # if we already found the source, skip attempt of "wolfssl-master"
+        else()
+            set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl-master)
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
+
+            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+            if ( FOUND_WOLFSSL )
+                message(STATUS "Found wolfssl in master-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
+
+        if ( FOUND_WOLFSSL )
+            # if we already found the source, skip attempt of "wolfssl"
+        else()
+            set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssl)
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR_ALT}")
+
+            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSL )
+            if ( FOUND_WOLFSSL )
+                message(STATUS "Found wolfssl in CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
                 return()
             endif()
         endif()
@@ -223,7 +261,8 @@ function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
         get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" DIRECTORY)
         message(STATUS "Next CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
         if( "${PRIOR_SEARCH_DIR}" STREQUAL "${CURRENT_SEARCH_DIR}" )
-            # when the search directory is empty, we'll give up
+            # When the parent is current directory, cannot go any further. We didn't find wolfssl.
+            # When the search directory is empty, we'll give up.
             set(CURRENT_SEARCH_DIR "")
         endif()
     endwhile()
@@ -239,13 +278,42 @@ endfunction()
 #   FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
 #
 
+message(STATUS "CONFIG_TARGET_PLATFORM = ${CONFIG_TARGET_PLATFORM}")
+
+if (0)
+    get_cmake_property(_variableNames VARIABLES)
+    list (SORT _variableNames)
+    message(STATUS "")
+    message(STATUS "ALL VARIABLES BEGIN")
+    message(STATUS "")
+    foreach (_variableName ${_variableNames})
+        message(STATUS "${_variableName}=${${_variableName}}")
+    endforeach()
+    message(STATUS "")
+    message(STATUS "ALL VARIABLES END")
+    message(STATUS "")
+endif()
+
+if ( ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266") OR ("${IDF_TARGET}" STREQUAL "esp8266") )
+    # There's no esp_timer, no driver components for the ESP8266
+    message(STATUS "Early expansion EXCLUDES esp_timer: ${THIS_INCLUDE_TIMER}")
+    message(STATUS "Early expansion EXCLUDES driver: ${THIS_INCLUDE_DRIVER}")
+    set(THIS_INCLUDE_TIMER "")
+    set(THIS_INCLUDE_DRIVER "")
+else()
+    message(STATUS "Early expansion includes esp_timer: ${THIS_INCLUDE_TIMER}")
+    message(STATUS "Early expansion includes driver: ${THIS_INCLUDE_DRIVER}")
+    set(THIS_INCLUDE_TIMER "esp_timer")
+    set(THIS_INCLUDE_DRIVER "driver")
+endif()
+
 if(CMAKE_BUILD_EARLY_EXPANSION)
     message(STATUS "wolfssl component CMAKE_BUILD_EARLY_EXPANSION:")
     idf_component_register(
                             REQUIRES "${COMPONENT_REQUIRES}"
                             PRIV_REQUIRES # esp_hw_support
-                                          "${THIS_INCLUDE_TIMER}"
-                                          "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
+                                          ${THIS_INCLUDE_TIMER}
+                                          ${THIS_INCLUDE_DRIVER} # this will typically only be needed for wolfSSL benchmark
                            )
 
 else()
@@ -254,18 +322,8 @@ else()
     message(STATUS "wolfssl component config:")
     message(STATUS "************************************************************************************************")
 
-    if ( "${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266")
-        # There's no esp_timer, no driver components for the ESP8266
-        set(THIS_INCLUDE_TIMER "")
-        set(THIS_INCLUDE_DRIVER "")
-    else()
-        set(THIS_INCLUDE_TIMER "esp_timer")
-        set(THIS_INCLUDE_DRIVER "driver")
-    endif()
-
     # search for wolfSSL
-    # TODO allow for cmake prior def
-
+    FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
     if(WOLFSSL_ROOT)
         IS_WOLFSSL_SOURCE("${WOLFSSL_ROOT}" FOUND_WOLFSSL)
         if(FOUND_WOLFSSL)
@@ -287,8 +345,8 @@ else()
     else()
         message(STATUS "Failed: wolfssl directory not found.")
         # Abort. We need wolfssl _somewhere_.
-        message(FATAL_ERROR "Could not find wolfssl in ${WOLFSSL_ROOT}.\n"
-                            "Try setting WOLFSSL_ROOT environment variable or git clone.")
+        message(FATAL_ERROR "Could not find wolfssl in any parent directory named wolfssl-${THIS_USER}, wolfssl-master, or wolfssl.\n"
+                            "Try setting WOLFSSL_ROOT environment variable, cmake variable in project, copy source, or use managed components.")
         # Abort CMake after fatal error.
     endif()
 
@@ -326,6 +384,7 @@ else()
 
     # wolfSSL user_settings.h is in the local project.
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
+    # add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
     add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h")
@@ -484,10 +543,10 @@ else()
             message(STATUS "Could not find RTOS path")
         endif()
     endif()
-
+    message(STATUS "THIS_IDF_PATH = $THIS_IDF_PATH")
     # wolfSSL-specific include directories
     set(COMPONENT_ADD_INCLUDEDIRS
-        "./include" # this is the location of local project wolfssl user_settings.h
+        "./include" # this is the location of wolfssl user_settings.h
         "\"${WOLFSSL_ROOT}/\""
         "\"${WOLFSSL_ROOT}/wolfssl/\""
         "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
@@ -514,9 +573,14 @@ else()
         "\"${WOLFSSL_ROOT}/src/ssl_bn.c\""      # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/ssl_certman.c\"" # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/ssl_crypto.c\""  # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_load.c\""    # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/ssl_misc.c\""    # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_p7p12.c\""   # included by ssl.c
+        "\"${WOLFSSL_ROOT}/src/ssl_sess.c\""    # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/x509.c\""
         "\"${WOLFSSL_ROOT}/src/x509_str.c\""
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/ext_kyber.c\""     # external Kyber disabled by default
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/ext_kyber.h\"" # external Kyber disabled by default
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_arm32.c\""

--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -933,7 +933,9 @@ static INLINE void WaitTcpReady(tcp_ready* ready)
         #endif
     #endif
 #else
-    #define WOLFSSH_THREAD WOLFSSL_THREAD
+    #ifndef WOLFSSH_THREAD
+        #define WOLFSSH_THREAD WOLFSSL_THREAD
+    #endif
 #endif
 
 #if (LIBWOLFSSL_VERSION_HEX < WOLFSSL_V5_6_4) \


### PR DESCRIPTION
Although it is already closed, this PR addresses https://github.com/wolfSSL/wolfssh/issues/697 and updates the published Espressif [wolfSSH Managed Component](https://components.espressif.com/components/wolfssl/wolfssh/). 

See the wolfSSL `scripts` for publishing details. I'll reference this PR when I submit the updates there.

There was an interim update of wolfSSL that had a _test_ but not a _fix_ for interleaved HW/SW that could under certain circumstances be problematic for both SSH and SRP. This was fixed in https://github.com/wolfSSL/wolfssl/pull/7535 and https://github.com/wolfSSL/wolfssl/pull/7505.

Once updated after the 5.7.0 wolfSSL release, the [wolfSSL Managed Component](https://components.espressif.com/components?q=namespace:wolfssl) needed to be updated as well.

There's a new wolfSSL 5.7.1 _preview release_, published to [wolfssl/versions/5.7.1-preview2d](https://components.espressif.com/components/wolfssl/wolfssl/versions/5.7.1-preview2d?language=en). Note this is _not_ the default version that appears at the wolfSSL Managed Components Home Page, since it is not a formal release. (wolfSSL 5.7.1 is not a wolfSSL version as of today).

I would have called it something like `5.7.0+Rev1` but I could not get that syntax to work with the Espressif site, even though it is vali according to https://semver.org/.

Various issues addressed here:

- Updated the `CMakeFiles.txt` to be a bit more robust and consistent with other similar files elsewhere.
- Fixes the Espressif example echoserver that had a bad parameter `void* args = {0};` instead of `func_args args = {0};` 
- Minor README.md file updates

The known-working, post-release Managed Components are:

`wolfSSH`: https://components.espressif.com/components/wolfssl/wolfssh/versions/1.4.17-preview1m5

and

`wolfSSL`: https://components.espressif.com/components/wolfssl/wolfssl/versions/5.7.1-preview2d?language=en

I expect the next product release versions will be a bit more graceful.
 