### PR TITLE
Nonblocking SCP

### DIFF
--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1214,7 +1214,8 @@ enum WS_BufferTypes {
 #define SCP_CONFIRM_FATAL 0x02   /* binary 2 */
 
 enum WS_ScpStates {
-    SCP_PARSE_COMMAND = 0,
+    SCP_SETUP = 0,
+    SCP_PARSE_COMMAND,
     SCP_SINK,
     SCP_SINK_BEGIN,
     SCP_TRANSFER,


### PR DESCRIPTION
1. Splitting the top level SCP functions for either from or to, and incorporating the sub-functions in appropriately.
2. Put making the scp command line to send to the peer into its own function.