### PR TITLE
Fix GitHub Actions upload artifact

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload failure logs
         if: ${{ failure() && steps.wolfssh-test.outcome == 'failure' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: zephyr-client-test-logs
           path: logs.zip


### PR DESCRIPTION
The v3 support was removed on 2025-01-30, it no longer works.