### PR TITLE
Release v1.4.18: Release Fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# wolfSSH v1.4.18 (July 20, 2024)
+# wolfSSH v1.4.18 (July 22, 2024)
 
 ## New Features
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -1344,7 +1344,7 @@ int IdentifyAsn1Key(const byte* in, word32 inSz, int isPrivate, void* heap)
 
 #ifndef WOLFSSH_NO_RSA
 
-#if LIBWOLFSSL_VERSION_HEX > WOLFSSL_V5_7_0
+#if (LIBWOLFSSL_VERSION_HEX > WOLFSSL_V5_7_0) && !defined(HAVE_FIPS)
 /*
  * The function wc_RsaPrivateKeyDecodeRaw() is available
  * from wolfSSL after v5.7.0.


### PR DESCRIPTION
Need to use the old RSA key read function if using FIPS wolfCrypt.