### PR TITLE
Fixes for SSHD Windows virtual terminal sequences

### DIFF
--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -2505,8 +2505,6 @@ static int SetupConsole(char* inCmd)
     if (WSTRCMP(shellCmd, inCmd) != 0) {
         /* if not opening a shell, pipe virtual terminal sequences to 'nul' */
         if (CreatePseudoConsole(cord, sIn, INVALID_HANDLE_VALUE, 0, &pCon) != S_OK) {
-            wolfSSH_Log(WS_LOG_ERROR,
-                "[SSHD] Issue creating pseudo console");
             ret = WS_FATAL_ERROR;
         }
         else {
@@ -2518,8 +2516,6 @@ static int SetupConsole(char* inCmd)
         /* if opening a shell, pipe virtual terminal sequences back to calling process */
         sOut = GetStdHandle(STD_OUTPUT_HANDLE);
         if (CreatePseudoConsole(cord, sIn, sOut, 0, &pCon) != S_OK) {
-            wolfSSH_Log(WS_LOG_ERROR,
-                "[SSHD] Issue creating pseudo console");
             ret = WS_FATAL_ERROR;
         }
         else {
@@ -2543,8 +2539,6 @@ static int SetupConsole(char* inCmd)
             ext.lpAttributeList =
                 (PPROC_THREAD_ATTRIBUTE_LIST)HeapAlloc(GetProcessHeap(), 0, sz);
             if (ext.lpAttributeList == NULL) {
-                wolfSSH_Log(WS_LOG_ERROR,
-                    "[SSHD] Issue getting memory for attribute list");
                 ret = WS_FATAL_ERROR;
             }
         }
@@ -2552,8 +2546,6 @@ static int SetupConsole(char* inCmd)
         if (ret == WS_SUCCESS) {
             if (InitializeProcThreadAttributeList(ext.lpAttributeList, 1, 0,
                 &sz) != TRUE) {
-                wolfSSH_Log(WS_LOG_ERROR,
-                    "[SSHD] Issue initializing proc thread attribute");
                 ret = WS_FATAL_ERROR;
             }
         }
@@ -2562,8 +2554,6 @@ static int SetupConsole(char* inCmd)
             if (UpdateProcThreadAttribute(ext.lpAttributeList, 0,
                 PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
                 pCon, sizeof(HPCON), NULL, NULL) != TRUE) {
-                wolfSSH_Log(WS_LOG_ERROR,
-                    "[SSHD] Issue updating proc thread attribute");
                 ret = WS_FATAL_ERROR;
             }
         }
@@ -2588,8 +2578,6 @@ static int SetupConsole(char* inCmd)
         if (CreateProcessW(NULL, cmd,
             NULL, NULL, FALSE, EXTENDED_STARTUPINFO_PRESENT, NULL, NULL,
             &ext.StartupInfo, &processInfo) != TRUE) {
-            wolfSSH_Log(WS_LOG_ERROR,
-                "[SSHD] Issue creating process, Windows error %d", GetLastError());
             return WS_FATAL_ERROR;
         }
         else {
@@ -2609,9 +2597,6 @@ static int SetupConsole(char* inCmd)
                 if (GetExitCodeProcess(processInfo.hProcess, &processState)
                     == TRUE) {
                     if (processState != STILL_ACTIVE) {
-                        wolfSSH_Log(WS_LOG_INFO,
-                            "[SSHD] Process has exited, exit state = %d, "
-                            "close down SSH connection", processState);
                         Sleep(100); /* give the stdout/stderr of process a
                                      * little time to write to pipe */
                         if (PeekNamedPipe(GetStdHandle(STD_OUTPUT_HANDLE), NULL, 0, NULL, &ava, NULL)


### PR DESCRIPTION
ZD 18152

This fixes the case where the command:

`./examples/client/client -u Fred -h 192.168.0.X -Ppassword -c dir > stdout.txt` would result in virtual terminal characters placed in stdout.txt.

It also avoid virtual terminal characters placed in bash variables.