### PR TITLE
Reduce SCP Allocations

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1043,6 +1043,8 @@ WOLFSSH* SshInit(WOLFSSH* ssh, WOLFSSH_CTX* ctx)
     ssh->scpRequestState = SCP_PARSE_COMMAND;
     ssh->scpConfirmMsg   = NULL;
     ssh->scpConfirmMsgSz = 0;
+    ssh->scpRecvMsg      = NULL;
+    ssh->scpRecvMsgSz    = 0;
     ssh->scpRecvCtx      = NULL;
     #if !defined(WOLFSSH_SCP_USER_CALLBACKS) && !defined(NO_FILESYSTEM)
     ssh->scpSendCtx      = &(ssh->scpSendCbCtx);
@@ -7143,7 +7145,7 @@ static int DoUserAuthRequestPublicKey(WOLFSSH* ssh, WS_UserAuthData* authData,
                 case WOLFSSH_USERAUTH_PARTIAL_SUCCESS:
                     WLOG(WS_LOG_DEBUG, "DUARPK: user auth partial success");
                     break;
-                    
+
                 case WOLFSSH_USERAUTH_WOULD_BLOCK:
                     WLOG(WS_LOG_DEBUG, "DUARPK: userauth callback would block");
                     break;


### PR DESCRIPTION
# DESCRIPTION

wolfSCP allocates a few buffers as needed and frees them immediately when done. It also checks at shutdown if the buffers need to be freed and frees them. When copying a large file (sink action), it will alloc and free the file buffer for each chunk of file sent by the peer. This could lead to fragmentation. Change the file receive and command buffers to be allocated when needed, and don't free them until cleanup.

# TESTING

```
./examples/scpclient/wolfscp -u john -i ~/.ssh/id_ecdsa -j ~/.ssh/id_ecdsa.pub -S $PWD/configure:$HOME/configure -p 22
sha256sum configure ~/configure
```