### PR TITLE
Adding define for wc_aes_block_size

### DIFF
--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -459,6 +459,11 @@ WOLFSSH_LOCAL const char* IdToName(byte id);
 WOLFSSH_LOCAL const char* NameByIndexType(byte type, word32* index);
 
 
+/* For cases when openssl coexist is used */
+#ifdef WC_NO_COMPAT_AES_BLOCK_SIZE
+    #define AES_BLOCK_SIZE WC_AES_BLOCK_SIZE
+#endif
+
 #define STATIC_BUFFER_LEN AES_BLOCK_SIZE
 /* This is one AES block size. We always grab one
  * block size first to decrypt to find the size of


### PR DESCRIPTION
Found when compiling with `wolfSSL` built with `--enable-opensslcoexist` it will lead to compile errors like:
```
| ../git/wolfssh/internal.h:462:27: error: 'AES_BLOCK_SIZE' undeclared here (not in a function); did you mean 'WC_AES_BLOCK_SIZE'?
|   462 | #define STATIC_BUFFER_LEN AES_BLOCK_SIZE
|       |                           ^~~~~~~~~~~~~~
| ../git/wolfssh/internal.h:475:31: note: in expansion of macro 'STATIC_BUFFER_LEN'
|   475 |     ALIGN16 byte staticBuffer[STATIC_BUFFER_LEN];
```

Found this issue when trying to make a yocto image that has `wolfSSL`, `wolfSSH`, and `wolfProvider`. wolfProvider needs opensslcoexist according to documentation.