### PR TITLE
Channel Callbacks

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7959,6 +7959,12 @@ static int DoChannelEof(WOLFSSH* ssh,
     }
 
     if (ret == WS_SUCCESS) {
+        if (ssh->ctx->channelEofCb) {
+            ssh->ctx->channelEofCb(channel, ssh->channelEofCtx);
+        }
+    }
+
+    if (ret == WS_SUCCESS) {
         channel->eofRxd = 1;
         if (!channel->eofTxd) {
             ret = SendChannelEof(ssh, channel->peerChannel);
@@ -7989,6 +7995,12 @@ static int DoChannelClose(WOLFSSH* ssh,
         channel = ChannelFind(ssh, channelId, WS_CHANNEL_ID_SELF);
         if (channel == NULL)
             ret = WS_INVALID_CHANID;
+    }
+
+    if (ret == WS_SUCCESS) {
+        if (ssh->ctx->channelCloseCb) {
+            ssh->ctx->channelCloseCb(channel, ssh->channelCloseCtx);
+        }
     }
 
     if (ret == WS_SUCCESS) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -8380,6 +8380,9 @@ static int DoChannelRequest(WOLFSSH* ssh,
             ret = GetStringAlloc(ssh->ctx->heap, &channel->command,
                     buf, len, &begin);
             channel->sessionType = WOLFSSH_SESSION_EXEC;
+            if (ssh->ctx->channelReqExecCb) {
+                ssh->ctx->channelReqExecCb(channel, ssh->channelReqCtx);
+            }
             ssh->clientState = CLIENT_DONE;
 
             WLOG(WS_LOG_DEBUG, "  command = %s", channel->command);

--- a/src/internal.c
+++ b/src/internal.c
@@ -8305,54 +8305,6 @@ static int DoChannelRequest(WOLFSSH* ssh,
         WLOG(WS_LOG_DEBUG, "  type = %s", type);
         WLOG(WS_LOG_DEBUG, "  wantReply = %u", wantReply);
 
-#ifdef WOLFSSH_TERM
-        if (WSTRNCMP(type, "pty-req", typeSz) == 0) {
-            char term[32];
-            const byte* modes;
-            word32 termSz, modesSz = 0;
-            word32 widthChar, heightRows, widthPixels, heightPixels;
-
-            termSz = (word32)sizeof(term);
-            ret = GetString(term, &termSz, buf, len, &begin);
-            if (ret == WS_SUCCESS)
-                ret = GetUint32(&widthChar, buf, len, &begin);
-            if (ret == WS_SUCCESS)
-                ret = GetUint32(&heightRows, buf, len, &begin);
-            if (ret == WS_SUCCESS)
-                ret = GetUint32(&widthPixels, buf, len, &begin);
-            if (ret == WS_SUCCESS)
-                ret = GetUint32(&heightPixels, buf, len, &begin);
-            if (ret == WS_SUCCESS)
-                ret = GetStringRef(&modesSz, &modes, buf, len, &begin);
-            if (ret == WS_SUCCESS) {
-                ssh->modes = (byte*)WMALLOC(modesSz,
-                        ssh->ctx->heap, DYNTYPE_STRING);
-                if (ssh->modes == NULL)
-                    ret = WS_MEMORY_E;
-            }
-            if (ret == WS_SUCCESS) {
-                ssh->modesSz = modesSz;
-                WMEMCPY(ssh->modes, modes, modesSz);
-                WLOG(WS_LOG_DEBUG, "  term = %s", term);
-                WLOG(WS_LOG_DEBUG, "  widthChar = %u", widthChar);
-                WLOG(WS_LOG_DEBUG, "  heightRows = %u", heightRows);
-                WLOG(WS_LOG_DEBUG, "  widthPixels = %u", widthPixels);
-                WLOG(WS_LOG_DEBUG, "  heightPixels = %u", heightPixels);
-                ssh->widthChar = widthChar;
-                ssh->heightRows = heightRows;
-                ssh->widthPixels = widthPixels;
-                ssh->heightPixels = heightPixels;
-                if (ssh->termResizeCb) {
-                    if (ssh->termResizeCb(ssh, widthChar, heightRows,
-                            widthPixels, heightPixels,
-                            ssh->termCtx) != WS_SUCCESS) {
-                        ret = WS_FATAL_ERROR;
-                    }
-                }
-            }
-        }
-        else
-#endif /* WOLFSSH_TERM */
         if (WSTRNCMP(type, "env", typeSz) == 0) {
             char name[WOLFSSH_MAX_NAMESZ];
             word32 nameSz;
@@ -8398,16 +8350,54 @@ static int DoChannelRequest(WOLFSSH* ssh,
 
             WLOG(WS_LOG_DEBUG, "  subsystem = %s", channel->command);
         }
-#ifdef WOLFSSH_AGENT
-        else if (WSTRNCMP(type, "auth-agent-req@openssh.com", typeSz) == 0) {
-            WLOG(WS_LOG_AGENT, "  ssh-agent");
-            if (ssh->ctx->agentCb != NULL)
-                ssh->useAgent = 1;
-            else
-                WLOG(WS_LOG_AGENT, "Agent callback not set, not using.");
+        #ifdef WOLFSSH_TERM
+        else if (WSTRNCMP(type, "pty-req", typeSz) == 0) {
+            char term[32];
+            const byte* modes;
+            word32 termSz, modesSz = 0;
+            word32 widthChar, heightRows, widthPixels, heightPixels;
+
+            termSz = (word32)sizeof(term);
+            ret = GetString(term, &termSz, buf, len, &begin);
+            if (ret == WS_SUCCESS)
+                ret = GetUint32(&widthChar, buf, len, &begin);
+            if (ret == WS_SUCCESS)
+                ret = GetUint32(&heightRows, buf, len, &begin);
+            if (ret == WS_SUCCESS)
+                ret = GetUint32(&widthPixels, buf, len, &begin);
+            if (ret == WS_SUCCESS)
+                ret = GetUint32(&heightPixels, buf, len, &begin);
+            if (ret == WS_SUCCESS)
+                ret = GetStringRef(&modesSz, &modes, buf, len, &begin);
+            if (ret == WS_SUCCESS) {
+                ssh->modes = (byte*)WMALLOC(modesSz,
+                        ssh->ctx->heap, DYNTYPE_STRING);
+                if (ssh->modes == NULL)
+                    ret = WS_MEMORY_E;
+            }
+            if (ret == WS_SUCCESS) {
+                ssh->modesSz = modesSz;
+                WMEMCPY(ssh->modes, modes, modesSz);
+                WLOG(WS_LOG_DEBUG, "  term = %s", term);
+                WLOG(WS_LOG_DEBUG, "  widthChar = %u", widthChar);
+                WLOG(WS_LOG_DEBUG, "  heightRows = %u", heightRows);
+                WLOG(WS_LOG_DEBUG, "  widthPixels = %u", widthPixels);
+                WLOG(WS_LOG_DEBUG, "  heightPixels = %u", heightPixels);
+                ssh->widthChar = widthChar;
+                ssh->heightRows = heightRows;
+                ssh->widthPixels = widthPixels;
+                ssh->heightPixels = heightPixels;
+                if (ssh->termResizeCb) {
+                    if (ssh->termResizeCb(ssh, widthChar, heightRows,
+                            widthPixels, heightPixels,
+                            ssh->termCtx) != WS_SUCCESS) {
+                        ret = WS_FATAL_ERROR;
+                    }
+                }
+            }
         }
-#endif /* WOLFSSH_AGENT */
-#if defined(WOLFSSH_SHELL) && defined(WOLFSSH_TERM)
+        #endif /* WOLFSSH_TERM */
+        #if defined(WOLFSSH_SHELL) && defined(WOLFSSH_TERM)
         else if (WSTRNCMP(type, "window-change", typeSz) == 0) {
             word32 widthChar, heightRows, widthPixels, heightPixels;
 
@@ -8437,8 +8427,8 @@ static int DoChannelRequest(WOLFSSH* ssh,
                 }
             }
         }
-#endif /* WOLFSSH_SHELL && WOLFSSH_TERM */
-#if defined(WOLFSSH_TERM) || defined(WOLFSSH_SHELL)
+        #endif /* WOLFSSH_SHELL && WOLFSSH_TERM */
+        #if defined(WOLFSSH_TERM) || defined(WOLFSSH_SHELL)
         else if (WSTRNCMP(type, "exit-status", typeSz) == 0) {
             ret = GetUint32(&ssh->exitStatus, buf, len, &begin);
             WLOG(WS_LOG_AGENT, "Got exit status %u.", ssh->exitStatus);
@@ -8471,7 +8461,16 @@ static int DoChannelRequest(WOLFSSH* ssh,
                 ret = GetString(sig, &sigSz, buf, len, &begin);
             }
         }
-#endif
+        #endif /* WOLFSSH_TERM or WOLFSSH_SHELL */
+        #ifdef WOLFSSH_AGENT
+        else if (WSTRNCMP(type, "auth-agent-req@openssh.com", typeSz) == 0) {
+            WLOG(WS_LOG_AGENT, "  ssh-agent");
+            if (ssh->ctx->agentCb != NULL)
+                ssh->useAgent = 1;
+            else
+                WLOG(WS_LOG_AGENT, "Agent callback not set, not using.");
+        }
+        #endif /* WOLFSSH_AGENT */
     }
 
     if (ret == WS_SUCCESS) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -7761,6 +7761,9 @@ static int DoChannelOpen(WOLFSSH* ssh,
         else {
             ChannelUpdatePeer(newChannel, peerChannelId,
                           peerInitialWindowSz, peerMaxPacketSz);
+            if (ssh->ctx->channelOpenCb) {
+                ret = ssh->ctx->channelOpenCb(newChannel, ssh->channelOpenCtx);
+            }
             if (ssh->channelListSz == 0)
                 ssh->defaultPeerChannelId = peerChannelId;
         #ifdef WOLFSSH_FWD

--- a/src/internal.c
+++ b/src/internal.c
@@ -7860,6 +7860,12 @@ static int DoChannelOpenConf(WOLFSSH* ssh,
                             peerInitialWindowSz, peerMaxPacketSz);
 
     if (ret == WS_SUCCESS) {
+        if (ssh->ctx->channelOpenConfCb != NULL) {
+            ret = ssh->ctx->channelOpenConfCb(channel, ssh->channelOpenCtx);
+        }
+    }
+
+    if (ret == WS_SUCCESS) {
         ssh->serverState = SERVER_CHANNEL_OPEN_DONE;
         ssh->defaultPeerChannelId = peerChannelId;
     }
@@ -7872,6 +7878,7 @@ static int DoChannelOpenConf(WOLFSSH* ssh,
 static int DoChannelOpenFail(WOLFSSH* ssh,
                              byte* buf, word32 len, word32* idx)
 {
+    WOLFSSH_CHANNEL* channel = NULL;
     char desc[80];
     word32 begin, channelId, reasonId, descSz, langSz;
     int ret = WS_SUCCESS;
@@ -7905,6 +7912,19 @@ static int DoChannelOpenFail(WOLFSSH* ssh,
             WLOG(WS_LOG_INFO, "description: %s", desc);
         }
 
+        if (ssh->ctx->channelOpenFailCb != NULL) {
+            channel = ChannelFind(ssh, channelId, WS_CHANNEL_ID_SELF);
+
+            if (channel != NULL) {
+                ret = ssh->ctx->channelOpenFailCb(channel, ssh->channelOpenCtx);
+            }
+            else {
+                ret = WS_INVALID_CHANID;
+            }
+        }
+    }
+
+    if (ret == WS_SUCCESS) {
         ret = ChannelRemove(ssh, channelId, WS_CHANNEL_ID_SELF);
     }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -8388,6 +8388,9 @@ static int DoChannelRequest(WOLFSSH* ssh,
             ret = GetStringAlloc(ssh->ctx->heap, &channel->command,
                     buf, len, &begin);
             channel->sessionType = WOLFSSH_SESSION_SUBSYSTEM;
+            if (ssh->ctx->channelReqSubsysCb) {
+                ssh->ctx->channelReqSubsysCb(channel, ssh->channelReqCtx);
+            }
             ssh->clientState = CLIENT_DONE;
 
             WLOG(WS_LOG_DEBUG, "  subsystem = %s", channel->command);

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -3119,6 +3119,20 @@ int wolfSSH_CTX_SetChannelReqShellCb(WOLFSSH_CTX* ctx,
 }
 
 
+int wolfSSH_CTX_SetChannelReqExecCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelReq cb)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx != NULL) {
+        ctx->channelReqExecCb = cb;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
 int wolfSSH_CTX_SetChannelReqSubsysCb(WOLFSSH_CTX* ctx,
         WS_CallbackChannelReq cb)
 {

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -3049,6 +3049,34 @@ void wolfSSH_SetKeyingCompletionCbCtx(WOLFSSH* ssh, void* ctx)
 }
 
 
+WS_SessionType wolfSSH_ChannelGetSessionType(const WOLFSSH_CHANNEL* channel)
+{
+    WS_SessionType type = WOLFSSH_SESSION_UNKNOWN;
+
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_ChannelGetType()");
+
+    if (channel) {
+        type = (WS_SessionType)channel->sessionType;
+    }
+
+    return type;
+}
+
+
+const char* wolfSSH_ChannelGetSessionCommand(const WOLFSSH_CHANNEL* channel)
+{
+    const char* cmd = NULL;
+
+    WLOG(WS_LOG_DEBUG, "Entering wolfSSH_ChannelGetCommand()");
+
+    if (channel) {
+        cmd = channel->command;
+    }
+
+    return cmd;
+}
+
+
 int wolfSSH_CTX_SetChannelOpenCb(WOLFSSH_CTX* ctx, WS_CallbackChannelOpen cb)
 {
     int ret = WS_SSH_CTX_NULL_E;
@@ -3078,12 +3106,26 @@ int wolfSSH_CTX_SetChannelOpenRespCb(WOLFSSH_CTX* ctx,
 
 
 int wolfSSH_CTX_SetChannelReqShellCb(WOLFSSH_CTX* ctx,
-        WS_CallbackChannelReqShell cb)
+        WS_CallbackChannelReq cb)
 {
     int ret = WS_SSH_CTX_NULL_E;
 
     if (ctx != NULL) {
         ctx->channelReqShellCb = cb;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+int wolfSSH_CTX_SetChannelReqSubsysCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelReq cb)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx != NULL) {
+        ctx->channelReqSubsysCb = cb;
         ret = WS_SUCCESS;
     }
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -3077,6 +3077,20 @@ int wolfSSH_CTX_SetChannelOpenRespCb(WOLFSSH_CTX* ctx,
 }
 
 
+int wolfSSH_CTX_SetChannelReqShellCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelReqShell cb)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx != NULL) {
+        ctx->channelReqShellCb = cb;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
 int wolfSSH_SetChannelOpenCtx(WOLFSSH* ssh, void* ctx)
 {
     int ret = WS_SSH_NULL_E;

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -3049,6 +3049,44 @@ void wolfSSH_SetKeyingCompletionCbCtx(WOLFSSH* ssh, void* ctx)
 }
 
 
+int wolfSSH_CTX_SetChannelOpenCb(WOLFSSH_CTX* ctx, WS_CallbackChannelOpen cb)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx != NULL) {
+        ctx->channelOpenCb = cb;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+int wolfSSH_SetChannelOpenCtx(WOLFSSH* ssh, void* ctx)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh != NULL) {
+        ssh->channelOpenCtx = ctx;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+void* wolfSSH_GetChannelOpenCtx(WOLFSSH* ssh)
+{
+    void* ctx = NULL;
+
+    if (ssh != NULL) {
+        ctx = ssh->channelOpenCtx;
+    }
+
+    return ctx;
+}
+
+
 #if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
     !defined(NO_WOLFSSH_SERVER)
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -3102,6 +3102,107 @@ void* wolfSSH_GetChannelOpenCtx(WOLFSSH* ssh)
 }
 
 
+int wolfSSH_SetChannelReqCtx(WOLFSSH* ssh, void* ctx)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh != NULL) {
+        ssh->channelReqCtx = ctx;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+void* wolfSSH_GetChannelReqCtx(WOLFSSH* ssh)
+{
+    void* ctx = NULL;
+
+    if (ssh != NULL) {
+        ctx = ssh->channelReqCtx;
+    }
+
+    return ctx;
+}
+
+
+int wolfSSH_CTX_SetChannelEofCb(WOLFSSH_CTX* ctx, WS_CallbackChannelEof cb)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx != NULL) {
+        ctx->channelEofCb = cb;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+int wolfSSH_SetChannelEofCtx(WOLFSSH* ssh, void* ctx)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh != NULL) {
+        ssh->channelEofCtx = ctx;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+void* wolfSSH_GetChannelEofCtx(WOLFSSH* ssh)
+{
+    void* ctx = NULL;
+
+    if (ssh != NULL) {
+        ctx = ssh->channelEofCtx;
+    }
+
+    return ctx;
+}
+
+
+int wolfSSH_CTX_SetChannelCloseCb(WOLFSSH_CTX* ctx, WS_CallbackChannelClose cb)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx != NULL) {
+        ctx->channelCloseCb = cb;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+int wolfSSH_SetChannelCloseCtx(WOLFSSH* ssh, void* ctx)
+{
+    int ret = WS_SSH_NULL_E;
+
+    if (ssh != NULL) {
+        ssh->channelCloseCtx = ctx;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
+void* wolfSSH_GetChannelCloseCtx(WOLFSSH* ssh)
+{
+    void* ctx = NULL;
+
+    if (ssh != NULL) {
+        ctx = ssh->channelCloseCtx;
+    }
+
+    return ctx;
+}
+
+
 #if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
     !defined(NO_WOLFSSH_SERVER)
 

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -3062,6 +3062,21 @@ int wolfSSH_CTX_SetChannelOpenCb(WOLFSSH_CTX* ctx, WS_CallbackChannelOpen cb)
 }
 
 
+int wolfSSH_CTX_SetChannelOpenRespCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelOpen confCb, WS_CallbackChannelOpen failCb)
+{
+    int ret = WS_SSH_CTX_NULL_E;
+
+    if (ctx != NULL) {
+        ctx->channelOpenConfCb = confCb;
+        ctx->channelOpenFailCb = failCb;
+        ret = WS_SUCCESS;
+    }
+
+    return ret;
+}
+
+
 int wolfSSH_SetChannelOpenCtx(WOLFSSH* ssh, void* ctx)
 {
     int ret = WS_SSH_NULL_E;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -502,6 +502,7 @@ struct WOLFSSH_CTX {
     WS_CallbackChannelOpen channelOpenConfCb; /* Channel Open Confirm */
     WS_CallbackChannelOpen channelOpenFailCb; /* Channel Open Fail */
     WS_CallbackChannelReq channelReqShellCb; /* Channel Request "Shell" */
+    WS_CallbackChannelReq channelReqExecCb; /* Channel Request "Exec" */
     WS_CallbackChannelReq channelReqSubsysCb; /* Channel Request "Subsystem" */
     WS_CallbackChannelEof channelEofCb; /* Channel Eof Callback */
     WS_CallbackChannelClose channelCloseCb; /* Channel Close Callback */

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -498,6 +498,7 @@ struct WOLFSSH_CTX {
     WS_CallbackGlobalReq globalReqCb; /* Global Request Callback */
     WS_CallbackReqSuccess reqSuccessCb; /* Global Request Success Callback */
     WS_CallbackReqSuccess reqFailureCb; /* Global Request Failure Callback */
+    WS_CallbackChannelOpen channelOpenCb;
 #ifdef WOLFSSH_SCP
     WS_CallbackScpRecv scpRecvCb;     /* SCP receive callback */
     WS_CallbackScpSend scpSendCb;     /* SCP send callback */
@@ -662,6 +663,7 @@ struct WOLFSSH {
     void* globalReqCtx;    /* Global Request CB context */
     void* reqSuccessCtx;   /* Global Request Sucess CB context */
     void* reqFailureCtx;   /* Global Request Failure CB context */
+    void* channelOpenCtx;  /* Channel Open CB context */
     void* fs;              /* File system handle */
     word32 curSz;
     word32 seq;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -498,9 +498,12 @@ struct WOLFSSH_CTX {
     WS_CallbackGlobalReq globalReqCb; /* Global Request Callback */
     WS_CallbackReqSuccess reqSuccessCb; /* Global Request Success Callback */
     WS_CallbackReqSuccess reqFailureCb; /* Global Request Failure Callback */
-    WS_CallbackChannelOpen channelOpenCb;
-    WS_CallbackChannelOpen channelOpenConfCb;
-    WS_CallbackChannelOpen channelOpenFailCb;
+    WS_CallbackChannelOpen channelOpenCb;     /* Channel Open Requested */
+    WS_CallbackChannelOpen channelOpenConfCb; /* Channel Open Confirm */
+    WS_CallbackChannelOpen channelOpenFailCb; /* Channel Open Fail */
+    WS_CallbackChannelReqShell channelReqShellCb; /* Channel Request "Shell" */
+    WS_CallbackChannelEof channelEofCb; /* Channel Eof Callback */
+    WS_CallbackChannelClose channelCloseCb; /* Channel Close Callback */
 #ifdef WOLFSSH_SCP
     WS_CallbackScpRecv scpRecvCb;     /* SCP receive callback */
     WS_CallbackScpSend scpSendCb;     /* SCP send callback */
@@ -661,11 +664,14 @@ struct WOLFSSH {
     word32 rxCount;
     word32 highwaterMark;
     byte highwaterFlag;    /* Set when highwater CB called */
-    void* highwaterCtx;
+    void* highwaterCtx;    /* Highwater CB context */
     void* globalReqCtx;    /* Global Request CB context */
     void* reqSuccessCtx;   /* Global Request Sucess CB context */
     void* reqFailureCtx;   /* Global Request Failure CB context */
     void* channelOpenCtx;  /* Channel Open CB context */
+    void* channelReqCtx;   /* Channel Request CB context */
+    void* channelEofCtx;   /* Channel EOF CB context */
+    void* channelCloseCtx; /* Channel Close CB context */
     void* fs;              /* File system handle */
     word32 curSz;
     word32 seq;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -499,6 +499,8 @@ struct WOLFSSH_CTX {
     WS_CallbackReqSuccess reqSuccessCb; /* Global Request Success Callback */
     WS_CallbackReqSuccess reqFailureCb; /* Global Request Failure Callback */
     WS_CallbackChannelOpen channelOpenCb;
+    WS_CallbackChannelOpen channelOpenConfCb;
+    WS_CallbackChannelOpen channelOpenFailCb;
 #ifdef WOLFSSH_SCP
     WS_CallbackScpRecv scpRecvCb;     /* SCP receive callback */
     WS_CallbackScpSend scpSendCb;     /* SCP send callback */

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -501,7 +501,8 @@ struct WOLFSSH_CTX {
     WS_CallbackChannelOpen channelOpenCb;     /* Channel Open Requested */
     WS_CallbackChannelOpen channelOpenConfCb; /* Channel Open Confirm */
     WS_CallbackChannelOpen channelOpenFailCb; /* Channel Open Fail */
-    WS_CallbackChannelReqShell channelReqShellCb; /* Channel Request "Shell" */
+    WS_CallbackChannelReq channelReqShellCb; /* Channel Request "Shell" */
+    WS_CallbackChannelReq channelReqSubsysCb; /* Channel Request "Subsystem" */
     WS_CallbackChannelEof channelEofCb; /* Channel Eof Callback */
     WS_CallbackChannelClose channelCloseCb; /* Channel Close Callback */
 #ifdef WOLFSSH_SCP

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -162,6 +162,15 @@ WOLFSSH_API void wolfSSH_SetKeyingCompletionCbCtx(WOLFSSH*,
 #define WS_CHANNEL_ID_PEER 1
 
 
+typedef enum {
+    WOLFSSH_SESSION_UNKNOWN = 0,
+    WOLFSSH_SESSION_SHELL,
+    WOLFSSH_SESSION_EXEC,
+    WOLFSSH_SESSION_SUBSYSTEM,
+    WOLFSSH_SESSION_TERMINAL,
+} WS_SessionType;
+
+
 typedef enum WS_FwdCbAction {
     WOLFSSH_FWD_LOCAL_SETUP,
     WOLFSSH_FWD_LOCAL_CLEANUP,
@@ -209,6 +218,10 @@ WOLFSSH_API int wolfSSH_ChannelRead(WOLFSSH_CHANNEL*, byte*, word32);
 WOLFSSH_API int wolfSSH_ChannelSend(WOLFSSH_CHANNEL*, const byte*, word32);
 WOLFSSH_API int wolfSSH_ChannelExit(WOLFSSH_CHANNEL*);
 WOLFSSH_API int wolfSSH_ChannelGetEof(WOLFSSH_CHANNEL*);
+WOLFSSH_API WS_SessionType wolfSSH_ChannelGetSessionType(
+        const WOLFSSH_CHANNEL* channel);
+WOLFSSH_API const char* wolfSSH_ChannelGetSessionCommand(
+        const WOLFSSH_CHANNEL* channel);
 
 /* Channel callbacks */
 typedef int (*WS_CallbackChannelOpen)(WOLFSSH_CHANNEL* channel, void* ctx);
@@ -219,10 +232,11 @@ WOLFSSH_API int wolfSSH_CTX_SetChannelOpenRespCb(WOLFSSH_CTX* ctx,
 WOLFSSH_API int wolfSSH_SetChannelOpenCtx(WOLFSSH* ssh, void* ctx);
 WOLFSSH_API void* wolfSSH_GetChannelOpenCtx(WOLFSSH* ssh);
 
-typedef int (*WS_CallbackChannelReqShell)(WOLFSSH_CHANNEL* channel,
-        void* ctx);
+typedef int (*WS_CallbackChannelReq)(WOLFSSH_CHANNEL* channel, void* ctx);
 WOLFSSH_API int wolfSSH_CTX_SetChannelReqShellCb(WOLFSSH_CTX* ctx,
-        WS_CallbackChannelReqShell cb);
+        WS_CallbackChannelReq cb);
+WOLFSSH_API int wolfSSH_CTX_SetChannelReqSubsysCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelReq cb);
 WOLFSSH_API int wolfSSH_SetChannelReqCtx(WOLFSSH* ssh, void* ctx);
 WOLFSSH_API void* wolfSSH_GetChannelReqCtx(WOLFSSH* ssh);
 
@@ -369,13 +383,6 @@ WOLFSSH_API int wolfSSH_KDF(byte, byte, byte*, word32, const byte*, word32,
 WOLFSSH_API int wolfSSH_ConvertConsole(WOLFSSH*, WOLFSSH_HANDLE, byte*, word32);
 #endif
 
-typedef enum {
-    WOLFSSH_SESSION_UNKNOWN = 0,
-    WOLFSSH_SESSION_SHELL,
-    WOLFSSH_SESSION_EXEC,
-    WOLFSSH_SESSION_SUBSYSTEM,
-    WOLFSSH_SESSION_TERMINAL,
-} WS_SessionType;
 
 WOLFSSH_API int wolfSSH_DoModes(const byte* modes, word32 modesSz, int fd);
 WOLFSSH_API WS_SessionType wolfSSH_GetSessionType(const WOLFSSH*);

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -219,6 +219,25 @@ WOLFSSH_API int wolfSSH_CTX_SetChannelOpenRespCb(WOLFSSH_CTX* ctx,
 WOLFSSH_API int wolfSSH_SetChannelOpenCtx(WOLFSSH* ssh, void* ctx);
 WOLFSSH_API void* wolfSSH_GetChannelOpenCtx(WOLFSSH* ssh);
 
+typedef int (*WS_CallbackChannelReqShell)(WOLFSSH_CHANNEL* channel,
+        void* ctx);
+WOLFSSH_API int wolfSSH_CTX_SetChannelReqShellCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelReqShell cb);
+WOLFSSH_API int wolfSSH_SetChannelReqCtx(WOLFSSH* ssh, void* ctx);
+WOLFSSH_API void* wolfSSH_GetChannelReqCtx(WOLFSSH* ssh);
+
+typedef int (*WS_CallbackChannelEof)(WOLFSSH_CHANNEL* channel, void* ctx);
+WOLFSSH_API int wolfSSH_CTX_SetChannelEofCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelEof cb);
+WOLFSSH_API int wolfSSH_SetChannelEofCtx(WOLFSSH* ssh, void* ctx);
+WOLFSSH_API void* wolfSSH_GetChannelEofCtx(WOLFSSH* ssh);
+
+typedef int (*WS_CallbackChannelClose)(WOLFSSH_CHANNEL* channel, void* ctx);
+WOLFSSH_API int wolfSSH_CTX_SetChannelCloseCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelClose cb);
+WOLFSSH_API int wolfSSH_SetChannelCloseCtx(WOLFSSH* ssh, void* ctx);
+WOLFSSH_API void* wolfSSH_GetChannelCloseCtx(WOLFSSH* ssh);
+
 WOLFSSH_API int wolfSSH_get_error(const WOLFSSH*);
 WOLFSSH_API const char* wolfSSH_get_error_name(const WOLFSSH*);
 WOLFSSH_API const char* wolfSSH_ErrorToName(int);

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -210,6 +210,12 @@ WOLFSSH_API int wolfSSH_ChannelSend(WOLFSSH_CHANNEL*, const byte*, word32);
 WOLFSSH_API int wolfSSH_ChannelExit(WOLFSSH_CHANNEL*);
 WOLFSSH_API int wolfSSH_ChannelGetEof(WOLFSSH_CHANNEL*);
 
+/* Channel callbacks */
+typedef int (*WS_CallbackChannelOpen)(WOLFSSH_CHANNEL* channel, void* ctx);
+WOLFSSH_API int wolfSSH_CTX_SetChannelOpenCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelOpen cb);
+WOLFSSH_API int wolfSSH_SetChannelOpenCtx(WOLFSSH* ssh, void* ctx);
+WOLFSSH_API void* wolfSSH_GetChannelOpenCtx(WOLFSSH* ssh);
 
 WOLFSSH_API int wolfSSH_get_error(const WOLFSSH*);
 WOLFSSH_API const char* wolfSSH_get_error_name(const WOLFSSH*);

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -235,6 +235,8 @@ WOLFSSH_API void* wolfSSH_GetChannelOpenCtx(WOLFSSH* ssh);
 typedef int (*WS_CallbackChannelReq)(WOLFSSH_CHANNEL* channel, void* ctx);
 WOLFSSH_API int wolfSSH_CTX_SetChannelReqShellCb(WOLFSSH_CTX* ctx,
         WS_CallbackChannelReq cb);
+WOLFSSH_API int wolfSSH_CTX_SetChannelReqExecCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelReq cb);
 WOLFSSH_API int wolfSSH_CTX_SetChannelReqSubsysCb(WOLFSSH_CTX* ctx,
         WS_CallbackChannelReq cb);
 WOLFSSH_API int wolfSSH_SetChannelReqCtx(WOLFSSH* ssh, void* ctx);

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -214,6 +214,8 @@ WOLFSSH_API int wolfSSH_ChannelGetEof(WOLFSSH_CHANNEL*);
 typedef int (*WS_CallbackChannelOpen)(WOLFSSH_CHANNEL* channel, void* ctx);
 WOLFSSH_API int wolfSSH_CTX_SetChannelOpenCb(WOLFSSH_CTX* ctx,
         WS_CallbackChannelOpen cb);
+WOLFSSH_API int wolfSSH_CTX_SetChannelOpenRespCb(WOLFSSH_CTX* ctx,
+        WS_CallbackChannelOpen confCb, WS_CallbackChannelOpen failCb);
 WOLFSSH_API int wolfSSH_SetChannelOpenCtx(WOLFSSH* ssh, void* ctx);
 WOLFSSH_API void* wolfSSH_GetChannelOpenCtx(WOLFSSH* ssh);
 


### PR DESCRIPTION
Add a set of callback function hooks for various steps in the creation of a channel. These include:

* Channel Open
* Channel Open Confirm
* Channel Open Failure
* Channel EOF
* Channel Close
* Channel Request Shell
* Channel Request Subsystem
* Channel Request Exec

A channel request can be rejected by the request callbacks. Also added functions to query a channel's connection type and exec command.