### PR TITLE
Remove Inline

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3660,7 +3660,7 @@ static INLINE byte KeySzForId(byte id)
     }
 }
 
-INLINE enum wc_HashType HashForId(byte id)
+enum wc_HashType HashForId(byte id)
 {
     switch (id) {
 


### PR DESCRIPTION
The function HashForId() was declared as INLINE. Remove it. The function is getting exported as WOLFSSH_LOCAL which conflicts with the inline.
(ZD 18448)