### PR TITLE
show version of wolfSSL linked to

### DIFF
--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -93,7 +93,8 @@ static void ShowUsage(char* appPath)
         appName = "wolfssh";
     }
 
-    printf("%s v%s\n", appName, LIBWOLFSSH_VERSION_STRING);
+    printf("%s v%s linked with wolfSSL %s\n", appName,
+        LIBWOLFSSH_VERSION_STRING, LIBWOLFSSL_VERSION_STRING);
     printf("usage: %s [-E logfile] [-G] [-l login_name] [-N] [-p port] "
             "[-V] destination\n",
             appName);

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -181,7 +181,8 @@ static void ServiceDebugCb(enum wolfSSH_LogLevel level, const char* const msgStr
 
 static void ShowUsage(void)
 {
-    printf("wolfsshd %s\n", LIBWOLFSSH_VERSION_STRING);
+    printf("wolfSSHd %s linked with wolfSSL %s\n", LIBWOLFSSH_VERSION_STRING,
+        LIBWOLFSSL_VERSION_STRING);
     printf(" -?             display this help and exit\n");
     printf(" -f <file name> Configuration file to use, default is "
                             "/etc/ssh/sshd_config\n");

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -82,7 +82,8 @@ static const char testString[] = "Hello, wolfSSH!";
 
 static void ShowUsage(void)
 {
-    printf("client %s\n", LIBWOLFSSH_VERSION_STRING);
+    printf("client %s linked with wolfSSL %s\n", LIBWOLFSSH_VERSION_STRING,
+        LIBWOLFSSL_VERSION_STRING);
     printf(" -?            display this help and exit\n");
     printf(" -h <host>     host to connect to, default %s\n", wolfSshIp);
     printf(" -p <num>      port to connect on, default %d\n", wolfSshPort);

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -2288,7 +2288,8 @@ static int SetDefaultSftpPath(WOLFSSH* ssh, const char* defaultSftpPath)
 
 static void ShowUsage(void)
 {
-    printf("echoserver %s\n", LIBWOLFSSH_VERSION_STRING);
+    printf("echoserver %s linked with wolfSSL %s\n", LIBWOLFSSH_VERSION_STRING,
+        LIBWOLFSSL_VERSION_STRING);
     printf(" -?            display this help and exit\n");
     printf(" -1            exit after single (one) connection\n");
     printf(" -e            expect ECC public key from client\n");

--- a/examples/portfwd/portfwd.c
+++ b/examples/portfwd/portfwd.c
@@ -79,7 +79,7 @@ static inline int max(int a, int b)
 
 static void ShowUsage(void)
 {
-    printf("portfwd %s\n"
+    printf("portfwd %s linked with wolfSSL %s\n"
            " -?            display this help and exit\n"
            " -h <host>     host to connect to, default %s\n"
            " -p <num>      port to connect on, default %u\n"
@@ -90,6 +90,7 @@ static void ShowUsage(void)
            " -T <host>     host to forward to, default to host\n"
            " -t <num>      port to forward to (REQUIRED)\n",
            LIBWOLFSSH_VERSION_STRING,
+           LIBWOLFSSL_VERSION_STRING,
            wolfSshIp, wolfSshPort, defaultFwdFromHost);
 }
 

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -51,7 +51,8 @@
 #define USAGE_WIDE "12"
 static void ShowUsage(void)
 {
-    printf("wolfscp %s\n", LIBWOLFSSH_VERSION_STRING);
+    printf("wolfscp %s linked with wolfSSL %s\n", LIBWOLFSSH_VERSION_STRING,
+        LIBWOLFSSL_VERSION_STRING);
     printf(" -%c %-" USAGE_WIDE "s %s\n", 'h', "",
             "display this help and exit");
     printf(" -%c %-" USAGE_WIDE "s %s, default %s\n", 'H', "<host>",

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -328,7 +328,8 @@ static void ShowCommands(void)
 
 static void ShowUsage(void)
 {
-    printf("wolfsftp %s\n", LIBWOLFSSH_VERSION_STRING);
+    printf("wolfsftp %s linked with wolfSSL %s\n", LIBWOLFSSH_VERSION_STRING,
+        LIBWOLFSSL_VERSION_STRING);
     printf(" -?            display this help and exit\n");
     printf(" -h <host>     host to connect to, default %s\n", wolfSshIp);
     printf(" -p <num>      port to connect on, default %d\n", wolfSshPort);


### PR DESCRIPTION
Updates apps to display the version of wolfSSL compiled with:

```
$ ./apps/wolfsshd/wolfsshd -v
wolfSSHd 1.4.18 linked with wolfSSL 5.7.2
 -?             display this help and exit
 -f <file name> Configuration file to use, default is /etc/ssh/sshd_config
 -p <int>       Port number to listen on
 -d             Turn on debug mode
 -D             Run in foreground (do not detach)
 -h <file name> host private key file to use
 -E <file name> append to log file
```