### PR TITLE
Fix testsuite with singlethreaded

### DIFF
--- a/.github/workflows/singlethread-check.yml
+++ b/.github/workflows/singlethread-check.yml
@@ -1,0 +1,75 @@
+name: Single-thread Check Test
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  WOLFSSL_REF: v5.7.0-stable
+
+jobs:
+  build_wolfssl:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    name: Build wolfssl
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 4
+    steps:
+      - name: Checking cache for wolfssl
+        uses: actions/cache@v4
+        id: cache-wolfssl
+        with:
+          path: build-dir/
+          key: wolfssh-singlethread-check-wolfssl-${{ env.WOLFSSL_REF }}-${{ matrix.os }}
+          lookup-only: true
+
+      - name: Checkout, build, and install wolfssl
+        if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          repository: wolfssl/wolfssl
+          ref: ${{ env.WOLFSSL_REF }}
+          path: wolfssl
+          configure: --enable-wolfssh  --enable-singlethreaded --enable-keygen
+          check: false
+          install: true
+
+  build_wolfssh:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        config: [
+          '',
+          '--enable-all',
+          '--enable-sftp',
+          '--enable-scp',
+          '--enable-shell',
+        ]
+    name: Build wolfssh
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 4
+    needs: build_wolfssl
+    steps:
+      - name: Checking cache for wolfssl
+        uses: actions/cache@v4
+        with:
+          path: build-dir/
+          key: wolfssh-singlethread-check-wolfssl-${{ env.WOLFSSL_REF }}-${{ matrix.os }}
+          fail-on-cache-miss: true
+
+      - name: Checkout, build, and test wolfssh
+        uses: wolfSSL/actions-build-autotools-project@v1
+        with:
+          repository: wolfssl/wolfssh
+          path: wolfssh
+          configure: ${{ matrix.config }} LDFLAGS="-L${{ github.workspace }}/build-dir/lib" CPPFLAGS="-I${{ github.workspace }}/build-dir/include"
+          check: true

--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -106,14 +106,6 @@ static const char* caCert   = NULL;
 #endif
 
 
-#if defined(WOLFSSH_AGENT)
-static inline void ato32(const byte* c, word32* u32)
-{
-    *u32 = (c[0] << 24) | (c[1] << 16) | (c[2] << 8) | c[3];
-}
-#endif
-
-
 static int NonBlockSSH_connect(WOLFSSH* ssh)
 {
     int ret;
@@ -214,6 +206,13 @@ static void modes_reset(void)
 #endif /* HAVE_TERMIOS_H && WOLFSSH_TERM */
 
 #if !defined(SINGLE_THREADED) && !defined(WOLFSSL_NUCLEUS)
+
+#if defined(WOLFSSH_AGENT)
+static inline void ato32(const byte* c, word32* u32)
+{
+    *u32 = (c[0] << 24) | (c[1] << 16) | (c[2] << 8) | c[3];
+}
+#endif
 
 typedef struct thread_args {
     WOLFSSH* ssh;
@@ -1023,13 +1022,13 @@ static THREAD_RETURN WOLFSSH_THREAD wolfSSH_Client(void* args)
     if (ret != WS_SUCCESS)
         err_sys("Couldn't connect SSH stream.");
 
+    MODES_CLEAR();
+
 #if !defined(SINGLE_THREADED) && !defined(WOLFSSL_NUCLEUS)
 #if 0
     if (keepOpen) /* set up for psuedo-terminal */
         ClientSetEcho(2);
 #endif
-
-    MODES_CLEAR();
 
     if (config.command != NULL || keepOpen == 1) {
     #if defined(_POSIX_THREADS)

--- a/tests/api.c
+++ b/tests/api.c
@@ -38,8 +38,9 @@
 
 #ifdef WOLFSSH_SFTP
     #define WOLFSSH_TEST_LOCKING
-    #define WOLFSSH_TEST_THREADING
-
+    #ifndef SINGLE_THREADED
+        #define WOLFSSH_TEST_THREADING
+    #endif
     #define WOLFSSH_TEST_SERVER
     #define WOLFSSH_TEST_ECHOSERVER
 #endif

--- a/tests/sftp.c
+++ b/tests/sftp.c
@@ -23,6 +23,11 @@
 #endif
 
 #include <stdio.h>
+#ifdef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/wolfcrypt/settings.h>
+#else
+    #include <wolfssl/options.h>
+#endif
 #include <wolfssh/settings.h>
 
 #if defined(WOLFSSH_SFTP) && !defined(SINGLE_THREADED)

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -22,12 +22,6 @@
     #include <config.h>
 #endif
 
-#define WOLFSSH_TEST_CLIENT
-#define WOLFSSH_TEST_SERVER
-#define WOLFSSH_TEST_THREADING
-#define WOLFSSH_TEST_LOCKING
-
-
 #include <stdio.h>
 
 #ifdef WOLFSSL_USER_SETTINGS
@@ -35,6 +29,13 @@
 #else
     #include <wolfssl/options.h>
 #endif
+
+#define WOLFSSH_TEST_CLIENT
+#define WOLFSSH_TEST_SERVER
+#ifndef SINGLE_THREADED
+    #define WOLFSSH_TEST_THREADING
+#endif
+#define WOLFSSH_TEST_LOCKING
 
 #include <wolfssh/settings.h>
 #include <wolfssh/ssh.h>


### PR DESCRIPTION
Fixes issues when wolfSSL is configured with `--enable-singletthreaded`
Also added workflow to test single thread build.

Reproduce with 
### wolfSSL
```
./configure --enable-wolfssh  --enable-singlethreaded --enable-keygen
```
### wolfSSH
```
./configure --enable-all
```

Fixes issue reported in https://www.wolfssl.com/forums/topic2133-how-to-compile-wolfssh-without-multithreading.html
