### PR TITLE
Adjust Espressif wolfssl_echoserver example timehelper

### DIFF
--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/main.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/main.h
@@ -26,7 +26,12 @@
 #include <esp_log.h>
 
 /* wolfSSL  */
-#include "user_settings.h" /* always include wolfSSL user_settings.h first */
+#include <wolfssl/wolfcrypt/settings.h> /* includes wolfSSL user-settings.h */
+#include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
+#ifndef WOLFSSL_ESPIDF
+    #warning "Problem with wolfSSL user_settings."
+    #warning "Check components/wolfssl/include"
+#endif
 #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
 #include <wolfssl/version.h>
 

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/time_helper.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/time_helper.h
@@ -30,21 +30,23 @@
 extern "C" {
 #endif
 
+#include <esp_err.h>
+
 /* a function to show the current data and time */
-int esp_show_current_datetime();
+esp_err_t  esp_show_current_datetime();
 
 /* worst case, if GitHub time not available, used fixed time */
-int set_fixed_default_time(void);
+esp_err_t  set_fixed_default_time(void);
 
 /* set time from string (e.g. GitHub commit time) */
-int set_time_from_string(char* time_buffer);
+esp_err_t set_time_from_string(const char* time_buffer);
 
 /* set time from NTP servers,
  * also initially calls set_fixed_default_time or set_time_from_string */
-int set_time(void);
+esp_err_t  set_time(void);
 
 /* wait NTP_RETRY_COUNT seconds before giving up on NTP time */
-int set_time_wait_for_ntp(void);
+esp_err_t  set_time_wait_for_ntp(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/main.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/main.c
@@ -46,7 +46,7 @@ static const char* const TAG = "My Project";
 void app_main(void)
 {
     func_args args = {0};
-    int ret = ESP_OK;
+    esp_err_t ret = ESP_OK;
 
     ESP_LOGI(TAG, "------------ wolfSSL wolfSSH template Example ----------");
     ESP_LOGI(TAG, "--------------------------------------------------------");

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/time_helper.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/time_helper.c
@@ -91,7 +91,7 @@ char* ntpServerList[NTP_SERVER_COUNT] = NTP_SERVER_LIST;
 extern char* ntpServerList[NTP_SERVER_COUNT];
 
 /* Show the current date and time */
-int esp_show_current_datetime()
+esp_err_t esp_show_current_datetime()
 {
     time_t now;
     char strftime_buf[64];
@@ -108,7 +108,7 @@ int esp_show_current_datetime()
 }
 
 /* the worst-case scenario is a hard-coded date/time */
-int set_fixed_default_time(void)
+esp_err_t set_fixed_default_time(void)
 {
     /* ideally, we'd like to set time from network,
      * but let's set a default time, just in case */
@@ -138,7 +138,7 @@ int set_fixed_default_time(void)
  *
  * returns 0 = success if able to set the time from the provided string
  * error for any other value, typically -1 */
-int set_time_from_string(char* time_buffer)
+esp_err_t set_time_from_string(const char* time_buffer)
 {
     /* expecting github default formatting: 'Thu Aug 31 12:41:45 2023 -0700' */
     const char *format = "%3s %3s %d %d:%d:%d %d %s";
@@ -222,7 +222,7 @@ int set_time_from_string(char* time_buffer)
 }
 
 /* set time; returns 0 if succecssfully configured with NTP */
-int set_time(void)
+esp_err_t set_time(void)
 {
 #ifndef NTP_SERVER_COUNT
     ESP_LOGW(TAG, "Warning: no sntp server names defined. "
@@ -319,7 +319,7 @@ int set_time(void)
 }
 
 /* wait for NTP to actually set the time */
-int set_time_wait_for_ntp(void)
+esp_err_t set_time_wait_for_ntp(void)
 {
     int ret = 0;
 #ifdef HAS_ESP_NETIF_SNTP


### PR DESCRIPTION
This PR addresses the Espressif `wolfssl_echoserver` build error noted in https://github.com/wolfSSL/wolfssh/issues/728 when publishing wolfssh as a Managed Component by updating the example and not the library. The root cause of the problem is the [un-gated header timelib functions](https://github.com/wolfSSL/wolfssl/blob/7c6eb7c4a1c9b933b35f4de38b7310b663516a69/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h#L152) and the respective type difference: `int` vs `esp_err_t`.

Eventually the example needs to be revised to completely remove the local timelib and use the [esp-sdk-lib.h](https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h) instead.

For now, since both the local example code and the `esp-sdk-lib.h` use the same time-related function names, the `esp_err_t` return type updates in this PR for the example allow an interim solution to the build problem.

Some of the other warnings observed will need to be addressed in a [wolfssl](https://github.com/wolfSSL/wolfssl) update.

The `REQUIRES` CMake value does not need `esp_netif` due to the `HAS_ESP_NETIF_SNTP` gating in the example which is disabled by default.

Since the core wolfSSH library remains unchanged, I plan to publish the wolfSSH Espressif Managed Component with this update included on top of the [v1.4.18-stable](https://github.com/wolfSSL/wolfssh/releases/tag/v1.4.18-stable) release tag.