### PR TITLE
Use wolfCrypt SSHv2 KDF

### DIFF
--- a/wolfssh/error.h
+++ b/wolfssh/error.h
@@ -135,8 +135,9 @@ enum WS_ErrorCodes {
     WS_MSGID_NOT_ALLOWED_E  = -1094, /* Message not allowed before userauth */
     WS_ED25519_E            = -1095, /* Ed25519 failure */
     WS_AUTH_PENDING         = -1096, /* User authentication still pending */
+    WS_KDF_E                = -1097, /* KDF error*/
 
-    WS_LAST_E               = -1096  /* Update this to indicate last error */
+    WS_LAST_E               = -1097  /* Update this to indicate last error */
 };
 
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1352,7 +1352,9 @@ enum TerminalModes {
 #endif /* WOLFSSH_TERM */
 
 
+#define WOLFSSL_V5_0_0 0x05000000
 #define WOLFSSL_V5_7_0 0x05007000
+#define WOLFSSL_V5_7_2 0x05007002
 
 
 #ifdef __cplusplus

--- a/zephyr/samples/tests/wolfssl_user_settings.h
+++ b/zephyr/samples/tests/wolfssl_user_settings.h
@@ -28,6 +28,9 @@ extern "C" {
 #undef  WOLFSSL_ZEPHYR
 #define WOLFSSL_ZEPHYR
 
+#undef  WOLFSSL_WOLFSSH
+#define WOLFSSL_WOLFSSH
+
 #undef  TFM_TIMING_RESISTANT
 #define TFM_TIMING_RESISTANT
 

--- a/zephyr/samples/tests/wolfssl_user_settings_nofs.h
+++ b/zephyr/samples/tests/wolfssl_user_settings_nofs.h
@@ -28,6 +28,9 @@ extern "C" {
 #undef  WOLFSSL_ZEPHYR
 #define WOLFSSL_ZEPHYR
 
+#undef  WOLFSSL_WOLFSSH
+#define WOLFSSL_WOLFSSH
+
 #undef  TFM_TIMING_RESISTANT
 #define TFM_TIMING_RESISTANT
 


### PR DESCRIPTION
Switching to use the new SSH-KDF function in wolfCrypt. Note, this only works in FIPS builds and/or when Kyber isn't used.