### PR TITLE
Using Decode Raw RSA Private Key

### DIFF
--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1331,6 +1331,10 @@ enum TerminalModes {
 };
 #endif /* WOLFSSH_TERM */
 
+
+#define WOLFSSL_V5_7_0 0x05007000
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
1. Add a check for wc_RsaPrivateKeyDecodeRaw() to configure.
2. If wc_RsaPrivateKeyDecodeRaw() is available (from PR https://github.com/wolfSSL/wolfssl/pull/7608), use it to load the private key from GetOpenSshKeyRsa(). If unavailable, process the key the original way.