### PR TITLE
keep trailing delimiter with SFTP open

### DIFF
--- a/apps/wolfsshd/test/run_all_sshd_tests.sh
+++ b/apps/wolfsshd/test/run_all_sshd_tests.sh
@@ -60,6 +60,7 @@ run_test() {
 run_test "sshd_exec_test.sh"
 run_test "sshd_term_size_test.sh"
 run_test "sshd_large_sftp_test.sh"
+run_test "sshd_bad_sftp_test.sh"
 
 #Github actions needs resolved for these test cases
 #run_test "error_return.sh"

--- a/apps/wolfsshd/test/sshd_bad_sftp_test.sh
+++ b/apps/wolfsshd/test/sshd_bad_sftp_test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# sshd local test
+
+PWD=`pwd`
+cd ../../..
+
+TEST_SFTP_CLIENT="./examples/sftpclient/wolfsftp"
+USER=`whoami`
+PRIVATE_KEY="./keys/hansel-key-ecc.der"
+PUBLIC_KEY="./keys/hansel-key-ecc.pub"
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "expecting host and port as arguments"
+    echo "./sshd_exec_test.sh 127.0.0.1 22222"
+    exit 1
+fi
+
+mkdir test-$$
+mkdir test-$$/subfolder
+
+echo "$TEST_SFTP_CLIENT -u $USER -i $PRIVATE_KEY -j $PUBLIC_KEY -g -l configure -r `pwd`/test-$$/subfolder/ -h \"$1\" -p \"$2\""
+"$TEST_SFTP_CLIENT -u $USER -i $PRIVATE_KEY -j $PUBLIC_KEY -g -l configure -r `pwd`/test-$$/subfolder/ -h $1 -p $2"
+
+RESULT=$?
+if [ "$RESULT" = "0" ]; then
+    echo "Expecting to fail transfer to folder"
+    exit 1
+fi
+rm -rf test-$$
+
+cd $PWD
+exit 0
+

--- a/src/internal.c
+++ b/src/internal.c
@@ -15720,16 +15720,22 @@ int wolfSSH_GetPath(const char* defaultPath, byte* in, word32 inSz,
     }
 
     if (out != NULL) {
-        WMEMCPY(out + curSz, in, inSz);
+        if (curSz + inSz < *outSz) {
+            WMEMCPY(out + curSz, in, inSz);
+        }
     }
     curSz += inSz;
     if (out != NULL) {
         if (!WOLFSSH_SFTP_IS_DELIM(out[0])) {
-            WMEMMOVE(out+1, out, curSz);
-            out[0] = '/';
+            if (curSz + 1 < *outSz) {
+                WMEMMOVE(out+1, out, curSz);
+                out[0] = '/';
+            }
             curSz++;
         }
-        out[curSz] = 0;
+        if (curSz < *outSz) {
+            out[curSz] = 0;
+        }
     }
     *outSz = curSz;
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -15736,6 +15736,9 @@ int wolfSSH_GetPath(const char* defaultPath, byte* in, word32 inSz,
         if (curSz < *outSz) {
             out[curSz] = 0;
         }
+        else {
+            return WS_BUFFER_E;
+        }
     }
     *outSz = curSz;
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -15686,6 +15686,57 @@ int SendChannelSuccess(WOLFSSH* ssh, word32 channelId, int success)
 
 #if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
     !defined(NO_WOLFSSH_SERVER)
+/* Checks if 'in' is absolute path, if not the returns the concat. of
+ * 'defaultPath' | 'in'. This leaves 'in' as-is and does not handle
+ * simplification of the path, such as removing ../
+ *
+ * Sanity checks outSz and then adjusts it for the size used
+ * returns WS_SUCCESS on success
+ */
+int wolfSSH_GetPath(const char* defaultPath, byte* in, word32 inSz,
+        char* out, word32* outSz)
+{
+    word32 curSz = 0;
+
+    if (out != NULL) {
+        WMEMSET(out, 0, *outSz);
+    }
+
+    if (inSz == 0 || (!WOLFSSH_SFTP_IS_DELIM(in[0]) &&
+        !WOLFSSH_SFTP_IS_WINPATH(inSz, in))) {
+        if (defaultPath != NULL) {
+            curSz = (word32)WSTRLEN(defaultPath);
+            if (out != NULL && curSz >= *outSz) {
+                return WS_INVALID_PATH_E;
+            }
+            if (out != NULL) {
+                WSTRNCPY(out, defaultPath, *outSz);
+                if (out[curSz] != '/') {
+                    out[curSz] = '/';
+                    curSz++;
+                }
+            }
+        }
+    }
+
+    if (out != NULL) {
+        WMEMCPY(out + curSz, in, inSz);
+    }
+    curSz += inSz;
+    if (out != NULL) {
+        if (!WOLFSSH_SFTP_IS_DELIM(out[0])) {
+            WMEMMOVE(out+1, out, curSz);
+            out[0] = '/';
+            curSz++;
+        }
+        out[curSz] = 0;
+    }
+    *outSz = curSz;
+
+    return WS_SUCCESS;
+}
+
+
 /* cleans up absolute path
  * returns size of new path on success (strlen sz) and negative values on fail*/
 int wolfSSH_CleanPath(WOLFSSH* ssh, char* in)

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -1974,7 +1974,7 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
 {
     WS_SFTP_FILEATRB atr;
     WFD    fd;
-    word32 sz;
+    word32 sz, dirSz;
     char   dir[WOLFSSH_MAX_FILENAME];
     word32 reason;
     word32 idx = 0;
@@ -2010,10 +2010,11 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
         return WS_BUFFER_E;
     }
 
-    ret = GetAndCleanPath(ssh->sftpDefaultPath, data + idx, sz,
-            dir, sizeof(dir));
-    if (ret < 0) {
-        return ret;
+    dirSz = sizeof(dir);
+    if (wolfSSH_GetPath(ssh->sftpDefaultPath, data + idx, sz, dir, &dirSz)
+            != WS_SUCCESS) {
+        WLOG(WS_LOG_SFTP, "Creating path for file to open failed");
+        return WS_FATAL_ERROR;
     }
     idx += sz;
 
@@ -2128,7 +2129,7 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
 {
 /*    WS_SFTP_FILEATRB atr;*/
     HANDLE fileHandle;
-    word32 sz;
+    word32 sz, dirSz;
     char   dir[WOLFSSH_MAX_FILENAME];
     word32 reason;
     word32 idx = 0;
@@ -2165,9 +2166,11 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
         return WS_BUFFER_E;
     }
 
-    if (GetAndCleanPath(ssh->sftpDefaultPath,
-                data + idx, sz, dir, sizeof(dir)) < 0) {
-        return WS_BUFFER_E;
+    dirSz = sizeof(dir);
+    if (wolfSSH_GetPath(ssh->sftpDefaultPath, data + idx, sz, dir, &dirSz)
+            != WS_SUCCESS) {
+        WLOG(WS_LOG_SFTP, "Creating path for file to open failed");
+        return WS_FATAL_ERROR;
     }
     idx += sz;
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -620,6 +620,12 @@ typedef struct HandshakeInfo {
     } privKey;
 } HandshakeInfo;
 
+#if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
+    !defined(NO_WOLFSSH_SERVER)
+WOLFSSH_LOCAL int wolfSSH_GetPath(const char* defaultPath, byte* in,
+    word32 inSz, char* out, word32* outSz);
+#endif
+
 #ifdef WOLFSSH_SFTP
 #define WOLFSSH_MAX_SFTPOFST 3
 

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -575,6 +575,14 @@ extern "C" {
     #define WLOCALTIME(c,r) (localtime_r((c),(r))!=NULL)
 #endif
 
+#ifndef WOLFSSH_SFTP_DELIM
+    /* Delimiter's used between two SFTP peers should be the same regardless of
+     * operating system. WS_DELIM defined elsewhere is OS specific delimiter. */
+    #define WOLFSSH_SFTP_DELIM "/\\"
+    #define WOLFSSH_SFTP_IS_DELIM(x) ((x) == '/' || (x) == '\\')
+    #define WOLFSSH_SFTP_IS_WINPATH(x,y) ((x) > 1 && (y)[1] == ':')
+#endif
+
 #if (defined(WOLFSSH_SFTP) || \
         defined(WOLFSSH_SCP) || defined(WOLFSSH_SSHD)) && \
     !defined(NO_WOLFSSH_SERVER) && !defined(NO_FILESYSTEM)


### PR DESCRIPTION
ZD 18566

Fix for SFTP cases with trailing delimiter.

OpenSSH client 9.6 (which does a SFTP command instead of SCP, -O restores using SCP protocol)
```
mkdir /tmp/subfolder
scp /tmp/test.txt jill@127.0.0.1:/tmp/subfolder/test/
```

Before this change wolfSSH would allow test.txt to be copied to /tmp/subfolder/test. After this change the command correctly fails.