### PR TITLE
use dynamic buffer for SCP base path

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1163,11 +1163,11 @@ void SshResourceFree(WOLFSSH* ssh, void* heap)
         ssh->scpRecvMsg = NULL;
         ssh->scpRecvMsgSz = 0;
     }
-#ifdef WOLFSSL_NUCLEUS
-    WFREE(ssh->scpBasePathDynamic, heap, DYNTYPE_BUFFER);
-    ssh->scpBasePathDynamic = NULL;
-    ssh->scpBasePathSz = 0;
-#endif
+    if (ssh->scpBasePathDynamic) {
+        WFREE(ssh->scpBasePathDynamic, heap, DYNTYPE_BUFFER);
+        ssh->scpBasePathDynamic = NULL;
+        ssh->scpBasePathSz = 0;
+    }
 #endif
 #ifdef WOLFSSH_SFTP
     if (ssh->sftpDefaultPath) {

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -1260,47 +1260,46 @@ int ParseScpCommand(WOLFSSH* ssh)
 
                     case 't':
                         ssh->scpDirection = WOLFSSH_SCP_TO;
-                    #ifdef WOLFSSL_NUCLEUS
                         ssh->scpBasePathSz = cmdSz + WOLFSSH_MAX_FILENAME;
                         ssh->scpBasePathDynamic = (char*)WMALLOC(
                                 ssh->scpBasePathSz,
                                 ssh->ctx->heap, DYNTYPE_BUFFER);
-                    #endif
+                        if (ssh->scpBasePathDynamic == NULL) {
+                            return WS_MEMORY_E;
+                        }
+                        WMEMSET(ssh->scpBasePathDynamic, 0, ssh->scpBasePathSz);
                         if (idx + 2 < cmdSz) {
                             /* skip space */
                             idx += 2;
-                        #ifdef WOLFSSL_NUCLEUS
                             ssh->scpBasePath = ssh->scpBasePathDynamic;
-                            WMEMCPY(ssh->scpBasePathDynamic, cmd + idx, cmdSz);
-                        #else
-                            ssh->scpBasePath = cmd + idx;
-                        #endif
+                            WMEMCPY(ssh->scpBasePathDynamic, cmd + idx,
+                                cmdSz - idx);
                             ret = ParseBasePathHelper(ssh, cmdSz);
                             if (ret == WS_SUCCESS &&
-                                    wolfSSH_CleanPath(ssh, (char*)ssh->scpBasePath) < 0)
+                                    wolfSSH_CleanPath(ssh,
+                                        ssh->scpBasePathDynamic) < 0)
                                 ret = WS_FATAL_ERROR;
                         }
                         break;
 
                     case 'f':
                         ssh->scpDirection = WOLFSSH_SCP_FROM;
-                    #ifdef WOLFSSL_NUCLEUS
                         ssh->scpBasePathSz = cmdSz + WOLFSSH_MAX_FILENAME;
                         ssh->scpBasePathDynamic = (char*)WMALLOC(
                                 ssh->scpBasePathSz,
                                 ssh->ctx->heap, DYNTYPE_BUFFER);
-                    #endif
+                        if (ssh->scpBasePathDynamic == NULL) {
+                            return WS_MEMORY_E;
+                        }
+                        WMEMSET(ssh->scpBasePathDynamic, 0, ssh->scpBasePathSz);
                         if (idx + 2 < cmdSz) {
                             /* skip space */
                             idx += 2;
-                        #ifdef WOLFSSL_NUCLEUS
                             ssh->scpBasePath = ssh->scpBasePathDynamic;
-                            WMEMCPY(ssh->scpBasePathDynamic, cmd + idx, cmdSz);
-                        #else
-                            ssh->scpBasePath = cmd + idx;
-                        #endif
+                            WMEMCPY(ssh->scpBasePathDynamic, cmd + idx,
+                                cmdSz - idx);
                             if (wolfSSH_CleanPath(ssh,
-                                        (char*)ssh->scpBasePath) < 0)
+                                        ssh->scpBasePathDynamic) < 0)
                                 ret = WS_FATAL_ERROR;
                         }
                         break;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -721,11 +721,9 @@ struct WOLFSSH {
     char*  scpRecvMsg;            /* reading up to newline delimiter */
     int    scpRecvMsgSz;          /* current size of scp recv message */
     const char* scpBasePath;      /* base path, ptr into channelList->command */
-#ifdef WOLFSSL_NUCLEUS
     /* alter base path instead of using chdir */
     char* scpBasePathDynamic;     /* dynamic base path */
     word32 scpBasePathSz;
-#endif
     byte   scpIsRecursive;        /* recursive transfer requested */
     byte   scpRequestType;        /* directory or single file */
     byte   scpMsgType;


### PR DESCRIPTION
ZD19249

We should not be attempting any modification on a const char* buffer. This sets it to always be dynamic.