### PR TITLE
Espressif example updates. Same as #770

### DIFF
--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/CMakeLists.txt
@@ -1,6 +1,6 @@
 #  [wolfSSL Project]/CMakeLists.txt
 #
-#  Copyright (C) 2014-2024 wolfSSL Inc.
+#  Copyright (C) 2014-2025 wolfSSL Inc.
 #
 #  This file is part of wolfSSH.
 #
@@ -35,6 +35,13 @@ set(WOLFSSL_USER_SETTINGS ON)
 # Assume we have a ESP_ENABLE_WOLFSSH section in user_settings.h
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DESP_ENABLE_WOLFSSH")
 
+# Managed wolfSSL Components prior to 5.7.4 need a manual setting for WOLFSSL_WOLFSSH
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_WOLFSSH")
+
+# Optional:
+# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSH_TERM")
+# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDEBUG_WOLFSSH")
+
 # The wolfSSL CMake file should be able to find the source code.
 # Otherwise, assign an environment variable or set it here:
 #
@@ -54,28 +61,28 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DESP_ENABLE_WOLFSSH")
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -83,7 +90,7 @@ endif()
 set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
 if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
-    message("Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
     set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
 else()
@@ -116,7 +123,7 @@ endif()
 set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
 
 if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
-    message("Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
     set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
 else()

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/README.md
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/README.md
@@ -11,13 +11,15 @@ To connect:
 ssh -p 22222 jack@192.168.1.32
 ```
 
+The default password for `jack` is 'fetchapail`.
+
 ### Prerequisites
 
 It is assumed the [ESP-IDF environment](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/) has been installed.
 
 ### Files Included
 
-- [main.c](./main/main.c) with a simple call to an Espressif library (`ESP_LOGI`) and a call to a wolfSSL library (`esp_ShowExtendedSystemInfo`) . 
+- [main.c](./main/main.c) with a simple call to an Espressif library (`ESP_LOGI`) and a call to a wolfSSL library (`esp_ShowExtendedSystemInfo`) .
 
 - See [components/wolfssl/include](./components/wolfssl/include/user_settings.h) directory to edit the wolfSSL `user_settings.h`.
 

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssh/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssh/CMakeLists.txt
@@ -1,6 +1,6 @@
 #  [wolfSSL Project]/components/wolfssh/CMakeLists.txt
 #
-#  Copyright (C) 2014-2024 wolfSSL Inc.
+#  Copyright (C) 2014-2025 wolfSSL Inc.
 #
 #  This file is part of wolfSSH.
 #
@@ -25,6 +25,70 @@
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSH_USER_SETTINGS")
 
+set(VERBOSE_COMPONENT_MESSAGES 1)
+
+# The scope of this CMAKE_C_FLAGS is just this component:
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+
+set(CMAKE_CURRENT_SOURCE_DIR ".")
+
+message(STATUS "CMAKE_CURRENT_LIST_DIR = ${CMAKE_CURRENT_LIST_DIR}")
+
+get_filename_component(THIS_DIR "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+message(STATUS "THIS_DIR = ${THIS_DIR}")
+
+# The root of the project is two directories up from here. (we are typically in [project name]components/mywolfssh)
+get_filename_component(PROJECT_ROOT "${THIS_DIR}" DIRECTORY)      # Up one directory from here is "components"
+get_filename_component(PROJECT_ROOT "${PROJECT_ROOT}" DIRECTORY)  # up one more directory should be the root of our project
+message(STATUS "PROJECT_ROOT = ${PROJECT_ROOT}")
+
+# in case wolfssl user_settings.h is missing, we'll look for one in the ESP32/lib directory:
+get_filename_component(LIB_USER_SETTINGS "${PROJECT_ROOT}/../lib/user_settings.h" ABSOLUTE)
+message(STATUS "wolfssl user_settings.h lib  = ${LIB_USER_SETTINGS}")
+
+get_filename_component(THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH "${PROJECT_ROOT}/components/wolfssl/include" ABSOLUTE)
+message(STATUS "wolfssl user_settings.h path = ${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
+
+# Optionally set your source to wolfSSL in your project CMakeLists.txt like this:
+# set(WOLFSSH_ROOT "c:/some/workspace/wolfssh" )
+
+if ( "${WOLFSSH_ROOT}" STREQUAL "")
+    set(WOLFSSH_ROOT "$ENV{WOLFSSH_ROOT}" )
+endif()
+
+# Optional compiler definitions to help with system name detection (typically printed by app diagnostics)
+if( VERBOSE_COMPONENT_MESSAGES )
+    if(WIN32)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
+        message(STATUS "Detected Windows")
+    endif()
+    if(CMAKE_HOST_UNIX)
+        message(STATUS "Detected UNIX")
+    endif()
+    if(APPLE)
+        message(STATUS "Detected APPLE")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
+        message(STATUS "Detected WSL")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
+        message(STATUS "Detected Linux")
+    endif()
+    if(APPLE)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
+        message(STATUS "Detected Apple")
+    endif()
+endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
+
+message(STATUS "CONFIG_TARGET_PLATFORM = ${CONFIG_TARGET_PLATFORM}")
+
+# find the user name to search for possible "wolfssh-username"
 # find the user name to search for possible "wolfssh-username"
 message(STATUS "USERNAME = $ENV{USERNAME}")
 if(  "$ENV{USER}" STREQUAL "" ) # the bash user
@@ -44,7 +108,7 @@ message(STATUS "THIS_USER = ${THIS_USER}")
 #
 # When editing component CMake files, consider the following :
 #
-# NO Managed Componenets: Normal stand-alone app, "as cloned" from github.
+# NO Managed Components: Normal stand-alone app, "as cloned" from github.
 #   There's no notion of staging names (e.g. mywolfssh) regardless of environment settings.
 #   All of the component source is locall. See settings such s WOLFSSL_ROOT=[your path]
 #
@@ -59,12 +123,12 @@ message(STATUS "THIS_USER = ${THIS_USER}")
 #    A partially managed component may also be manually created, when adding a managed component to
 #    and existing project. For example:
 #
-#       idf.py add-dependency "wolfssl/wolfssh^1.4.15-stable"
+#       idf.py add-dependency "wolfssl/wolfssh^1.4.18"
 #
-# Fully Managaged Componenets. This is the typical example as created from the Component Registry:
+# Fully Managed Components. This is the typical example as created from the Component Registry:
 #    For example:
 #
-#       idf.py create-project-from-example "wolfssl/wolfssh^1.4.15-stable:wolfssh_server"
+#       idf.py create-project-from-example "wolfssl/wolfssh^1.4.18"
 #
 # In all cases, keep in mind that components other than wolfssl will depend on the wolfssl component.
 #
@@ -108,7 +172,7 @@ endif()
 set(COMPONENT_REQUIRES lwip "${WOLFSSL_COMPONENT_NAME}")
 
 # function: IS_WOLFSSH_SOURCE
-#  parameter: DIRECTORY_PARAMETER - the directory to test
+#  parameter: DIRECTORY_PARAMETER = the directory to test
 #  output:    RESULT = contains contents of DIRECTORY_PARAMETER for wolfssh directory, otherwise blank.
 function(IS_WOLFSSH_SOURCE DIRECTORY_PARAMETER RESULT)
     if (EXISTS "${DIRECTORY_PARAMETER}/wolfssh/ssh.h")
@@ -132,9 +196,29 @@ endfunction()
 #
 function(FIND_WOLFSSH_DIRECTORY OUTPUT_FOUND_WOLFSSH_DIRECTORY)
     message(STATUS "Starting FIND_WOLFSSH_DIRECTORY")
-    set(CURRENT_SEARCH_DIR "$ENV{WOLFSSH_ROOT}")
-    if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
-        message(STATUS "The WOLFSSH_ROOT environment variable is not set. Searching...")
+
+    message(STATUS "OUTPUT_FOUND_WOLFSSH_DIRECTORY = ${${OUTPUT_FOUND_WOLFSSH_DIRECTORY}}")
+    IS_WOLFSSH_SOURCE("${${OUTPUT_FOUND_WOLFSSH_DIRECTORY}}" FOUND_WOLFSSH)
+    if( FOUND_WOLFSSH )
+        set(${OUTPUT_FOUND_WOLFSSH_DIRECTORY} ${${OUTPUT_FOUND_WOLFSSH_DIRECTORY}} PARENT_SCOPE)
+        return()
+    endif()
+    message(STATUS "")
+
+    if ( "${${OUTPUT_FOUND_WOLFSSH_DIRECTORY}}" STREQUAL "" )
+        set(CURRENT_SEARCH_DIR "$ENV{WOLFSSH_ROOT}")
+        if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
+            message(STATUS "The WOLFSSH_ROOT environment variable is not set. Searching...")
+        else()
+            get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSH_ROOT}" ABSOLUTE)
+            IS_WOLFSSH_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSH)
+            if( FOUND_WOLFSSH )
+                message(STATUS "Found WOLFSSH_ROOT via Environment Variable:")
+            else()
+                message(FATAL_ERROR "WOLFSSH_ROOT Environment Variable defined, but path not found:")
+                message(STATUS "$ENV{WOLFSSH_ROOT}")
+            endif()
+        endif()
     else()
         # There's a non-blank WOLFSSH_ROOT environment variable. Is it a valid wolfssh directory?
         get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSH_ROOT}" ABSOLUTE)
@@ -143,11 +227,11 @@ function(FIND_WOLFSSH_DIRECTORY OUTPUT_FOUND_WOLFSSH_DIRECTORY)
             message(STATUS "Found WOLFSSH_ROOT via Environment Variable:")
         else()
             message(FATAL_ERROR "WOLFSSH_ROOT Environment Variable defined, but path not found: $ENV{WOLFSSH_ROOT}")
-            message(STATUS "Exit CMake")
+            #message(STATUS "Exit CMake")
         endif()
     endif()
 
-    # we'll start in the THIS_CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/WOLFSSH
+    # we'll start in the THIS_CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/wolfssh
     message(STATUS "THIS_CMAKE_CURRENT_SOURCE_DIR = ${THIS_CMAKE_CURRENT_SOURCE_DIR}")
     get_filename_component(CURRENT_SEARCH_DIR "${THIS_CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
     message(STATUS "CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
@@ -156,7 +240,7 @@ function(FIND_WOLFSSH_DIRECTORY OUTPUT_FOUND_WOLFSSH_DIRECTORY)
     # loop through all the parents, looking for wolfssh
     while(NOT CURRENT_SEARCH_DIR STREQUAL "/" AND NOT CURRENT_SEARCH_DIR STREQUAL "" )
         string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
-        # wolfssh may simply be in a parent directory, such as for local examples in WOLFSSH repo
+        # wolfssh may simply be in a parent directory, such as for local examples in wolfssh repo
         IS_WOLFSSH_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSH)
         if( FOUND_WOLFSSH )
             message(STATUS "Found wolfssh in CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
@@ -178,7 +262,7 @@ function(FIND_WOLFSSH_DIRECTORY OUTPUT_FOUND_WOLFSSH_DIRECTORY)
             endif()
         endif()
 
-        # Next check for no user suffix "WOLFSSH" subdirectory as we recurse up the directory tree
+        # Next check for no user suffix "wolfssh" subdirectory as we recurse up the directory tree
         set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssh)
         # if(EXISTS ${CURRENT_SEARCH_DIR} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR} AND EXISTS "${CURRENT_SEARCH_DIR}/wolfcrypt/src")
         IS_WOLFSSH_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSH )
@@ -206,18 +290,18 @@ endfunction()
 # The component name is the directory name. "No feature to change this".
 # See https://github.com/espressif/esp-idf/issues/8978#issuecomment-1129892685
 
-# set the root of WOLFSSH in top-level project CMakelists.txt:
+# set the root of wolfssh in top-level project CMakelists.txt:
 #   set(WOLFSSH_ROOT  "C:/some path/with/spaces")
-#   set(WOLFSSH_ROOT  "c:/workspace/WOLFSSH-[username]")
+#   set(WOLFSSH_ROOT  "c:/workspace/wolfssh-[username]")
 #   set(WOLFSSH_ROOT  "/mnt/c/some path/with/spaces")
 #   or use this logic to assign value from Environment Variable WOLFSSH_ROOT,
 #   or assume this is an example 7 subdirectories below:
 
-# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/WOLFSSH_test/components/WOLFSSH
-# The root of WOLFSSH is 7 directories up from here:
+# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/wolfssh_test/components/wolfssh
+# The root of wolfssh is 7 directories up from here:
 
 if(CMAKE_BUILD_EARLY_EXPANSION)
-    message(STATUS "WOLFSSH component CMAKE_BUILD_EARLY_EXPANSION:")
+    message(STATUS "wolfssh component CMAKE_BUILD_EARLY_EXPANSION:")
     idf_component_register(
                             REQUIRES "${COMPONENT_REQUIRES}"
                             PRIV_REQUIRES
@@ -233,16 +317,110 @@ else()
     message(STATUS "************************************************************************************************")
     FIND_WOLFSSH_DIRECTORY(WOLFSSH_ROOT)
 
-    set(WOLFSSH_ROOT "${WOLFSSH_ROOT}" CACHE STRING "WOLFSSH_ROOT")
-    if(WOLFSSH_ROOT)
-        message(STATUS "Found wolfssh directory at: ${WOLFSSH_ROOT}")
-    else()
-        message(STATUS "wolfssh directory not found.")
-        # Abort. We need wolfmqtt _somewhere_.
-        message(FATAL_ERROR "Could not find wolfssh in ${WOLFSSH_ROOT}.\n"
-                            "Try setting WOLFSSH_ROOT environment variable or git clone.")
+    # Check to see if we're already in WOLFSSH, and only if WOLFSSH_ROOT not specified
+    if ("${WOLFSSH_ROOT}" STREQUAL "")
+        # WOLFSSH examples are 7 directories deep from WOLFSSH repo root
+        #                        1  2  3  4  5  6  7
+        set(THIS_RELATIVE_PATH "../../../../../../..")
+        get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+        message(STATUS "Searching in path = ${THIS_SEARCH_PATH}")
+
+        if (EXISTS "${THIS_SEARCH_PATH}/wolfcrypt/src")
+            # we're already in WOLFSSH examples!
+            get_filename_component(WOLFSSH_ROOT  "${THIS_SEARCH_PATH}" ABSOLUTE)
+            message(STATUS "Using WOLFSSH example with root ${WOLFSSH_ROOT}")
+        else()
+            # We're in some other repo such as wolfssh, so we'll search for an
+            # adjacent-level directory for WOLFSSH. (8 directories up, then down one)
+            #
+            # For example WOLFSSH examples:
+            #   C:\workspace\WOLFSSH-gojimmypi\IDE\Espressif\ESP-IDF\examples\WOLFSSH_benchmark\components\WOLFSSH
+            #
+            # For example wolfSSH examples:
+            #   C:\workspace\wolfssh-gojimmypi\ide\Espressif\ESP-IDF\examples\wolfssh_benchmark\components\WOLFSSH
+            #
+            #                        1  2  3  4  5  6  7  8
+            set(THIS_RELATIVE_PATH "../../../../../../../..")
+            get_filename_component(THIS_SEARCH_PATH  "${THIS_RELATIVE_PATH}" ABSOLUTE)
+            message(STATUS "Searching next in path = ${THIS_SEARCH_PATH}")
+        endif()
     endif()
 
+    # search other possible locations
+    if ("${WOLFSSH_ROOT}" STREQUAL "")
+        # there's not a hard-coded WOLFSSH_ROOT value above, so let's see if we can find it.
+        if( "$ENV{WOLFSSH_ROOT}" STREQUAL "" )
+            message(STATUS "Environment Variable WOLFSSH_ROOT not set. Will search common locations.")
+
+            message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+            get_filename_component(THIS_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+            message(STATUS "THIS_DIR = ${THIS_DIR}")
+
+            # find the user name to search for possible "WOLFSSH-username"
+            message(STATUS "USERNAME = $ENV{USERNAME}")
+            if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+                if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+                    message(STATUS "could not find USER or USERNAME")
+                else()
+                    # the bash user is not blank, so we'll use it.
+                    set(THIS_USER "$ENV{USERNAME}")
+                endif()
+            else()
+                # the bash user is not blank, so we'll use it.
+               set(THIS_USER "$ENV{USER}")
+            endif()
+            message(STATUS "THIS_USER = ${THIS_USER}")
+
+            # This same makefile is used for both the WOLFSSH component, and other
+            # components that may depend on WOLFSSH, such as wolfssh. Therefore
+            # we need to determine if this makefile is in the WOLFSSH repo, or
+            # some other repo.
+
+            if(  "{THIS_USER}" STREQUAL "" )
+                # This is highly unusual to not find a user name.
+                # In this case, we'll just search for a "WOLFSSH" directory:
+                message(STATUS "No username found!")
+                get_filename_component(WOLFSSH_ROOT  "${THIS_RELATIVE_PATH}/WOLFSSH" ABSOLUTE)
+            else()
+                # We found an environment USER name!
+                # The first place to look for WOLFSSH will be in a user-clone called "WOLFSSH-[username]"
+                message(STATUS "Using [THIS_USER = ${THIS_USER}] to see if there's a [relative path]/WOLFSSH-${THIS_USER} directory.")
+                get_filename_component(WOLFSSH_ROOT  "${THIS_RELATIVE_PATH}/WOLFSSH-${THIS_USER}" ABSOLUTE)
+
+                if( EXISTS "${WOLFSSH_ROOT}" )
+                    message(STATUS "Found WOLFSSH in user-suffix ${WOLFSSH_ROOT}")
+                else()
+                    # If there's not a user-clone called "WOLFSSH-[username]",
+                    # perhaps there's simply a git clone called "WOLFSSH"?
+                    message(STATUS "Did not find WOLFSSH-${THIS_USER}; continuing search...")
+                    get_filename_component(WOLFSSH_ROOT  "${THIS_RELATIVE_PATH}/WOLFSSH" ABSOLUTE)
+
+                    if( EXISTS "${WOLFSSH_ROOT}" )
+                        message(STATUS "Found WOLFSSH in standard ${WOLFSSH_ROOT}")
+                    else()
+                        # Things are looking pretty bleak. We'll likely not be able to compile.
+                        message(STATUS "Did not find WOLFSSH in ${WOLFSSH_ROOT}")
+                    endif()
+                endif()
+            endif()
+
+        else()
+            # there's an environment variable, so use it.
+            set(WOLFSSH_ROOT "$ENV{WOLFSSH_ROOT}")
+
+            if( EXISTS "${WOLFSSH_ROOT}" )
+                get_filename_component(WOLFSSH_ROOT  "$ENV{WOLFSSH_ROOT}" ABSOLUTE)
+                message(STATUS "Found WOLFSSH_ROOT via Environment Variable:")
+            else()
+                message(FATAL_ERROR "WOLFSSH_ROOT Environment Variable defined, but path not found:")
+                message(STATUS "$ENV{WOLFSSH_ROOT}")
+            endif()
+        endif()
+        # end of search for WOLFSSH component root
+    else()
+        # There's already a value assigned; we won't search for anything else.
+        message(STATUS "Found user-specified WOLFSSH_ROOT value.")
+    endif() # WOLFSSH_ROOT user defined
 
     # After all the logic above, does our WOLFSSH_ROOT actually exist?
     if( EXISTS "${WOLFSSH_ROOT}" )
@@ -270,86 +448,97 @@ else()
     message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
 
     #
-    # Check to see if there's both a local copy and EDP-IDF copy of the WOLFSSH and/or wolfssh components.
+    # Check to see if there's both a local copy and EDP-IDF copy of the wolfssh and/or wolfssh components.
     #
-    if( EXISTS "${WOLFSSH_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/WOLFSSH/" )
+    if( EXISTS "${WOLFSSH_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssh/" )
         #
-        # WOLFSSH found in both ESP-IDF and local project - needs to be resolved by user
+        # wolfssh found in both ESP-IDF and local project - needs to be resolved by user
         #
         message(STATUS "")
         message(STATUS "**************************************************************************************")
         message(STATUS "")
-        message(STATUS "Error: Found components/WOLFSSH in both local project and IDF_PATH")
+        message(STATUS "Error: Found components/wolfssh in both local project and IDF_PATH")
         message(STATUS "")
         message(STATUS "To proceed: ")
         message(STATUS "")
         message(STATUS "Remove either the local project component: ${WOLFSSH_PROJECT_DIR} ")
-        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/WOLFSSH/ ")
+        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssh/ ")
         message(STATUS "")
-        message(FATAL_ERROR "Please use WOLFSSH in either local project or Espressif components, but not both.")
+        message(FATAL_ERROR "Please use wolfssh in either local project or Espressif components, but not both.")
         message(STATUS "")
         message(STATUS "**************************************************************************************")
         message(STATUS "")
+
+        message(STATUS "Please use wolfSSL in either local project or Espressif components, but not both.")
 
         # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSH_MULTI_INSTALL_WARNING")
 
     else()
-        if( EXISTS "$ENV{IDF_PATH}/components/WOLFSSH/" )
+        if( EXISTS "$ENV{IDF_PATH}/components/wolfssh/" )
             #
-            # WOLFSSH found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
+            # wolfssh found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
             #
             message(STATUS "")
-            message(STATUS "Using components/WOLFSSH in IDF_PATH = $ENV{IDF_PATH}")
+            message(STATUS "Using components/wolfssh in IDF_PATH = $ENV{IDF_PATH}")
             message(STATUS "")
         else()
             #
-            # WOLFSSH is not an ESP-IDF component.
-            # We need to now determine if it is local and if so if it is part of the WOLFSSH repo,
-            # or if  WOLFSSH is simply installed as a local component.
+            # wolfssh is not an ESP-IDF component.
+            # We need to now determine if it is local and if so if it is part of the wolfssh repo,
+            # or if  wolfssh is simply installed as a local component.
             #
 
             if( EXISTS "${WOLFSSH_PROJECT_DIR}" )
                 #
-                # WOLFSSH found in local project.
+                # wolfssh found in local project.
                 #
                 if( EXISTS "${WOLFSSH_PROJECT_DIR}/wolfcrypt/" )
                     message(STATUS "")
-                    message(STATUS "Using installed project ./components/WOLFSSH in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "Using installed project ./components/wolfssh in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
                     message(STATUS "")
                     #
-                    # Note we already checked above and confirmed there's not another WOLFSSH installed in the ESP-IDF components.
+                    # Note we already checked above and confirmed there's not another wolfssh installed in the ESP-IDF components.
                     #
                     # We won't do anything else here, as it will be assumed the original install completed successfully.
                     #
-                else() # full WOLFSSH not installed in local project
+                else() # full wolfssh not installed in local project
                     #
-                    # This is the developer repo mode. WOLFSSH will be assumed to be not installed to ESP-IDF nor local project
-                    # In this configuration, we are likely running a WOLFSSH example found directly in the repo.
+                    # This is the developer repo mode. wolfssh will be assumed to be not installed to ESP-IDF nor local project
+                    # In this configuration, we are likely running a wolfssh example found directly in the repo.
                     #
                     message(STATUS "")
-                    message(STATUS "Using developer repo ./components/WOLFSSH in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "Using developer repo ./components/wolfssh in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
                     message(STATUS "")
 
                     message(STATUS "************************************************************************************************")
-                    # When in developer mode, we are typically running WOLFSSH examples such as benchmark or test directories.
-                    # However, the as-cloned or distributed WOLFSSH does not have the ./include/ directory, so we'll add it as needed.
+                    # When in developer mode, we are typically running wolfssh examples such as benchmark or test directories.
+                    # However, the as-cloned or distributed wolfssh does not have the ./include/ directory, so we'll add it as needed.
                     #
                     # first check if there's a [root]/include/user_settings.h
                     if( EXISTS "${WOLFSSH_ROOT}/include/user_settings.h" )
-                        message(FATAL_ERROR "Found stray WOLFSSH user_settings.h in "
+                        message(FATAL_ERROR "Found stray wolfssh user_settings.h in "
                                             "${WOLFSSH_ROOT}/include/user_settings.h "
-                                            " (please move it to ${WOLFSSH_PROJECT_DIR}/include/user_settings.h )")
+                                            " (please move it to ${WOLFSSH_PROJECT_DIR}/components/wolfssl/include/user_settings.h )")
                     else()
                         # we won't overwrite an existing user settings file, just note that we already have one:
-                        if( EXISTS "${WOLFSSH_PROJECT_DIR}/include/user_settings.h" )
-                            message(STATUS "Using existing WOLFSSH user_settings.h in "
-                                           "${WOLFSSH_PROJECT_DIR}/include/user_settings.h")
+                        if( EXISTS "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}/user_settings.h" )
+                            message(STATUS "Using existing wolfssh user_settings.h in "
+                                           "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
                         else()
-                            message(STATUS "Installing WOLFSSH user_settings.h to "
-                                           "${WOLFSSH_PROJECT_DIR}/include/user_settings.h")
-                            # file(COPY "${WOLFSSH_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h"
-                            # DESTINATION "${CMAKE_HOME_DIRECTORY}/WOLFSSH/include/")
+                            if(EXISTS "${LIB_USER_SETTINGS}" )
+                                message(STATUS "Installing wolfssh user_settings.h to "
+                                               "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
+                                file(COPY        "${LIB_USER_SETTINGS}"
+                                     DESTINATION "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
+                                if( EXISTS "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}/user_settings.h" )
+                                    message(STATUS "Confirmed  wolfssl user_settings.h in ${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
+                                else()
+                                    message(ERROR "ERROR: Failed to copy wolfssl user_settings.h from ${LIB_USER_SETTINGS} to ${LIB_USER_SETTINGS}")
+                                endif()
+                            else()
+                                message(ERROR "wolfssl user_settings.h not in project, and not found in ${LIB_USER_SETTINGS}")
+                            endif()
                         endif()
                     endif() # user_settings.h
 
@@ -358,19 +547,19 @@ else()
                 endif()
 
             else()
-                # we did not find a ./components/WOLFSSH/include/ directory from this pass of cmake.
+                # we did not find a ./components/wolfssh/include/ directory from this pass of cmake.
                 if($WOLFSSH_FOUND_IDF)
                     message(STATUS "")
-                    message(STATUS "WARNING: WOLFSSH not found.")
+                    message(STATUS "WARNING: wolfssh not found.")
                     message(STATUS "")
                 else()
                     # probably needs to be re-parsed by Espressif
-                    message(STATUS "WOLFSSH found IDF. Project Source:${PROJECT_SOURCE_DIR}")
+                    message(STATUS "wolfssh found IDF. Project Source:${PROJECT_SOURCE_DIR}")
                 endif() # else we have not found ESP-IDF yet
-            endif() # else not a local WOLFSSH component
+            endif() # else not a local wolfssh component
 
         endif() #else not an ESP-IDF component
-    endif() # else not local copy and EDP-IDF WOLFSSH
+    endif() # else not local copy and EDP-IDF wolfssh
 
 
     # RTOS_IDF_PATH is typically:
@@ -459,17 +648,17 @@ else()
         message(STATUS "")
     endif()
 
-    # target_sources(WOLFSSH PRIVATE  "\"${WOLFSSH_ROOT}/WOLFSSH/\""  "\"${WOLFSSH_ROOT}/WOLFSSH/wolfcrypt\"")
+    # target_sources(wolfssh PRIVATE  "\"${WOLFSSH_ROOT}/wolfssh/\""  "\"${WOLFSSH_ROOT}/wolfssh/wolfcrypt\"")
 endif() # CMAKE_BUILD_EARLY_EXPANSION
 
 
 
-# check to see if there's both a local copy and EDP-IDF copy of the WOLFSSH components
-if( EXISTS "${WOLFSSH_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/WOLFSSH/" )
+# check to see if there's both a local copy and EDP-IDF copy of the wolfssh components
+if( EXISTS "${WOLFSSH_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssh/" )
     message(STATUS "")
     message(STATUS "")
     message(STATUS "********************************************************************")
-    message(STATUS "WARNING: Found components/WOLFSSH in both local project and IDF_PATH")
+    message(STATUS "WARNING: Found components/wolfssh in both local project and IDF_PATH")
     message(STATUS "********************************************************************")
     message(STATUS "")
 endif()
@@ -539,6 +728,6 @@ if(NOT CMAKE_BUILD_EARLY_EXPANSION)
     LIBWOLFSSH_SAVE_INFO(LIBWOLFSSH_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
 
     message(STATUS "************************************************************************************************")
-    message(STATUS "WOLFSSH component config complete!")
+    message(STATUS "wolfssh component config complete!")
     message(STATUS "************************************************************************************************")
 endif()

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2024 wolfSSL Inc.
+#  Copyright (C) 2014-2025 wolfSSL Inc.
 #
 #  This file is part of wolfSSH.
 #
@@ -18,17 +18,67 @@
 #
 # cmake for wolfssl Espressif projects
 #
-# Version 5.7.0 template update + THIS_IDF_PATH
+# Version 5.7.2 Espressif ESP-IDF integration
 #
 # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
 #
-
+message(STATUS "Begin wolfssl ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
 cmake_minimum_required(VERSION 3.16)
 
 set(VERBOSE_COMPONENT_MESSAGES 1)
 
+# Optional requires include:
+# set(THIS_ESP_TLS "esp-tls")
+set(THIS_ESP_TLS "")
+
+# function: IS_ESP_IDF_COMPONENT
+#  output:    RESULT = 1 (true) if this component is located in the ESP-IDF components
+#             otherwise 0 (false)
+function( IS_ESP_IDF_COMPONENT  RESULT )
+    # NOTE: Component location is based on the location of the CMakeList.txt
+    # and *not* the location of the wolfSSL source code. (which may be anywhere)
+
+    # Normalize the paths to remove any trailing slashes
+    get_filename_component(NORMALIZED_IDF_PATH  "${IDF_PATH}"      REALPATH)
+    get_filename_component(NORMALIZED_TEST_PATH "${COMPONENT_DIR}" REALPATH)
+
+    # Check if the test path starts with the IDF_PATH
+    string(FIND "${NORMALIZED_TEST_PATH}" "${NORMALIZED_IDF_PATH}" pos)
+
+    if(${pos} EQUAL 0)
+        message(STATUS "${COMPONENT_DIR} is within IDF_PATH.")
+        set(${RESULT} 1 PARENT_SCOPE)
+    else()
+        message(STATUS "${COMPONENT_DIR} is not within IDF_PATH.")
+        set(${RESULT} 0 PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Determine if this cmake file is located in the ESP-IDF component directory or not,
+# and if so, if it is being ignored (allowing the use of a local project one, instead).
+IS_ESP_IDF_COMPONENT( IS_WOLSSL_ESP_IDF_COMPONENT )
+if( IS_WOLSSL_ESP_IDF_COMPONENT )
+    message(STATUS "This wolfSSL is a component in ESP-IDF.")
+    if ( CONFIG_IGNORE_ESP_IDF_WOLFSSL_COMPONENT )
+        idf_component_register()
+        message(STATUS "Warning: wolfSSL component in ESP-IDF is being ignored.")
+        return()
+    endif()
+endif()
+
+
+if( "${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}" STREQUAL "" )
+    # nothing to do
+else()
+    # Only forward slashes, or double backslashes are supported.
+    # By the time we get here the sdkconfig file has a value for wolfSSL source code root.
+    string(REPLACE "\\" "/" CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT})
+    message(STATUS "Cleaned wolfssl path: ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
+endif()
+
 # The scope of this CMAKE_C_FLAGS is just this component:
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWOLFSSL_USER_SETTINGS")
 
 set(CMAKE_CURRENT_SOURCE_DIR ".")
 # set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
@@ -41,7 +91,7 @@ if ( "${WOLFSSL_ROOT}" STREQUAL "")
 endif()
 
 if(  "$ENV{IDF_PATH}" STREQUAL "" )
-     message(FATAL_ERROR "IDF_PATH Environment variable not set!")
+    message(FATAL_ERROR "IDF_PATH Environment variable not set!")
 else()
     string(REPLACE "\\" "/" THIS_IDF_PATH "$ENV{IDF_PATH}")
 endif()
@@ -51,28 +101,28 @@ if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-        message("Detected Windows")
+        message(STATUS "Detected Windows")
     endif()
     if(CMAKE_HOST_UNIX)
-        message("Detected UNIX")
+        message(STATUS "Detected UNIX")
     endif()
     if(APPLE)
-        message("Detected APPLE")
+        message(STATUS "Detected APPLE")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-        message("Detected WSL")
+        message(STATUS "Detected WSL")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-        message("Detected Linux")
+        message(STATUS "Detected Linux")
     endif()
     if(APPLE)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-        message("Detected Apple")
+        message(STATUS "Detected Apple")
     endif()
 endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -105,10 +155,11 @@ if( ("${CMAKE_PROJECT_NAME}" STREQUAL "wolfssl_benchmark") OR ("${CMAKE_PROJECT_
     message(STATUS "Not including lwip for ${CMAKE_PROJECT_NAME}")
 else()
     # benchmark and test do not need wifi, everything else probably does:
-    set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
+    set(COMPONENT_REQUIRES lwip "${THIS_ESP_TLS}") # we typically don't need lwip directly in wolfssl component
 endif()
 
-# find the user name to search for possible "wolfssl-username"
+# Find the user name to search for possible "wolfssl-username"
+# Reminder: Windows is  %USERNAME%, Linux is $USER
 message(STATUS "USERNAME = $ENV{USERNAME}")
 if(  "$ENV{USER}" STREQUAL "" ) # the bash user
     if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
@@ -123,6 +174,30 @@ else()
 endif()
 message(STATUS "THIS_USER = ${THIS_USER}")
 
+if( "$ENV{IDF_PATH}" STREQUAL "" )
+    message(FATAL_ERROR "IDF_PATH Environment variable not set!")
+else()
+    string(REPLACE "\\" "/" THIS_IDF_PATH "$ENV{IDF_PATH}")
+endif()
+
+# ENVIRONMENT_VAR_TO_MACRO
+# Check environment variable name EVARPARAM as [name]
+# If defined, and has a value of EVARVALUE as [value],
+# then assign a compiler definition "-D[name]=[value]"
+function(ENVIRONMENT_VAR_TO_MACRO EVARPARAM EVARVALUE)
+    # If the EVARPARAM environment variable name is set to EVARVALUE,
+    # set the compiler flag definition to enable CSV output.
+    if ( "$ENV{${EVARPARAM}}" STREQUAL "${EVARVALUE}")
+        message(STATUS "Appending compile definition: -D${EVARPARAM}=${EVARVALUE}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D${EVARPARAM}=${EVARVALUE}")
+    else()
+        if(DEFINED ENV{${EVARPARAM}})
+            message(STATUS "Environment variable ${EVARPARAM} detected but set to $ENV{${EVARPARAM}}, not appending compile definition.")
+        else()
+            message(STATUS "Environment variable ${EVARPARAM} not detected, not appending compile definition.")
+        endif()
+    endif()
+endfunction()
 
 # COMPONENT_NAME = wolfssl
 # The component name is the directory name. "No feature to change this".
@@ -141,7 +216,8 @@ message(STATUS "THIS_USER = ${THIS_USER}")
 # function: IS_WOLFSSL_SOURCE
 #  parameter: DIRECTORY_PARAMETER - the directory to test
 #  output:    RESULT = contains contents of DIRECTORY_PARAMETER for wolfssl directory, otherwise blank.
-function(IS_WOLFSSL_SOURCE DIRECTORY_PARAMETER RESULT)
+function( IS_WOLFSSL_SOURCE  DIRECTORY_PARAMETER
+          RESULT )
     if (EXISTS "${DIRECTORY_PARAMETER}/wolfcrypt/src")
         set(${RESULT} "${DIRECTORY_PARAMETER}" PARENT_SCOPE)
     else()
@@ -160,26 +236,56 @@ function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
     message(STATUS "Starting FIND_WOLFSSL_DIRECTORY: ${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
 
     if ( "${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}" STREQUAL "" )
+        # The parameter is empty, so we certainly need to search.
+        # First, see if there's an environment variable. This takes highest priority (unless already found as hard-coded, above)
         set(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}")
         if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
             message(STATUS "The WOLFSSL_ROOT environment variable is not set. Searching...")
-        else()
-            get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
-            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
-            if( FOUND_WOLFSSL )
-                message(STATUS "Found WOLFSSL_ROOT via Environment Variable:")
+            # Next, if not found, see if wolfSSL was selected for ESP-TLS Kconfig
+            if(CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT)
+                set(CURRENT_SEARCH_DIR ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT})
+                get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" ABSOLUTE)
+                message(STATUS "WOLFSSL_ROOT found in sdkconfig/KConfig: ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
             else()
-                message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
-                message(STATUS "$ENV{WOLFSSL_ROOT}")
-            endif()
-        endif()
+                message(STATUS "wolfSSL not defined in [Component Config] [wolfssl]. Continuing search...")
+                # If not specified as a search hint in OUTPUT_FOUND_WOLFSSL_DIRECTORY:
+                # This wolfSSL component CMakeLists.txt may be found EITHER in:
+                #   1) local project component
+                #   2) ESP-IDF share components
+                # We'll start in the CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/wolfssl
+                # That option might find wolfSSL source code as a copy in the component directory (e.g. Managed Components)
+                # Unless cmake is in the ESP-IDF, in which case it is unlikely to find wolfSSL source in any parent.
+                message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+                get_filename_component(CURRENT_SEARCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+                message(STATUS "CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+                string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
+            endif() # CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT
+        endif() # check environment var blank
     else()
-        get_filename_component(CURRENT_SEARCH_DIR "${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}" ABSOLUTE)
+        message(STATUS "Parameter found for FIND_WOLFSSL_DIRECTORY")
+        message(STATUS "Setting wolfSSL search directory to: ${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+        set(CURRENT_SEARCH_DIR "${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+    endif() # parameter empty
+
+    # Check to see if we found a path in environment or config settings, above.
+    if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
+        message(STATUS "Source for wolfSSL not specified in path nor config settings.")
+        # We'll continue the search by recursing up the directory tree, below.
+    else()
+        # Setting found! Does it contain a valid path?
+        string(REPLACE "\\" "/" CURRENT_SEARCH_DIR ${CURRENT_SEARCH_DIR})
+        get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" ABSOLUTE)
         IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
         if( FOUND_WOLFSSL )
-            message(STATUS "Found WOLFSSL_ROOT via prior specification.")
+            message(STATUS "Found wolfSSL source code via setting: ${CURRENT_SEARCH_DIR}")
+            set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+            return()
         else()
-            message(FATAL_ERROR "WOLFSSL_ROOT Variable defined, but path not found: ${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+            if(WIN32)
+                message(STATUS "When specifying a path for Windows, use forward slahes, or double backslashes.")
+            endif()
+            message(STATUS "CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT sdkconfig setting = ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
+            message(STATUS "WOLFSSL_ROOT Variable defined, but source code not found: ${CURRENT_SEARCH_DIR}")
         endif()
     endif()
 
@@ -280,6 +386,11 @@ endfunction()
 
 message(STATUS "CONFIG_TARGET_PLATFORM = ${CONFIG_TARGET_PLATFORM}")
 
+# Check for environment variable that may be assigned to macros
+ENVIRONMENT_VAR_TO_MACRO("GENERATE_MACHINE_PARSEABLE_REPORT" "1")
+ENVIRONMENT_VAR_TO_MACRO("WOLFSSL_BENCHMARK_FIXED_CSV"       "1")
+
+# Optional variable inspection
 if (0)
     get_cmake_property(_variableNames VARIABLES)
     list (SORT _variableNames)
@@ -296,15 +407,25 @@ endif()
 
 if ( ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266") OR ("${IDF_TARGET}" STREQUAL "esp8266") )
     # There's no esp_timer, no driver components for the ESP8266
-    message(STATUS "Early expansion EXCLUDES esp_timer: ${THIS_INCLUDE_TIMER}")
-    message(STATUS "Early expansion EXCLUDES driver: ${THIS_INCLUDE_DRIVER}")
-    set(THIS_INCLUDE_TIMER "")
-    set(THIS_INCLUDE_DRIVER "")
+    message(STATUS "Early expansion EXCLUDES for esp8266:")
+    message(STATUS "THIS_INCLUDE_DRIVER:  '${THIS_INCLUDE_DRIVER}'")
+    message(STATUS "THIS_INCLUDE_TIMER:   '${THIS_INCLUDE_TIMER}'")
+    message(STATUS "Early expansion INCLUDE for esp8266:")
+    message(STATUS "THIS_INCLUDE_PTHREAD: '${THIS_INCLUDE_PTHREAD}'")
+    set(THIS_ESP_TLS         "")
+    set(THIS_INCLUDE_DRIVER  "")
+    set(THIS_INCLUDE_TIMER   "")
+    set(THIS_INCLUDE_PTHREAD "pthread")
 else()
     message(STATUS "Early expansion includes esp_timer: ${THIS_INCLUDE_TIMER}")
     message(STATUS "Early expansion includes driver: ${THIS_INCLUDE_DRIVER}")
-    set(THIS_INCLUDE_TIMER "esp_timer")
+    set(THIS_ESP_TLS        "esp-tls")
     set(THIS_INCLUDE_DRIVER "driver")
+    set(THIS_INCLUDE_TIMER  "esp_timer")
+    set(THIS_INCLUDE_PTHREAD "")
+    # Let the app know that we've included the esp-tls component requirement.
+    # This is critical for use the the esp-tls component. See wolfssl esp_crt_bundle.c file.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_REQUIRED_ESP_TLS=1")
 endif()
 
 if(CMAKE_BUILD_EARLY_EXPANSION)
@@ -312,8 +433,10 @@ if(CMAKE_BUILD_EARLY_EXPANSION)
     idf_component_register(
                             REQUIRES "${COMPONENT_REQUIRES}"
                             PRIV_REQUIRES # esp_hw_support
-                                          ${THIS_INCLUDE_TIMER}
-                                          ${THIS_INCLUDE_DRIVER} # this will typically only be needed for wolfSSL benchmark
+                                          "${THIS_ESP_TLS}"
+                                          "${THIS_INCLUDE_PTHREAD}"
+                                          "${THIS_INCLUDE_TIMER}"
+                                          "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
                            )
 
 else()
@@ -321,6 +444,15 @@ else()
     message(STATUS "************************************************************************************************")
     message(STATUS "wolfssl component config:")
     message(STATUS "************************************************************************************************")
+
+    if ( "${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266")
+        # There's no esp_timer, no driver components for the ESP8266
+        set(THIS_INCLUDE_TIMER "")
+        set(THIS_INCLUDE_DRIVER "")
+    else()
+        set(THIS_INCLUDE_TIMER "esp_timer")
+        set(THIS_INCLUDE_DRIVER "driver")
+    endif()
 
     # search for wolfSSL
     FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
@@ -335,7 +467,9 @@ else()
             # Abort CMake after fatal error.
         endif()
     else()
-        message(STATUS "Searching for wolfSL source code...")
+        message(STATUS "Source code for wolfSSL still not found.")
+        message(STATUS "Searching from project home: ${CMAKE_HOME_DIRECTORY} ...")
+        set(WOLFSSL_ROOT "${CMAKE_HOME_DIRECTORY}")
         FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
     endif()
 
@@ -343,11 +477,18 @@ else()
     if(WOLFSSL_ROOT)
         message(STATUS "Confirmed wolfssl directory at: ${WOLFSSL_ROOT}")
     else()
-        message(STATUS "Failed: wolfssl directory not found.")
+        # Try to allow a more intuitive error that the source code was not found in cmake:
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_WARNING_SOURCE_NOT_FOUND")
+
+        message(STATUS "Failed: wolfssl source code directory not found.")
         # Abort. We need wolfssl _somewhere_.
-        message(FATAL_ERROR "Could not find wolfssl in any parent directory named wolfssl-${THIS_USER}, wolfssl-master, or wolfssl.\n"
-                            "Try setting WOLFSSL_ROOT environment variable, cmake variable in project, copy source, or use managed components.")
-        # Abort CMake after fatal error.
+        message(STATUS "")
+        message(STATUS "")
+        message(STATUS "Could not find wolfssl in any parent directory named wolfssl-${THIS_USER}, wolfssl-master, or wolfssl.\n"
+                       "Try setting WOLFSSL_ROOT environment variable, cmake variable in project, copy source, or use managed components.")
+        message(STATUS "")
+        message(STATUS "")
+        # Abort CMake after fatal error. (or not?)
     endif()
 
     set(INCLUDE_PATH ${WOLFSSL_ROOT})
@@ -373,22 +514,24 @@ else()
         endif()
     endif()
 
+    message(STATUS "WOLFSSL_EXTRA_PROJECT_DIR = ${WOLFSSL_EXTRA_PROJECT_DIR}")
     set(COMPONENT_SRCDIRS "\"${WOLFSSL_ROOT}/src/\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/esp_crt_bundle\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel\""
                           "\"${WOLFSSL_EXTRA_PROJECT_DIR}\""
                          ) # COMPONENT_SRCDIRS
 
     message(STATUS "This COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
 
-    # wolfSSL user_settings.h is in the local project.
+    # wolfSSL user_settings.h may be in the local project.
+    # TODO check if exists and possibly set to ESP-IDF
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
-    # add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
-    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h")
-
+    add_compile_definitions(WOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+    message(STATUS "Added definition for user_settings.h: -DWOLFSSL_USER_SETTINGS_DIR=\"${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h\"")
     # Espressif may take several passes through this makefile. Check to see if we found IDF
     string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
 
@@ -421,8 +564,7 @@ else()
         message(STATUS "**************************************************************************************")
         message(STATUS "")
 
-        message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
-        # Abort CMake after fatal error.
+        message(STATUS "Please use wolfSSL in either local project or Espressif components, but not both.")
 
         # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
@@ -530,7 +672,9 @@ else()
     # depending on the environment, we may need to swap backslashes with forward slashes
     string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
 
-    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+    if(WOLFSSL_ROOT)
+        string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+    endif()
 
     if(IS_DIRECTORY "${RTOS_IDF_PATH}")
         message(STATUS "Found current RTOS path: ${RTOS_IDF_PATH}")
@@ -546,12 +690,16 @@ else()
     message(STATUS "THIS_IDF_PATH = $THIS_IDF_PATH")
     # wolfSSL-specific include directories
     set(COMPONENT_ADD_INCLUDEDIRS
-        "./include" # this is the location of wolfssl user_settings.h
+        "./include" # this is the location of local project wolfssl user_settings.h
         "\"${WOLFSSL_ROOT}/\""
         "\"${WOLFSSL_ROOT}/wolfssl/\""
         "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
         "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/port/Espressif\""
         "\"${RTOS_IDF_PATH}/\""
+        # wolfSSL release after v5.7 includes WiFi, time, and mem/debug helpers
+        "${THIS_IDF_PATH}/components/esp_event/include"
+        "${THIS_IDF_PATH}/components/esp_netif/include"
+        "${THIS_IDF_PATH}/components/esp_wifi/include"
         )
 
     # Optionally include cryptoauthlib if present
@@ -579,8 +727,8 @@ else()
         "\"${WOLFSSL_ROOT}/src/ssl_sess.c\""    # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/x509.c\""
         "\"${WOLFSSL_ROOT}/src/x509_str.c\""
-        "\"${WOLFSSL_ROOT}/wolfcrypt/src/ext_kyber.c\""     # external Kyber disabled by default
-        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/ext_kyber.h\"" # external Kyber disabled by default
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/ext_kyber.c\""     # external non-wolfssl Kyber disabled by default
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/ext_kyber.h\"" # external non-wolfssl Kyber disabled by default
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_arm32.c\""
@@ -591,6 +739,7 @@ else()
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_cortexm.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_x86_64.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_x86_64_asm.S\""
+        "\"${WOLFSSL_ROOT}/examples\"" # Examples are distributed in Managed Components, but not part of a project.
         "\"${EXCLUDE_ASM}\""
         )
 
@@ -612,15 +761,120 @@ else()
     # see https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/build-system.html?highlight=space%20path
     #
     set(EXTRA_COMPONENT_DIRS "${COMPONENT_SRCDIRS}")
-    idf_component_register(
-                            SRC_DIRS "${COMPONENT_SRCDIRS}"
-                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
-                            REQUIRES "${COMPONENT_REQUIRES}"
-                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
-                            PRIV_REQUIRES
-                              "${THIS_INCLUDE_TIMER}"
-                              "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
-                           )
+
+    if(WOLFSSL_ROOT)
+        # Only register the component if we found wolfSSL source.
+        # This is important to allow Cmake to finish to completion, otherwise the UI
+        # may not be able to display the Kconfig settings to fix a bad or missing source.
+        idf_component_register(
+                                SRC_DIRS "${COMPONENT_SRCDIRS}"
+                                INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                                REQUIRES "${COMPONENT_REQUIRES}"
+                                EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                                PRIV_REQUIRES
+                                  "${THIS_ESP_TLS}"
+                                  "${THIS_INCLUDE_TIMER}"
+                                  "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
+                               )
+    else()
+        # Register the component simply to allow CMake to complete, but there's no wolfSSL source.
+        # Expect many other errors, but the project should at least be loadable and UI can edit Kconfig settings.
+        idf_component_register()
+        message(STATUS "Warning: wolfSSL component not registered as no source code found (WOLFSSL_ROOT is blank)")
+    endif()
+
+# function(WOLFSSL_INIT_CERT_BUNDLE)
+if( CONFIG_WOLFSSL_CERTIFICATE_BUNDLE
+    AND NOT CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+    AND NOT ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266")
+  )
+    if (CMAKE_BUILD_EARLY_EXPANSION)
+        message(ERROR "Bundle Cert initialization must occur during CMAKE_BUILD_EARLY_EXPANSION")
+    endif()
+    # reminder: we need a value for wolfSSL root first!
+    if( "${WOLFSSL_ROOT}" STREQUAL "" )
+        message(ERROR "Certificate bundles need a value for WOLFSSL_ROOT")
+    endif()
+    set(WOLFSSL_ESP_CRT_BUNDLE_DIR ${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/esp_crt_bundle)
+    message(STATUS "WOLFSSL_ESP_CRT_BUNDLE_DIR=${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+    if(EXISTS "${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+        set(bundle_name "x509_crt_bundle_wolfssl")
+
+        # For now the certs are in the same directory
+        set(DEFAULT_CRT_DIR "${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+
+        # Generate custom certificate bundle using the generate_cert_bundle utility
+        set(GENERATE_CERT_BUNDLEPY ${python} ${WOLFSSL_ESP_CRT_BUNDLE_DIR}/gen_crt_bundle.py)
+
+        if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_all.pem ${DEFAULT_CRT_DIR}/cacrt_local.pem)
+        elseif(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_CMN)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_all.pem ${DEFAULT_CRT_DIR}/cacrt_local.pem)
+            list(APPEND args --filter ${DEFAULT_CRT_DIR}/cmn_crt_authorities.csv)
+        endif()
+
+        # Add deprecated root certs if enabled. This config is not visible if the default cert
+        # bundle is not selected
+        if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEPRECATED_LIST)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_deprecated.pem)
+        endif()
+
+        if(CONFIG_WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE)
+            get_filename_component(custom_bundle_path
+              ${CONFIG_WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE_PATH} ABSOLUTE BASE_DIR "${project_dir}")
+            list(APPEND crt_paths ${custom_bundle_path})
+            message(STATUS "Using a custom wolfSSL bundle path: ${custom_bundle_path}")
+        else()
+            message(STATUS "Not using a custom wolfSSL bundle path.")
+        endif()
+        list(APPEND args --input ${crt_paths} -q)
+
+        message(STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
+        get_filename_component(crt_bundle
+            ${bundle_name}
+            ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+        message(STATUS "Setting up bundle generate: ${GENERATE_CERT_BUNDLEPY} ${args}")
+        message(STATUS "Depends on custom bundle path: ${custom_bundle_path}")
+        message(STATUS "crt_bundle ${crt_bundle}")
+        message(STATUS "COMPONENT_LIB ${COMPONENT_LIB}")
+        message(STATUS "GENERATE_CERT_BUNDLEPY ${GENERATE_CERT_BUNDLEPY}")
+        message(STATUS "args ${args}")
+        message(STATUS "cert_bundle ${cert_bundle}")
+
+        # Generate bundle according to config
+        # File is generated at build time, not cmake load
+        add_custom_command(OUTPUT ${crt_bundle}
+            COMMAND ${GENERATE_CERT_BUNDLEPY} ARGS ${args}
+            DEPENDS ${custom_bundle_path}
+            VERBATIM)
+
+        if(EXISTS "${crt_bundle}")
+            message(STATUS "Bundle file exists from prior build: ${crt_bundle}")
+        else()
+            message(STATUS "Bundle file expected during next build: ${crt_bundle}")
+        endif()
+
+        # Reminder the file is generated at build time, not cmake load time.
+        message(STATUS "wolfSSL Cert Bundle File to be created at build time in: ${crt_bundle}")
+
+        add_custom_target(custom_wolfssl_bundle DEPENDS ${cert_bundle})
+
+        # the wolfSSL crtificate bundle is baked into wolfSSL
+        add_dependencies(${COMPONENT_LIB} custom_wolfssl_bundle)
+
+        # COMPONENT_LIB may vary: __idf_wolfssl, __idf_esp_wolfssl, etc
+        # target_add_binary_data(__idf_wolfssl ${crt_bundle} BINARY)
+        target_add_binary_data(${COMPONENT_LIB} ${crt_bundle} BINARY)
+        set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                     APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+                     "${crt_bundle}")
+    else()
+        message(STATUS "WARNING: CONFIG_WOLFSSL_CERTIFICATE_BUNDLE enabled but directory not found: ${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+    endif()
+endif()
+
+# endfunction() # WOLFSSL_INIT_CERT_BUNDLE
 
     # Some optional diagnostics. Verbose ones are truncated.
     if (VERBOSE_COMPONENT_MESSAGES)
@@ -652,6 +906,12 @@ else()
     endif()
 
     # target_sources(wolfssl PRIVATE  "\"${WOLFSSL_ROOT}/wolfssl/\""  "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt\"")
+    message(STATUS "DETECTED_PROJECT_NAME=${CMAKE_PROJECT_NAME}")
+    message(STATUS "COMPONENT_TARGET=${COMPONENT_TARGET}")
+    target_compile_definitions(${COMPONENT_TARGET} PRIVATE DETECTED_PROJECT_NAME="${CMAKE_PROJECT_NAME}")
+    if( "${CMAKE_PROJECT_NAME}" STREQUAL "esp_http_client_example" )
+        target_compile_definitions(${COMPONENT_TARGET} PRIVATE APP_ESP_HTTP_CLIENT_EXAMPLE="y")
+    endif()
 
 endif() # CMAKE_BUILD_EARLY_EXPANSION
 
@@ -697,7 +957,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
@@ -705,35 +965,89 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # create some programmatic #define values that will be used by ShowExtendedSystemInfo().
 # see wolfcrypt\src\port\Espressif\esp32_utl.c
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT AND (IS_GIT_REPO STREQUAL "true"))
     set (git_cmd "git")
     message(STATUS "Adding macro definitions:")
 
     # LIBWOLFSSL_VERSION_GIT_ORIGIN: git config --get remote.origin.url
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_ORIGIN "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_BRANCH: git rev-parse --abbrev-ref HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_BRANCH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_HASH: git rev-parse HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_SHORT_HASH: git rev-parse --short HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_HASH_DATE git show --no-patch --no-notes --pretty=\'\%cd\'
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd}
+                    "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
 
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_WOLFSSL_ROOT "${WOLFSSL_ROOT}" "${TMP_RES}")
 
-    message(STATUS "************************************************************************************************")
-    message(STATUS "wolfssl component config complete!")
-    message(STATUS "************************************************************************************************")
 endif()
+
+# Ensure flag "-DWOLFSSL_ESPIDF" is already in CMAKE_C_FLAGS if not yet found from project
+string(FIND "${CMAKE_C_FLAGS}" "-DWOLFSSL_ESPIDF" FLAG_ALRREADY_FOUND_WOLFSSL_ESPIDF)
+
+if(FLAG_ALRREADY_FOUND_WOLFSSL_ESPIDF EQUAL -1)
+    # Flag not found, append it
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESPIDF")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+endif()
+
+if(WOLFSSL_ROOT)
+    message(STATUS "Using wolfSSL in ${WOLFSSL_ROOT}")
+
+    # PlatformIO does not process script from from the Espressif cmake process.
+    # We need to know where wolfSSL source code was found, so save it in the
+    # PIO_WOLFSSL_ROOT environment variable to later be read by extra_script.py
+
+    set(ENV{PIO_WOLFSSL_ROOT} "${WOLFSSL_ROOT}")
+    message(STATUS "PIO_WOLFSSL_ROOT =  $ENV{PIO_WOLFSSL_ROOT}")
+    message(STATUS "PLATFORMIO_BUILD_DIR = $ENV{PLATFORMIO_BUILD_DIR}")
+    # See esp-tls Kconfig; menu "ESP-TLS", ESP_TLS_LIBRARY_CHOOSE
+    if(CONFIG_ESP_TLS_USING_WOLFSSL)
+        if ( ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266") OR ("${IDF_TARGET}" STREQUAL "esp8266") )
+            message(STATUS "This version of wolfSSL is not supported on the ESP8266 esp-tls at this time. Check ESP-TLS config")
+        else()
+            message(STATUS "wolfSSL will be used for ESP-TLS")
+        endif()
+    else()
+        message(STATUS "WARNING: wolfSSL NOT selected for ESP-TLS. Features and performance will be limited.")
+    endif()
+else()
+    message(STATUS "")
+    message(STATUS "Consider setting WOLFSSL_ROOT environment variable, use Kconfig setting, or set manually in this cmake file, above.")
+    message(STATUS "")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "ERROR: Could not find wolfSSL Source Code")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+endif()
+
+message(STATUS "************************************************************************************************")
+message(STATUS "wolfSSL component config complete!")
+message(STATUS "************************************************************************************************")

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/Kconfig
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/Kconfig
@@ -1,0 +1,522 @@
+# Kconfig template
+#
+# Copyright (C) 2014-2025 wolfSSL Inc.
+#
+# This file is part of wolfSSH.
+#
+# wolfSSH is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# wolfSSH is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Kconfig File Version 5.7.2.001 for esp-idf integration
+
+# Kconfig Format Rules
+#
+# See:
+#  https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/kconfig.html
+#
+# Format rules for Kconfig files are as follows:
+#
+# Option names in any menus should have consistent prefixes. The prefix
+# currently should have at least 3 characters.
+#
+# The unit of indentation should be 4 spaces. All sub-items belonging to a
+# parent item are indented by one level deeper. For example, menu is indented
+# by 0 spaces, config menu by 4 spaces, help in config by 8 spaces, and the
+# text under help by 12 spaces.
+#
+# No trailing spaces are allowed at the end of the lines.
+#
+# The maximum length of options is NOT 50 characters as documented.
+#   kconfcheck will complain that options should be 40 at most.
+#
+# Fix option lengths first. Superfluous errors on other lines may occur.
+#
+# The maximum length of lines is 120 characters.
+#
+# python -m kconfcheck <path_to_kconfig_file>
+#
+# ---------------------------------------------------------------------------------------------------------------------
+# Begin main wolfSSL configuration menu
+# ---------------------------------------------------------------------------------------------------------------------
+#   See ESP-IDF esp-tls component for config TLS_STACK_WOLFSSL
+
+menu "wolfSSL"
+
+    menu "Hardening"
+        config ESP_WOLFSSL_WC_NO_HARDEN
+            bool "Disable wolfSSL hardening"
+            default n
+            help
+                Sets WC_NO_HARDEN
+
+        config ESP_WOLFSSL_TFM_TIMING_RESISTANT
+            bool "Enable TFM Timing Resistant Code"
+            default n
+            help
+                Sets TFM_TIMING_RESISTANT.
+
+    endmenu # Hardening
+
+    config ESP_WOLFSSL_ENABLE_BENCHMARK
+        bool "Enable wolfSSL Benchmark Library"
+        default n
+        help
+            Enables wolfcrypt/benchmark/benchmark.c code for benchmark metrics. Disables NO_CRYPT_BENCHMARK.
+
+
+    menu "Benchmark Debug"
+        config ESP_DEBUG_WOLFSSL_BENCHMARK_TIMING
+            bool "Enable benchmark timing debug"
+            depends on ESP_WOLFSSL_ENABLE_BENCHMARK
+            default n
+            help
+                Enable wolfssl debug for benchmark metric timing (CPU Cycles, RTOS ticks, etc).
+
+        config ESP_WOLFSSL_BENCHMARK_TIMER_DEBUG
+            bool "Enable benchmark timer debug"
+            depends on ESP_WOLFSSL_ENABLE_BENCHMARK
+            default n
+            help
+                Turn on timer debugging (used when CPU cycles not available)
+
+    endmenu # Benchmark Debug
+
+    # -----------------------------------------------------------------------------------------------------------------
+    # wolfCrypt Test
+    # -----------------------------------------------------------------------------------------------------------------
+    config ESP_WOLFSSL_ENABLE_TEST
+        bool "Enable wolfCrypt Test Library"
+        default n
+        help
+            Enables wolfcrypt/test/test.c code for testing. Disables NO_CRYPT_TEST.
+
+    menu "wolfCrypt tests"
+        config WOLFSSL_HAVE_WOLFCRYPT_TEST_OPTIONS
+            bool "Enable wolfCrypt Test Options"
+            depends on ESP_WOLFSSL_ENABLE_TEST
+            default n
+            help
+                Enables HAVE_WOLFCRYPT_TEST_OPTIONS
+
+        config TEST_ESPIDF_ALL_WOLFSSL
+            bool "Enable all features to use in tests"
+            depends on ESP_WOLFSSL_ENABLE_TEST
+            default n
+            help
+                Enables TEST_ESPIDF_ALL_WOLFSSL
+
+    endmenu # wolfCrypt tests
+
+    # -----------------------------------------------------------------------------------------------------------------
+    # Apple HomeKit Options
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Apple HomeKit"
+        config WOLFSSL_APPLE_HOMEKIT
+            bool "Enable Apple HomeKit options"
+            default n
+            help
+                Enables FP_MAX_BITS (8192 * 2), SRP, ChaCha, Poly1305, Base64 encoding needed for Apple HomeKit.
+    endmenu # Apple HomeKit
+    # -----------------------------------------------------------------------------------------------------------------
+
+    config ESP_WOLFSSL_DISABLE_MY_ECC
+        bool "Disable ECC in my project"
+        default "n"
+        help
+            ECC is enabled by default. Select this option to disable.
+
+    config ESP_WOLFSSL_ENABLE_MY_USE_RSA
+        bool "Enable RSA in my project"
+        default "n"
+        help
+            RSA is disabled by default. Select this option to enable.
+
+    config ESP_WOLFSSL_BENCHMARK
+        bool "Enable wolfSSL Benchmark"
+        default n
+        help
+            Enables user settings relevant to benchmark code
+
+    config ESP_TLS_USING_WOLFSSL_SPECIFIED
+        bool "Use the specified wolfssl for ESP-TLS"
+        default Y
+        help
+            Includes wolfSSL from specified directory (not using esp-wolfssl).
+
+    config ESP_WOLFSSL_NO_USE_FAST_MATH
+        bool "Disable FAST_MATH library and all ESP32 Hardware Acceleration"
+        select ESP_WOLFSSL_NO_HW
+        select ESP_WOLFSSL_NO_HW_AES
+        select ESP_WOLFSSL_NO_HW_HASH
+        select ESP_WOLFSSL_NO_HW_RSA_PRI
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+        default n
+        help
+            When disabling all hardware acceleration for smaller memory footprint,
+            disabling TFM fast math provides faster wolfSSL software algorithms in an
+            even smaller flash memory footprint.
+
+    menu "Protocol Config"
+        config WOLFSSL_HAVE_ALPN
+            bool "Enable ALPN (Application Layer Protocol Negotiation) in wolfSSL"
+            default y
+
+        config WOLFSSL_ALLOW_TLS13
+            bool "Allow TLS 1.3"
+            default y
+            help
+                Allow TLS to fallback to TLS1.2. Memory footprint will likely be larger for TLS1.2.
+                When disabled HTTPS and MQTT over TLS connections will fail if TLS1.3 not accepted.
+
+        config WOLFSSL_ALLOW_TLS12
+            bool "Allow TLS 1.2"
+            default n
+            help
+                Allow TLS to fallback to TLS1.2. Memory footprint will likely be larger for TLS1.2.
+                When disabled HTTPS and MQTT over TLS connections will fail if TLS1.3 not accepted.
+
+        config WOLFSSL_HAVE_TLS_EXTENSIONS
+            bool "Enable TLS Extensions"
+            default y
+            help
+                Sets HAVE_TLS_EXTENSIONS which is needed for TLS 1.3, SNI, ALPN, and more.
+
+        config WOLFSSL_ALT_CERT_CHAINS
+            bool "Enable Alternate Certificate Chains"
+            default n
+            help
+                The option relaxes the default strict wolfSSL certificate chain processing. This
+                will typically need to be enabled when loading only a CA file. Typically solves
+                the -188 ASN_NO_SIGNER_E error. Use with caution.
+
+        config WOLFSSL_HAVE_OCSP
+            bool "Enable OCSP (Online Certificate Status Protocol) in wolfSSL"
+            default n
+            help
+                Sets HAVE_OCSP
+
+    endmenu # Protocol Config
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    config TLS_STACK_WOLFSSL
+        # Invisible option that locks TLS_STACK_WOLFSSL to ESP_TLS_USING_WOLFSSL
+        bool
+        default n
+        select FREERTOS_ENABLE_BACKWARD_COMPATIBILITY
+        help
+            Includes wolfSSL in ESP-TLS so that it can be compiled with wolfSSL as its SSL/TLS library.
+            Enabled when wolfSSL is selected in ESP_TLS_LIBRARY_CHOOSE.
+
+    menu "wolfSSL ESP-TLS"
+        depends on ESP_TLS_USING_WOLFSSL
+
+        menu "Certificate Bundle"
+            depends on ESP_TLS_USING_WOLFSSL
+
+            config WOLFSSL_CERTIFICATE_BUNDLE
+                bool "Enable trusted root certificate bundle"
+                default y if ESP_TLS_USING_WOLFSSL
+                default n
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Enable support for large number of default root certificates
+
+                    When enabled this option allows user to store default as well
+                    as customer specific root certificates in compressed format rather
+                    than storing full certificate. For the root certificates the public key and the subject name
+                    will be stored.
+
+            config WOLFSSL_NO_ASN_STRICT
+                bool "Relax Certificate ASN Strict Checks"
+                default n
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Allows sub-optimal certificate ASN checks. Unless using a bundle with known issues,
+                    it is recommended to NOT enable this.
+
+            config WOLFSSL_ASN_ALLOW_0_SERIAL
+                bool "Allow cert missing an ASN Serial Number"
+                default y
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Although not recommended, there may be certificates in the bundle that are missing
+                    a serial number. This option allows the missing value without having to fully
+                    disable strict ASN checking with WOLFSSL_NO_ASN_STRICT.
+
+            choice WOLFSSL_DEFAULT_CERTIFICATE_BUNDLE
+                bool "Default certificate bundle options"
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                default WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL
+
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL
+                    bool "Use the full default certificate bundle"
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_CMN
+                    bool "Use only the most common certificates from the default bundles"
+                    help
+                        Use only the most common certificates from the default bundles, reducing the size with 50%,
+                        while still having around 99% coverage.
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+                    bool "Do not use the default certificate bundle"
+            endchoice
+
+            config WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                default n
+                bool "Add custom certificates to the default bundle"
+            config WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE_PATH
+                depends on WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                string "Custom certificate bundle path"
+                help
+                    Name of the custom certificate directory or file. This path is evaluated
+                    relative to the project root directory.
+
+            config WOLFSSL_CERTIFICATE_BUNDLE_DEPRECATED_LIST
+                bool "Add deprecated root certificates"
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL && !WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+                help
+                    Include the deprecated list of root certificates in the bundle.
+                    This list gets updated when a certificate is removed from the Mozilla's
+                    NSS root certificate store. This config can be enabled if you would like
+                    to ensure that none of the certificates that were deployed in the product
+                    are affected because of the update to bundle. In turn, enabling this
+                    config keeps expired, retracted certificates in the bundle and it may
+                    pose a security risk.
+
+                    - Deprecated cert list may grow based based on sync with upstream bundle
+                    - Deprecated certs would be be removed in ESP-IDF (next) major release
+
+            config WOLFSSL_CERTIFICATE_BUNDLE_MAX_CERTS
+                int "Maximum no of certificates allowed in certificate bundle"
+                default 200
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+
+        endmenu
+    endmenu # wolfSSL ESP-TLS
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    config ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+        bool "Modify default hardware acceleration settings"
+        default n
+        help
+            When disabling all hardware acceleration for smaller memory footprint,
+            disabling TFM fast math provides faster wolfSSL software algorithms in an
+            even smaller flash memory footprint.
+            Typically used for debugging, analysis, or optimizations. The default
+            hardware acceleration features can be each manually adjusted.
+
+    menu "wolfSSL Hardware Acceleration"
+
+        config ESP_WOLFSSL_NO_ESP32_CRYPT
+            bool "Disable all ESP32 Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            select ESP_WOLFSSL_NO_HW_AES
+            select ESP_WOLFSSL_NO_HW_HASH
+            select ESP_WOLFSSL_NO_HW_RSA_PRI
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_ESP32_CRYPT.
+                Consider disabling FASTMATH (other libraries are faster in software and smaller)
+
+        config ESP_WOLFSSL_NO_HW_AES
+            bool "Disable all ESP32 AES Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default.When selected defines: NO_HW_AES
+
+        config ESP_WOLFSSL_NO_HW_HASH
+            bool "Disable all ESP32 SHA Hash Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_HASH
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI
+            bool "Disable all ESP32 RSA Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            select ESP_WOLFSSL_NO_HW_PRI_MP_MUL
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+            bool "Disable all ESP32 Multiplication Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI_MP_MUL
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            bool "Disable all ESP32 Modular Multiplication Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI_MULMOD
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            bool "Disable all ESP32 RSA Exponential Math Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default.
+                Select this option to force disable: NO_HW_RSA_PRI_EXPTMOD
+
+        config ESP_WOLFSSL_DEBUG_ESP_HW_MULTI_RSAMAX_BITS
+            bool "Enable debugging of RSA Multiplication operand length"
+            default n
+            help
+                Prints an esp log warning to the default console UART when one of the
+                multiplication operands exceeds the maximum size supported by hardware,
+                requiring fallback to software. This can be helpful to pick key sizes
+                when performance is critical. See also metrics for counting instances.
+
+        config ESP_WOLFSSL_DEBUG_ESP_HW_MOD_RSAMAX_BITS
+            bool "Enable debugging of RSA Modular operand length"
+            default n
+            help
+                Prints an esp log warning to the default console UART when one of the
+                modular math operands exceeds the maximum size supported by hardware,
+                requiring fallback to software. This can be helpful to pick key sizes
+                when performance is critical. See also metrics for counting instances.
+
+    endmenu # wolfSSL Hardware Acceleration
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Experimental Options"
+
+        config ESP_WOLFSSL_EXPERIMENTAL_SETTINGS
+            bool "Enable wolfSSL Experimental Settings"
+            default n
+            help
+                Enables experimental settings for wolfSSL. See documentation.
+
+        config ESP_WOLFSSL_ENABLE_KYBER
+            bool "Enable wolfSSL Kyber"
+            default n
+            help
+                Enable debugging messages for wolfSSL. See user_settings.h for additional debug options.
+
+    endmenu # wolfSSL Experimental Options
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Debug Options"
+        config ESP_WOLFSSL_DEBUG_WOLFSSL
+            bool "Enable wolfSSL Debugging"
+            default n
+            help
+                Enable debugging messages for wolfSSL. See user_settings.h for additional debug options.
+
+        config ESP_WOLFSSL_TEST_LOOP
+            bool "Run test apps in a loop until failure"
+            default y
+            help
+                Enable a loop wrapper for benchmark, http_client, and wolfssl test apps.
+
+    endmenu # wolfSSL Debug Options
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Customization"
+        config CUSTOM_SETTING_WOLFSSL_ROOT
+            string "Enter a path for wolfSSL source code"
+            default "~/workspace/wolfssl"
+            help
+                This option lets you specify a directory for the wolfSSL source code (typically a git clone).
+                Enter the path using forward slashes (e.g., C:/myfolder/mysubfolder) or double backslashes
+                (e.g., C:\\myfolder\\mysubfolder).
+
+    endmenu # wolfSSL Customization
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Component Config"
+        config IGNORE_ESP_IDF_WOLFSSL_COMPONENT
+            bool "Ignore the ESP-IDF component of wolfSSL (if present)"
+            default n
+            help
+                Ignores wolfSSL present in the esp-idf/components directory. Requires wolfssl as a local component.
+
+        config IGNORE_LOCAL_WOLFSSL_COMPONENT
+            bool "Ignore the local component of wolfSSL (if present)"
+            default n
+            help
+                Ignores wolfSSL present in the local project components directory.
+                Requires wolfssl as a ESP-IDF component.
+
+    endmenu # Component Config
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Utility Config"
+        config USE_WOLFSSL_ESP_SDK_TIME
+            bool "Enable wolfSSL time helper functions"
+            default n
+            help
+                Enables use of various time and date setting functions found in the esp-sdk-lib.h file.
+
+        config USE_WOLFSSL_ESP_SDK_WIFI
+            bool "Enable wolfSSL WiFi helper functions"
+            default n
+            help
+                Enables use of various time and date setting functions found in the esp-sdk-lib.h file.
+
+    endmenu # Utility Config
+endmenu # wolfSSL
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+menu "wolfSSH"
+    config ESP_ENABLE_WOLFSSH
+        bool "Enable wolfSSH options"
+        default n
+        help
+            Enables WOLFSSH_TERM, WOLFSSL_KEY_GEN, WOLFSSL_PTHREADS, WOLFSSH_TEST_SERVER, WOLFSSH_TEST_THREADING
+
+    config ESP_WOLFSSL_DEBUG_WOLFSSH
+        bool "Enable wolfSSH debugging"
+        default n
+        help
+            Enable wolfSSH debugging macro. See user_settings.h
+
+endmenu # wolfSSH
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+menu "wolfMQTT"
+    config ESP_ENABLE_WOLFMQTT
+        bool "Enable wolfMQTT options"
+        default n
+        help
+            Enables WOLFMQTT
+
+    config ESP_WOLFSSL_DEBUG_WOLFMQTT
+        bool "Enable wolfMQTT debugging"
+        default n
+        help
+            Enable wolfMQTT debugging macro. See user_settings.h
+
+endmenu # wolfMQTT
+# ---------------------------------------------------------------------------------------------------------------------

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/README.md
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/README.md
@@ -1,9 +1,162 @@
-# Component wolfSSL
+# wolfSSL Espressif Component
 
-This `wolfssl` directory exists only for the stand-alone examples.
+This is the directory for wolfSSL as an Espressif ESP-IDF component.
 
-The only files of interest are the [CMakeLists.txt](./CMakeLists.txt) that should point
-to the wolfSSL source code and the respective [include/user_settings.h](./include/user_settings.h).
+Other options are available, such as installing wolfSSL as a local _project_ component using the [Managed Component](https://www.wolfssl.com/wolfssl-now-available-in-espressif-component-registry/).
 
-This directory is _not_ included in the publish to the Espressif Registry, as that
-mechanism copies the published source code to the local component directory as needed. 
+Enabling this wolfSSL ESP-IDF component allows other ESP-IDF libraries such as those that depend on [ESP-TLS](https://github.com/espressif/esp-idf/tree/master/components/esp-tls)
+to also use the wolfSSL library. (See [github.com/wolfSSL/wolfssl](https://github.com/wolfSSL/wolfssl))
+
+The wolfSSL source code is not included here. Instead, the `idf.py menuconfig` option can be used to configure the
+`sdkconfig` file setting: `CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT` to point to the desired wolfSSL code.
+
+## Directory Contents
+
+This directory must contain, at a minimum:
+
+- `CMakeLists.txt`
+- `./include/user_settings.h`
+
+The directory should also contain:
+- `Kconfig`
+- `component.mk`
+
+The directory may contain wolfSSL source, for example with a [Managed Component](https://www.wolfssl.com/wolfssl-now-available-in-espressif-component-registry/),
+or if the `setup.sh` script was used from [wolfSSL/IDE/Espressif/ESP-IDF](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF).
+
+
+Under normal circumstances when the wolfSSL source is not included here, the `CMakeLists.txt` will search for it in this order:
+
+- A hard-coded `WOLFSSL_ROOT` cmake variable.
+- `WOLFSSL_ROOT` Environment Variable
+- The `CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT` value in the `sdkconfig` file, from the `Kconfig` option.
+- Any parent directories, up to the root (if this directory is in the ESP-IDF components)
+- Any parent directories, up to the root (if this directory is a project component)
+
+While recursing up the directory tree, the following names of wolfSSL directories will be considered:
+
+- `wolfssl-[current user name]`
+- `wolfssl-master`
+- `wolfssl`
+
+## Getting Started
+
+See the `Espressif Getting Started Guide`.
+
+```
+# Set environment variable to ESP-IDF location
+# For example, VisualGDB in WSL
+WRK_IDF_PATH=/mnt/c/SysGCC/esp32/esp-idf/v5.2
+WRK_IDF_PATH=/mnt/c/SysGCC/esp32-master/esp-idf/v5.3-master
+
+# Or wherever the ESP-IDF is installed:
+WRK_IDF_PATH=~/esp/esp-idf
+
+echo "Run export.sh from ${WRK_IDF_PATH}"
+. ${WRK_IDF_PATH}/export.sh
+
+cd [your project]
+
+idf.py menuconfig
+```
+
+Enable wolfSSL to be used in the ESP-TLS:
+
+```
+Component config  --->
+    ESP-TLS  --->
+        Choose SSL/TLS library for ESP-TLS (See help for more Info)
+            (X) wolfSSL (License info in wolfSSL directory README)
+```
+
+Adjust wolfSSL settings, such as path to source code as needed:
+
+```
+Component config  --->
+    wolfSSL  --->
+        [*] Include wolfSSL in ESP-TLS
+        [*] Use the specified wolfssl for ESP-TLS
+        (~/workspace/wolfssl) Enter a path for wolfSSL source code
+```
+
+## Configuration
+
+All settings for wolfSSL are adjusted in the [include/user_settings.h](./include/user_settings.h) file.
+
+The `user_settings.h` file should not be included directly. Instead, `#include <wolfssl/wolfcrypt/settings.h>`
+before any other wolfSSL headers, like this:
+
+
+```c
+/* ESP-IDF */
+#include <esp_log.h>
+#include "sdkconfig.h"
+
+/* wolfSSL */
+/* Always include wolfcrypt/settings.h before any other wolfSSL file.    */
+/* Reminder: settings.h pulls in user_settings.h; don't include it here. */
+#if defined(WOLFSSL_USER_SETTINGS)
+    #include <wolfssl/wolfcrypt/settings.h>
+    #if defined(WOLFSSL_ESPIDF)
+        #include <wolfssl/version.h>
+        #include <wolfssl/wolfcrypt/types.h>
+        #include <wolfcrypt/test/test.h>
+        #include <wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h>
+        #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
+    #else
+        #error "Problem with wolfSSL user_settings. "           \
+               "Check components/wolfssl/include "              \
+               "and confirm WOLFSSL_USER_SETTINGS is defined, " \
+               "typically in the component CMakeLists.txt"
+    #endif
+#else
+    /* Define WOLFSSL_USER_SETTINGS project wide for settings.h to include   */
+    /* wolfSSL user settings in ./components/wolfssl/include/user_settings.h */
+    #error "Missing WOLFSSL_USER_SETTINGS in CMakeLists or Makefile:\
+    CFLAGS +=-DWOLFSSL_USER_SETTINGS"
+#endif
+```
+
+## Examples
+
+See the wolfSSL examples:
+
+- [wolfSSL Core Examples](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples)
+- [wolfSSL Additional Examples](https://github.com/wolfSSL/wolfssl-examples/tree/master/ESP32)
+- [wolfSSH Core Examples](https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples)
+- [wolfSSH Additional Examples](https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif)
+- [wolfMQTT Examples](https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples)
+
+## Platforms
+
+The ESP-IDF wolfSSL is also available for PlatformIO:
+
+- [Release wolfSSL](https://registry.platformio.org/search?q=owner%3Awolfssl)
+- [Staging / Preview wolfSSL](https://registry.platformio.org/search?q=owner%3Awolfssl-staging)
+
+The wolfSSL library can also be used for Espressif with Arduino:
+
+- [arduino.cc/reference/en/libraries/wolfssl](https://www.arduino.cc/reference/en/libraries/wolfssl/)
+- [github.com/wolfSSL/Arduino-wolfSSL](https://github.com/wolfSSL/Arduino-wolfSSL)
+
+
+## Additional Information
+
+- [wolfSSL Documentation](https://www.wolfssl.com/documentation/manuals/wolfssl/index.html) and [docs/espressif](https://www.wolfssl.com/docs/espressif/)
+- [wolfSSL FAQ](https://www.wolfssl.com/docs/frequently-asked-questions-faq/)
+- [wolfSSL Products](https://www.wolfssl.com/products/)
+- [www.wolfssl.com/espressif](https://www.wolfssl.com/espressif/)
+- [More...](https://www.wolfssl.com/?s=espressif)
+
+## Contact
+
+Have a specific request or questions? We'd love to hear from you! Please contact us at support@wolfssl.com or open an issue on GitHub.
+
+## Licensing and Support
+
+wolfSSL (formerly known as CyaSSL) and wolfCrypt are either licensed for use under the GPLv2 (or at your option any later version) or a standard commercial license. For our users who cannot use wolfSSL under GPLv2 (or any later version), a commercial license to wolfSSL and wolfCrypt is available.
+
+See the LICENSE.txt, visit wolfssl.com/license, contact us at licensing@wolfssl.com or call +1 425 245 8247
+
+View Commercial Support Options: [wolfssl.com/products/support-and-maintenance](wolfssl.com/products/support-and-maintenance)
+

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/component.mk
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/component.mk
@@ -1,0 +1,305 @@
+#
+# Copyright (C) 2014-2025 wolfSSL Inc.
+#
+# This file is part of wolfSSH.
+#
+# wolfSSH is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# wolfSSH is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+$(info ***********  wolfssl component ************)
+
+#
+# Component Makefile
+#
+#
+# The Espressif Managed Components are only for newer versions of the ESP-IDF
+# Typically only for ESP32[-x] targets and only for ESP-IDF v4.3 or later:
+# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html
+#     https://components.espressif.com/
+#
+# Usage:
+#
+#   make flash
+#
+#   make flash ESPPORT=/dev/ttyS55
+#
+#   make flash ESPBAUD=9600
+#
+#   make monitor ESPPORT=COM1
+#
+#   make monitor ESPPORT=/dev/ttyS55 MONITORBAUD=115200
+#
+#   export ESPPORT=/dev/ttyS55
+#
+# https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/get-started/index.html
+#
+
+# Although the project should define WOLFSSL_USER_SETTINGS, we'll also
+# define it here:
+CFLAGS +=-DWOLFSSL_USER_SETTINGS
+
+# Note that 4 source files created by autogen are excluded here.
+#
+# See these files commented out, below. Adjust as needed for your application:
+#
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/async.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/selftest.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_first.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_last.o
+
+
+# NOTICE: the WOLFSSL_ROOT setting MUST be relative!
+# See https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/api-guides/build-system.html?highlight=must+relative#optional-component-specific-variables
+# In the wolfSSL GitHub examples for Espressif:
+#   https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples
+# When this wolfssl component.mk makefile is in [project]/components/wolfssl
+# The root is 7 directories up from here (the location of of this component.mk):
+#
+WOLFSSL_ROOT     ?= ../../../../../../..
+THIS_DIR         := $(shell pwd)
+WOLFSSL_ROOT_OBJ := $(THIS_DIR)
+
+# When running make from commandline or VisualGDB, the current path varies:
+ifeq ("$(VISUALGDB_DIR)","")
+    # current path is typically /mnt/c/workspace/wolfssl-gojimmypi/IDE/Espressif/ESP-IDF/examples/wolfssl_test/build/wolfssl
+    $(info VISUALGDB_DIR build not detected. shell: $(shell echo $$SHELL))
+else
+    # current path is typically /C/workspace/wolfssl-gojimmypi/IDE/Espressif/ESP-IDF/examples/wolfssl_test/build/Debug/wolfssl
+    $(info Detected VisualGDB in: $(VISUALGDB_DIR) shell: $(shell echo $$SHELL))
+endif
+
+# To set the location of a different location, it is best to use relative paths.
+#
+# Set WOLFSSL_ROOT to a relative path from the current component directory.
+# For example, if the wolfssl_client is copied from the examples to test:
+#
+# cp -r /IDE/Espressif/ESP-IDF/examples/wolfssl_client/* /mnt/c/test/demo
+#
+# we run make in   /mnt/c/test/demo
+# component is in  /mnt/c/test/demo/components/wolfssl
+# wolfssl is in    /mnt/c/workspace/wolfssl-master
+#
+# "/mnt/c" is 4 directories up:
+#             2 for `./test/demo` from where we run `make`, plus
+#             2 more from the location of `component.mk` located
+#               in `[current directory]/components/wolfssl`.
+#
+# Thus we need 4 parent reference to find the relative path to wolfSSL:
+# WOLFSSL_ROOT := ../../../../workspace/wolfssl-master
+
+# Optional CFLAGS (make works without these; for reference only)
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl/wolfcrypt
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl/wolfcrypt/port/Espressif
+
+abs_WOLFSSL_ROOT     := $(shell realpath $(WOLFSSL_ROOT))
+
+# print-wolfssl-path-value:
+#	@echo "WOLFSSL_ROOT defined: $(WOLFSSL_ROOT)"
+#	@echo "WOLFSSL_ROOT actual:  $(abs_WOLFSSL_ROOT)"
+
+$(info WOLFSSL_ROOT     defined: $(WOLFSSL_ROOT))
+$(info WOLFSSL_ROOT     actual:  $(abs_WOLFSSL_ROOT))
+$(info THIS_DIR         defined: $(THIS_DIR))
+$(info WOLFSSL_ROOT_OBJ defined: $(WOLFSSL_ROOT_OBJ))
+
+# NOTE: The wolfSSL include directory (e.g. user_settings.h) is
+# located HERE in THIS project, and *not* in the wolfSSL root.
+COMPONENT_ADD_INCLUDEDIRS := .
+COMPONENT_ADD_INCLUDEDIRS += include
+COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/.
+COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl
+COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl/wolfcrypt
+COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl/wolfcrypt/port/Espressif
+
+# COMPONENT_ADD_INCLUDEDIRS += $ENV(IDF_PATH)/components/freertos/include/freertos
+# COMPONENT_ADD_INCLUDEDIRS += "$ENV(IDF_PATH)/soc/esp32s3/include/soc"
+
+# wolfSSL
+COMPONENT_SRCDIRS := $(WOLFSSL_ROOT)/src
+
+# wolfcrypt
+COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/src
+
+# Espressif
+COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif
+COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/atmel
+
+COMPONENT_OBJEXCLUDE := $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/aes_asm.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/evp.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/misc.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/sha512_asm.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/fe_x25519_asm.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/aes_gcm_x86_asm.o
+
+##
+## wolfSSL
+##
+## reminder object files may end up in `./build` or `build/debug` or `build/release`, depending on build environment & settings.
+##
+# COMPONENT_OBJS := $(WOLFSSL_ROOT)/src/bio.o  # part of ssl.c, omitted to avoid "does not need to be compiled separately"
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/conf.o # part of ssl.c
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/crl.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/dtls.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/dtls13.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/internal.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/keys.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/ocsp.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/pk.o   # part of ssl.c
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/quic.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/sniffer.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/ssl.o
+# COMPONENT_OBJS += src/ssl_asn1.o
+# COMPONENT_OBJS += src/ssl_bn.o
+# COMPONENT_OBJS += src/ssl_certman.o
+# COMPONENT_OBJS += src/ssl_crypto.o
+# COMPONENT_OBJS += src/ssl_misc.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/tls.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/tls13.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/wolfio.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/x509.o     # part of ssl.c
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/x509_str.o # part of ssl.c
+
+##
+## wolfcrypt
+##
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/aes.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/arc4.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/asm.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/asn.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/async.o # autogen exclusion
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/blake2b.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/blake2s.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/camellia.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/chacha.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/chacha20_poly1305.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/cmac.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/coding.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/compress.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/cpuid.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/cryptocb.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/curve25519.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/curve448.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/des3.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/dh.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/dilithium.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/dsa.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ecc.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/eccsi.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ecc_fp.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ed25519.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ed448.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/error.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/evp.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_kyber.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_lms.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_xmss.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/falcon.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fe_448.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fe_low_mem.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fe_operations.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fips.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fips_test.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ge_448.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ge_low_mem.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ge_operations.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/hash.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/hmac.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/hpke.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/integer.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/kdf.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/logging.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/md2.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/md4.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/md5.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/memory.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/misc.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/pkcs12.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/pkcs7.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/poly1305.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/pwdbased.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/random.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/rc2.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ripemd.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/rsa.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sakke.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/selftest.o # autogen exclusion
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha256.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha3.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha512.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/signature.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/siphash.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sm2.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sm3.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sm4.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sphincs.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_arm32.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_arm64.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_armthumb.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_c32.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_c64.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_cortexm.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_dsp32.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_int.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_arm32.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_arm64.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_armthumb.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_c32.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_c64.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_cortexm.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_x86_64.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_x86_64.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/srp.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/tfm.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_dsp.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_encrypt.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_kyber.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_kyber_poly.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_lms.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_pkcs11.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_port.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_xmss.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_first.o # autogen exclusion
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_last.o  # autogen exclusion
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfevent.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfmath.o
+
+##
+## Espressif
+##
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp32_aes.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp32_mp.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp32_sha.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp32_util.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp_sdk_time_lib.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp_sdk_wifi_lib.o
+
+##
+## wolfcrypt benchmark  (optional)
+##
+## COMPONENT_OBJS            += $(WOLFSSL_ROOT)/wolfcrypt/benchmark/benchmark.o
+## COMPONENT_SRCDIRS         += $(WOLFSSL_ROOT)/wolfcrypt/benchmark
+## COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfcrypt/benchmark
+
+
+##
+## wolfcrypt test (optional)
+##
+## COMPONENT_OBJS            += $(WOLFSSL_ROOT)/wolfcrypt/test/test.o
+## COMPONENT_SRCDIRS         += $(WOLFSSL_ROOT)/wolfcrypt/test
+## COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfcrypt/test/include
+
+$(info ********** end wolfssl component **********)

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/include/user_settings.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/components/wolfssl/include/user_settings.h
@@ -1,6 +1,6 @@
-/* user_settings.h
+/* wolfssl-component include/user_settings.h
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *
@@ -17,20 +17,61 @@
  * You should have received a copy of the GNU General Public License
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
+#define WOLFSSL_ESPIDF_COMPONENT_VERSION 0x01
 
-#include <sdkconfig.h> /* essential to chip set detection */
+/* Examples such as test and benchmark are known to cause watchdog timeouts.
+ * Note this is often set in project Makefile:
+ * CFLAGS += -DWOLFSSL_ESP_NO_WATCHDOG=1 */
+#define WOLFSSL_ESP_NO_WATCHDOG 1
 
-#undef WOLFSSL_ESPIDF
-#undef WOLFSSL_ESP32
-#undef WOLFSSL_ESPWROOM32SE
-#undef WOLFSSL_ESP32
-#undef WOLFSSL_ESP8266
+/* The Espressif project config file. See also sdkconfig.defaults */
+#include "sdkconfig.h"
 
-#define WOLFSSL_ESPIDF
+/* This user_settings.h is for Espressif ESP-IDF
+ *
+ * Standardized wolfSSL Espressif ESP32 + ESP8266 user_settings.h V5.7.0-1
+ *
+ * Do not include any wolfssl headers here.
+ *
+ * When editing this file:
+ * ensure all examples match. The template example is the reference.
+ */
+
+/* Naming convention: (see also esp32-crypt.h for the reference source).
+ *
+ * CONFIG_
+ *      This prefix indicates the setting came from the sdkconfig / Kconfig.
+ *
+ *      May or may not be related to wolfSSL.
+ *
+ *      The name after this prefix must exactly match that in the Kconfig file.
+ *
+ * WOLFSSL_
+ *      Typical of many, but not all wolfSSL macro names.
+ *
+ *      Applies to all wolfSSL products such as wolfSSH, wolfMQTT, etc.
+ *
+ *      May or may not have a corresponding sdkconfig / Kconfig control.
+ *
+ * ESP_WOLFSSL_
+ *      These are NOT valid wolfSSL macro names. These are names only used in
+ *      the ESP-IDF Kconfig files. When parsed, they will have a "CONFIG_"
+ *      suffix added. See next section.
+ *
+ * CONFIG_ESP_WOLFSSL_
+ *      This is a wolfSSL-specific macro that has been defined in the ESP-IDF
+ *      via the sdkconfig / menuconfig. Any text after this prefix should
+ *      exactly match an existing wolfSSL macro name.
+ *
+ *      Applies to all wolfSSL products such as wolfSSH, wolfMQTT, etc.
+ *
+ *      These macros may also be specific to only the project or environment,
+ *      and possibly not used anywhere else in the wolfSSL libraries.
+ */
 
 /* The Espressif sdkconfig will have chipset info.
 **
-** Possible values:
+** Some possible values:
 **
 **   CONFIG_IDF_TARGET_ESP32
 **   CONFIG_IDF_TARGET_ESP32S2
@@ -39,17 +80,229 @@
 **   CONFIG_IDF_TARGET_ESP32C6
 */
 
+#undef  WOLFSSL_ESPIDF
+#define WOLFSSL_ESPIDF
+
+/* Test various user_settings between applications by selecting example apps
+ * in `idf.py menuconfig` for Example wolfSSL Configuration settings: */
+
+/* Turn on messages that are useful to see only in examples. */
+#define WOLFSSL_EXAMPLE_VERBOSITY
+
+/* Paths can be long, ensure the entire value printed during debug */
+#define WOLFSSL_MAX_ERROR_SZ 500
+
+/* wolfSSL Examples: set macros used in example applications.
+ *
+ * These Settings NOT available in ESP-IDF (e.g. esp-tls)
+ *
+ * Any settings needed by ESP-IDF components should be explicitly set,
+ * and not by these example-specific settings via CONFIG_WOLFSSL_EXAMPLE_n
+ *
+ * ESP-IDF settings should be Kconfig "CONFIG_[name]" values when possible. */
+#if defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/template */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TEST)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_test */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+    #define TEST_ESPIDF_ALL_WOLFSSL
+
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_BENCHMARK)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+    #define WOLFSSL_BENCHMARK_FIXED_UNITS_KB
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_CLIENT)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_client */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_SERVER)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfSSH Examples */
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE)
+    /* See https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples/wolfssh_template */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER)
+    /* See https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_ESP32_SSH_SERVER)
+    /* See https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif/ESP32/ESP32-SSH-Server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_ESP8266_SSH_SERVER)
+    /* See https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif/ESP8266/ESP8266-SSH-Server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfMQTT Examples */
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_TEMPLATE)
+    /* See https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_AWS_IOT_MQTT)
+    /* See https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfTPM Examples */
+#elif defined(CONFIG_WOLFTPM_EXAMPLE_NAME_ESPRESSIF)
+    /* See https://github.com/wolfSSL/wolfTPM/tree/master/IDE/Espressif */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* Apple HomeKit Examples */
+#elif defined(CONFIG_WOLFSSL_APPLE_HOMEKIT)
+    /* See https://github.com/AchimPieters/esp32-homekit-demo */
+
+/* no example selected */
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_NONE)
+    /* We'll assume the app needs to use wolfSSL sdk lib function */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* Other applications detected by cmake */
+#elif defined(APP_ESP_HTTP_CLIENT_EXAMPLE)
+    /* The wolfSSL Version of the client example */
+    #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C2)
+        /* Less memory available, so smaller key sizes: */
+        #define FP_MAX_BITS (4096 * 2)
+    #else
+        #define FP_MAX_BITS (8192 * 2)
+    #endif
+    #define HAVE_ALPN
+    #define HAVE_SNI
+    #define OPENSSL_EXTRA_X509_SMALL
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+    #define OPENSSL_EXTRA
+    #ifndef WOLFSSL_ALWAYS_VERIFY_CB
+       #define WOLFSSL_ALWAYS_VERIFY_CB
+    #endif
+    #ifndef WOLFSSL_VERIFY_CB_ALL_CERTS
+        #define WOLFSSL_VERIFY_CB_ALL_CERTS
+    #endif
+    #ifndef KEEP_PEER_CERT
+        #define KEEP_PEER_CERT
+    #endif
+
+#elif defined(APP_ESP_HTTP_CLIENT)
+    /* The ESP-IDF Version */
+    #define FP_MAX_BITS (8192 * 2)
+    #define HAVE_ALPN
+    #define HAVE_SNI
+    #define OPENSSL_EXTRA_X509_SMALL
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+    #define OPENSSL_EXTRA
+    #ifndef WOLFSSL_ALWAYS_VERIFY_CB
+       #define WOLFSSL_ALWAYS_VERIFY_CB
+    #endif
+    #ifndef WOLFSSL_VERIFY_CB_ALL_CERTS
+        #define WOLFSSL_VERIFY_CB_ALL_CERTS
+    #endif
+    #ifndef KEEP_PEER_CERT
+        #define KEEP_PEER_CERT
+    #endif
+#else
+    #ifdef WOLFSSL_ESPIDF
+        /* #warning "App config undetected" */
+    #endif
+    /* the code is older or does not have application name defined. */
+#endif /* Example wolfSSL Configuration app settings */
+
+/* Experimental Kyber */
+#ifdef CONFIG_WOLFSSL_ENABLE_KYBER
+    /* Kyber typically needs a minimum 10K stack */
+    #define WOLFSSL_EXPERIMENTAL_SETTINGS
+    #define WOLFSSL_HAVE_KYBER
+    #define WOLFSSL_WC_KYBER
+    #define WOLFSSL_SHA3
+    #if defined(CONFIG_IDF_TARGET_ESP8266)
+        /* With limited RAM, we'll disable some of the Kyber sizes: */
+        #define WOLFSSL_NO_KYBER1024
+        #define WOLFSSL_NO_KYBER768
+        #define NO_SESSION_CACHE
+    #endif
+#endif
+
+/* Enable AES for all examples */
+#ifdef NO_AES
+    #warning "Found NO_AES, wolfSSL AES Cannot be enabled. Check config."
+#else
+    #define WOLFSSL_AES
+    #define WOLFSSL_AES_COUNTER
+
+    /* Typically only needed for wolfssl_test, see docs. */
+    #define WOLFSSL_AES_DIRECT
+#endif
+
+/* Pick a cert buffer size: */
+/* #define USE_CERT_BUFFERS_2048 */
+/* #define USE_CERT_BUFFERS_1024 */
+#define USE_CERT_BUFFERS_2048
+
+/* The Espressif sdkconfig will have chipset info.
+**
+** Some possible values:
+**
+**   CONFIG_IDF_TARGET_ESP32
+**   CONFIG_IDF_TARGET_ESP32S2
+**   CONFIG_IDF_TARGET_ESP32S3
+**   CONFIG_IDF_TARGET_ESP32C3
+**   CONFIG_IDF_TARGET_ESP32C6
+*/
+
+/* Optionally enable Apple HomeKit from compiler directive or Kconfig setting */
+#if defined(WOLFSSL_APPLE_HOMEKIT) || defined(CONFIG_WOLFSSL_APPLE_HOMEKIT)
+     /* SRP is known to need 8K; slow on some devices */
+     #define FP_MAX_BITS (8192 * 2)
+     #define WOLFCRYPT_HAVE_SRP
+     #define HAVE_CHACHA
+     #define HAVE_POLY1305
+     #define WOLFSSL_BASE64_ENCODE
+ #endif /* Apple HomeKit settings */
+
+/* Used by ESP-IDF components: */
+#if defined(CONFIG_ESP_TLS_USING_WOLFSSL)
+    /* The ESP-TLS */
+    #ifndef FP_MAX_BITS
+        #if defined(CONFIG_IDF_TARGET_ESP32C2) || \
+            defined(CONFIG_IDF_TARGET_ESP8684) || \
+            defined(CONFIG_IDF_TARGET_ESP8266)
+            /* Optionally set smaller size here */
+            #define FP_MAX_BITS MIN_FFDHE_FP_MAX_BITS
+        #else
+            #define FP_MAX_BITS (4096 * 2)
+        #endif
+    #endif
+    #define HAVE_ALPN
+    #ifndef CONFIG_IDF_TARGET_ESP8266
+        /* Unless installed in the ESP8266 RTOS SDK locally, the wolfSSL
+         * API for SNI will not be seen in the components/esp-tls layer.
+         * Only enable SNI for non-ESP8266 targets by default: */
+        #define HAVE_SNI
+    #endif
+    #define OPENSSL_EXTRA_X509_SMALL
+
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+#endif
+
 /* Optionally enable some wolfSSH settings */
-#ifdef ESP_ENABLE_WOLFSSH
-    /* The default SSH Windows size is massive for an embedded target. Limit it: */
+#if defined(ESP_ENABLE_WOLFSSH) || defined(CONFIG_ESP_ENABLE_WOLFSSH)
+    /* Enable wolfSSH. Espressif examples need a few more settings, below */
+    #undef  WOLFSSL_WOLFSSH
+    #define WOLFSSL_WOLFSSH
+
+    /* The default SSH Windows size is massive for an embedded target.
+     * Limit it: */
     #define DEFAULT_WINDOW_SZ 2000
 
     /* These may be defined in cmake for other examples: */
     #undef  WOLFSSH_TERM
     #define WOLFSSH_TERM
 
-    #undef  DEBUG_WOLFSSH
-    #define DEBUG_WOLFSSH
+    /* optional debug */
+    /* #undef  DEBUG_WOLFSSH */
+    /* #define DEBUG_WOLFSSH */
 
     #undef  WOLFSSL_KEY_GEN
     #define WOLFSSL_KEY_GEN
@@ -59,21 +312,54 @@
 
     #define WOLFSSH_TEST_SERVER
     #define WOLFSSH_TEST_THREADING
-
 #endif /* ESP_ENABLE_WOLFSSH */
 
-/* when you want to use SINGLE THREAD */
-/* #define SINGLE_THREADED */
+
+/* Not yet using WiFi lib, so don't compile in the esp-sdk-lib WiFi helpers: */
+/* #define USE_WOLFSSL_ESP_SDK_WIFI */
 
 /*
- * choose ONE of these Espressif chips to define:
+ * ONE of these Espressif chip families will be detected from sdkconfig:
  *
  * WOLFSSL_ESP32
  * WOLFSSL_ESPWROOM32SE
  * WOLFSSL_ESP8266
+ *
+ * following ifdef detection only for syntax highlighting:
  */
+#ifdef WOLFSSL_ESPWROOM32SE
+    #undef WOLFSSL_ESPWROOM32SE
+#endif
+#ifdef WOLFSSL_ESP8266
+    #undef WOLFSSL_ESP8266
+#endif
+#ifdef WOLFSSL_ESP32
+    #undef WOLFSSL_ESP32
+#endif
+/* See below for chipset detection from sdkconfig.h */
 
-#define WOLFSSL_ESP32
+/* when you want to use SINGLE THREAD. Note Default ESP-IDF is FreeRTOS */
+#define SINGLE_THREADED
+
+/* Small session cache saves a lot of RAM for ClientCache and SessionCache.
+ * Memory requirement is about 5KB, otherwise 20K is needed when not specified.
+ * If extra small footprint is needed, try MICRO_SESSION_CACHE (< 1K)
+ * When really desperate or no TLS used, try NO_SESSION_CACHE.  */
+#define NO_SESSION_CACHE
+
+/* Small Stack uses more heap. */
+#define WOLFSSL_SMALL_STACK
+
+/* Full debugging turned off, but show malloc failure detail */
+/* #define DEBUG_WOLFSSL */
+#define DEBUG_WOLFSSL_MALLOC
+
+/* See test.c that sets cert buffers; we'll set them here: */
+#define USE_CERT_BUFFERS_256
+#define USE_CERT_BUFFERS_2048
+
+/* RSA_LOW_MEM: Half as much memory but twice as slow. */
+#define RSA_LOW_MEM
 
 /* optionally turn off SHA512/224 SHA512/256 */
 /* #define WOLFSSL_NOSHA512_224 */
@@ -87,37 +373,84 @@
 /* #define NO_OLD_TLS */
 
 #define BENCH_EMBEDDED
-#define USE_CERT_BUFFERS_2048
 
-#define NO_OLD_TLS
-/* TLS 1.3
- #define WOLFSSL_TLS13
- #define HAVE_TLS_EXTENSIONS
- #define WC_RSA_PSS
- #define HAVE_SUPPORTED_CURVES
-*/
+/* TLS 1.3                                 */
+#ifdef CONFIG_WOLFSSL_ALLOW_TLS13
+    #define WOLFSSL_TLS13
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_HKDF
 
-#define HAVE_HKDF
-#define HAVE_AEAD
+    /* May be required */
+    #ifndef HAVE_AEAD
+    #endif
+
+    /* Required for ECC */
+    #define HAVE_SUPPORTED_CURVES
+
+    /* Required for RSA */
+    #define WC_RSA_PSS
+
+    /* TLS 1.3 normally requires HAVE_FFDHE */
+    #if defined(HAVE_FFDHE_2048) || \
+        defined(HAVE_FFDHE_3072) || \
+        defined(HAVE_FFDHE_4096) || \
+        defined(HAVE_FFDHE_6144) || \
+        defined(HAVE_FFDHE_8192)
+    #else
+        #define HAVE_FFDHE_2048
+        /* #error "TLS 1.3 requires HAVE_FFDHE_[nnnn]" */
+    #endif
+#endif
+
+#if defined(CONFIG_IDF_TARGET_ESP32C2) || \
+    defined(CONFIG_IDF_TARGET_ESP8684)
+    /* Optionally set smaller size here */
+    #ifdef HAVE_FFDHE_4096
+        /* this size may be problematic on the C2 */
+    #endif
+    #define HAVE_FFDHE_2048
+#else
+    #define HAVE_FFDHE_4096
+#endif
 
 #define NO_FILESYSTEM
 
+#define NO_OLD_TLS
+
 #define HAVE_AESGCM
 
-#define WOLFSSL_RIPEMD
-/* when you want to use SHA224 */
-/* #define WOLFSSL_SHA224      */
+/* Optional RIPEMD: RACE Integrity Primitives Evaluation Message Digest */
+/* #define WOLFSSL_RIPEMD */
 
+/* when you want to use SHA224 */
+#define WOLFSSL_SHA224
 
 /* when you want to use SHA384 */
-/* #define WOLFSSL_SHA384 */
+#define WOLFSSL_SHA384
 
-/* #define WOLFSSL_SHA3 */
+/* Some features not enabled for ESP8266: */
+#if defined(CONFIG_IDF_TARGET_ESP8266) || \
+    defined(CONFIG_IDF_TARGET_ESP32C2)
+    /* Some known low-memory devices have features not enabled by default. */
+    /* TODO determine low memory configuration for ECC. */
+#else
+    /* when you want to use SHA512 */
+    #define WOLFSSL_SHA512
 
-#define WOLFSSL_SHA512
+    /* when you want to use SHA3 */
+    /* #define WOLFSSL_SHA3 */
 
-#define MY_USE_ECC 1
-#define MY_USE_RSA 0
+    /* ED25519 requires SHA512 */
+    #define HAVE_ED25519
+#endif
+
+#if defined(CONFIG_IDF_TARGET_ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C2)
+    #define MY_USE_ECC 0
+    #define MY_USE_RSA 1
+#else
+    #define MY_USE_ECC 1
+    #define MY_USE_RSA 0
+#endif
 
 /* We can use either or both ECC and RSA, but must use at least one. */
 #if MY_USE_ECC || MY_USE_RSA
@@ -126,7 +459,7 @@
         #define HAVE_ECC
         #define HAVE_CURVE25519
         #define HAVE_ED25519
-
+        #define WOLFSSL_SHA512
         /*
         #define HAVE_ECC384
         #define CURVE25519_SMALL
@@ -151,24 +484,42 @@
     #error "Either RSA or ECC must be enabled"
 #endif
 
+/* Optional OpenSSL compatibility */
+/* #define OPENSSL_EXTRA */
 
-/* when you want to use pkcs7 */
+/* #Optional HAVE_PKCS7 */
 /* #define HAVE_PKCS7 */
 
 #if defined(HAVE_PKCS7)
+    /* HAVE_PKCS7 may enable HAVE_PBKDF2 see settings.h */
+    #define NO_PBKDF2
+
     #define HAVE_AES_KEYWRAP
     #define HAVE_X963_KDF
     #define WOLFSSL_AES_DIRECT
 #endif
 
-/* when you want to use aes counter mode */
+/* when you want to use AES counter mode */
 /* #define WOLFSSL_AES_DIRECT */
 /* #define WOLFSSL_AES_COUNTER */
 
-/* debug options */
-/* #define DEBUG_WOLFSSL */
-/* #define WOLFSSL_ESP32_CRYPT_DEBUG */
-/* #define WOLFSSL_ATECC508A_DEBUG          */
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
+/* WC_NO_CACHE_RESISTANT: slower but more secure */
+/* #define WC_NO_CACHE_RESISTANT */
+
+/* TFM_TIMING_RESISTANT: slower but more secure */
+/* #define TFM_TIMING_RESISTANT */
+
+/* #define WOLFSSL_ATECC508A_DEBUG         */
 
 /* date/time                               */
 /* if it cannot adjust time in the device, */
@@ -176,15 +527,21 @@
 /* #define NO_ASN_TIME */
 /* #define XTIME time */
 
-/* adjust wait-timeout count if you see timeout in RSA HW acceleration */
-#define ESP_RSA_TIMEOUT_CNT    0x249F00
 
+/* Adjust wait-timeout count if you see timeout in RSA HW acceleration.
+ * Set to very large number and enable WOLFSSL_HW_METRICS to determine max. */
+#ifndef ESP_RSA_TIMEOUT_CNT
+    #define ESP_RSA_TIMEOUT_CNT 0xFF0000
+#endif
+
+/* hash limit for test.c */
+#define HASH_SIZE_LIMIT
 
 /* USE_FAST_MATH is default */
 #define USE_FAST_MATH
 
 /*****      Use SP_MATH      *****/
-/* #undef USE_FAST_MATH          */
+/* #undef  USE_FAST_MATH         */
 /* #define SP_MATH               */
 /* #define WOLFSSL_SP_MATH_ALL   */
 /* #define WOLFSSL_SP_RISCV32    */
@@ -193,11 +550,65 @@
 /* #undef USE_FAST_MATH          */
 /* #define USE_INTEGER_HEAP_MATH */
 
+/* Just syntax highlighting to check math libraries: */
+#if defined(SP_MATH)               || \
+    defined(USE_INTEGER_HEAP_MATH) || \
+    defined(USE_INTEGER_HEAP_MATH) || \
+    defined(USE_FAST_MATH)         || \
+    defined(WOLFSSL_SP_MATH_ALL)   || \
+    defined(WOLFSSL_SP_RISCV32)
+#endif
 
 #define WOLFSSL_SMALL_STACK
 
-/* The ESP32 has some detailed statup information available:*/
+
 #define HAVE_VERSION_EXTENDED_INFO
+/* #define HAVE_WC_INTROSPECTION */
+
+#ifndef NO_SESSION_CACHE
+    #define  HAVE_SESSION_TICKET
+#endif
+
+/* #define HAVE_HASHDRBG */
+
+#if 0
+/* Example for additional cert functions */
+#define WOLFSSL_KEY_GEN
+    #define WOLFSSL_CERT_REQ
+    #define WOLFSSL_CERT_GEN
+    #define WOLFSSL_CERT_EXT
+    #define WOLFSSL_SYS_CA_CERTS
+
+
+    #define WOLFSSL_CERT_TEXT
+
+    /* command-line options
+    --enable-keygen
+    --enable-certgen
+    --enable-certreq
+    --enable-certext
+    --enable-asn-template
+    */
+
+#endif
+
+#define WOLFSSL_ASN_TEMPLATE
+
+/*
+#undef  WOLFSSL_KEY_GEN
+#undef  WOLFSSL_CERT_REQ
+#undef  WOLFSSL_CERT_GEN
+#undef  WOLFSSL_CERT_EXT
+#undef  WOLFSSL_SYS_CA_CERTS
+*/
+
+/* command-line options
+--enable-keygen
+--enable-certgen
+--enable-certreq
+--enable-certext
+--enable-asn-template
+*/
 
 /* optional SM4 Ciphers. See https://github.com/wolfSSL/wolfsm */
 /*
@@ -251,20 +662,14 @@
     #define USE_CERT_BUFFERS_2048
 #endif
 
-/* esp32-wroom-32se specific definition */
-#if defined(WOLFSSL_ESPWROOM32SE)
-    #define WOLFSSL_ATECC508A
-    #define HAVE_PK_CALLBACKS
-    /* when you want to use a custom slot allocation for ATECC608A */
-    /* unless your configuration is unusual, you can use default   */
-    /* implementation.                                             */
-    /* #define CUSTOM_SLOT_ALLOCATION                              */
-#endif
-
-/* Default is HW enabled unless turned off.
-** Uncomment these lines to force SW instead of HW acceleration */
-
+/* Chipset detection from sdkconfig.h
+ * Default is HW enabled unless turned off.
+ * Uncomment lines to force SW instead of HW acceleration */
 #if defined(CONFIG_IDF_TARGET_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ESP32
+    /*  Alternatively, if there's an ECC Secure Element present: */
+    /* #define WOLFSSL_ESPWROOM32SE */
+
     /* wolfSSL HW Acceleration supported on ESP32. Uncomment to disable: */
     /*  #define NO_ESP32_CRYPT                 */
     /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
@@ -275,23 +680,14 @@
     /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD */
 
     /*  These are defined automatically in esp32-crypt.h, here for clarity:  */
-    /* no SHA224 HW on ESP32  */
-    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224 /* no SHA224 HW on ESP32  */
 
-    /* Define USE_FAST_MATH and SMALL_STACK                        */
-    #define ESP32_USE_RSA_PRIMITIVE
-
-    /* threshold for performance adjustment for HW primitive use   */
-    /* X bits of G^X mod P greater than                            */
-    #define EPS_RSA_EXPT_XBTIS           32
-
-    /* X and Y of X * Y mod P greater than                         */
     #undef  ESP_RSA_MULM_BITS
-    #define ESP_RSA_MULM_BITS            16
-
+    #define ESP_RSA_MULM_BITS 16 /* TODO add compile-time warning */
     /***** END CONFIG_IDF_TARGET_ESP32 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    #define WOLFSSL_ESP32
     /* wolfSSL HW Acceleration supported on ESP32-S2. Uncomment to disable: */
     /*  #define NO_ESP32_CRYPT                 */
     /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
@@ -304,6 +700,7 @@
     /***** END CONFIG_IDF_TARGET_ESP32S2 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    #define WOLFSSL_ESP32
     /* wolfSSL HW Acceleration supported on ESP32-S3. Uncomment to disable: */
     /*  #define NO_ESP32_CRYPT                         */
     /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH            */
@@ -317,6 +714,7 @@
 
 #elif defined(CONFIG_IDF_TARGET_ESP32C2) || \
       defined(CONFIG_IDF_TARGET_ESP8684)
+    #define WOLFSSL_ESP32
     /* ESP8684 is essentially ESP32-C2 chip + flash embedded together in a
      * single QFN 4x4 mm package. Out of released documentation, Technical
      * Reference Manual as well as ESP-IDF Programming Guide is applicable
@@ -342,6 +740,7 @@
     /***** END CONFIG_IDF_TARGET_ESP32C2 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    #define WOLFSSL_ESP32
     /* wolfSSL HW Acceleration supported on ESP32-C3. Uncomment to disable: */
 
     /*  #define NO_ESP32_CRYPT                 */
@@ -359,6 +758,7 @@
     /***** END CONFIG_IDF_TARGET_ESP32C3 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    #define WOLFSSL_ESP32
     /* wolfSSL HW Acceleration supported on ESP32-C6. Uncomment to disable: */
 
     /*  #define NO_ESP32_CRYPT                 */
@@ -375,6 +775,7 @@
     /***** END CONFIG_IDF_TARGET_ESP32C6 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32H2)
+    #define WOLFSSL_ESP32
     /*  wolfSSL Hardware Acceleration not yet implemented */
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH
@@ -383,11 +784,19 @@
     /***** END CONFIG_IDF_TARGET_ESP32H2 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP8266)
-    /*  TODO: Revisit ESP8266 */
+    #define WOLFSSL_ESP8266
+
+    /* There's no hardware encryption on the ESP8266 */
+    /* Consider using the ESP32-C2/C3/C6             */
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH
     #define NO_WOLFSSL_ESP32_CRYPT_AES
     #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+    #ifndef FP_MAX_BITS
+        /* FP_MAX_BITS matters in wolfssl_test, not just TLS setting.   */
+        /* MIN_FFDHE_FP_MAX_BITS = (MIN_FFDHE_BITS * 2); see settings.h */
+        #define FP_MAX_BITS MIN_FFDHE_FP_MAX_BITS
+    #endif
     /***** END CONFIG_IDF_TARGET_ESP266 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP8684)
@@ -399,33 +808,86 @@
     /***** END CONFIG_IDF_TARGET_ESP8684 *****/
 
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
+    #warning "Unexpected CONFIG_IDF_TARGET_NN value"
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH
     #define NO_WOLFSSL_ESP32_CRYPT_AES
     #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
 #endif /* CONFIG_IDF_TARGET Check */
 
+/* RSA primitive specific definition, listed AFTER the Chipset detection */
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    /* Consider USE_FAST_MATH and SMALL_STACK                        */
+
+    #ifndef NO_RSA
+        #define ESP32_USE_RSA_PRIMITIVE
+
+        #if defined(CONFIG_IDF_TARGET_ESP32)
+            #ifdef CONFIG_ESP_MAIN_TASK_STACK_SIZE
+                #if CONFIG_ESP_MAIN_TASK_STACK_SIZE < 10500
+                    #warning "RSA may be difficult with less than 10KB Stack "/
+                #endif
+            #endif
+
+            /* NOTE HW unreliable for small values! */
+            /* threshold for performance adjustment for HW primitive use   */
+            /* X bits of G^X mod P greater than                            */
+            #undef  ESP_RSA_EXPT_XBITS
+            #define ESP_RSA_EXPT_XBITS 32
+
+            /* X and Y of X * Y mod P greater than                         */
+            #undef  ESP_RSA_MULM_BITS
+            #define ESP_RSA_MULM_BITS  16
+        #endif
+    #endif
+#endif
+
 /* Debug options:
+See wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h for details on debug options
+
+optionally increase error message size for very long paths.
+#define WOLFSSL_MAX_ERROR_SZ 500
+
+Turn wolfSSL debugging on/off:
+    wolfSSL_Debugging_ON();
+    wolfSSL_Debugging_OFF();
 
 #define ESP_VERIFY_MEMBLOCK
 #define DEBUG_WOLFSSL
 #define DEBUG_WOLFSSL_VERBOSE
 #define DEBUG_WOLFSSL_SHA_MUTEX
+#define WOLFSSL_DEBUG_IGNORE_ASN_TIME
+#define WOLFSSL_DEBUG_CERT_BUNDLE
+#define WOLFSSL_DEBUG_CERT_BUNDLE_NAME
 #define WOLFSSL_ESP32_CRYPT_DEBUG
 #define WOLFSSL_ESP32_CRYPT_HASH_SHA224_DEBUG
 #define NO_RECOVER_SOFTWARE_CALC
 #define WOLFSSL_TEST_STRAY 1
 #define USE_ESP_DPORT_ACCESS_READ_BUFFER
 #define WOLFSSL_ESP32_HW_LOCK_DEBUG
+#define WOLFSSL_DEBUG_MUTEX
 #define WOLFSSL_DEBUG_ESP_RSA_MULM_BITS
+#define WOLFSSL_DEBUG_ESP_HW_MOD_RSAMAX_BITS
+#define WOLFSSL_DEBUG_ESP_HW_MULTI_RSAMAX_BITS
 #define ESP_DISABLE_HW_TASK_LOCK
+#define ESP_MONITOR_HW_TASK_LOCK
+#define USE_ESP_DPORT_ACCESS_READ_BUFFER
+
+See wolfcrypt/benchmark/benchmark.c for debug and other settings:
+
+Turn on benchmark timing debugging (CPU Cycles, RTOS ticks, etc)
+#define DEBUG_WOLFSSL_BENCHMARK_TIMING
+
+Turn on timer debugging (used when CPU cycles not available)
+#define WOLFSSL_BENCHMARK_TIMER_DEBUG
 */
 
 /* Pause in a loop rather than exit. */
-#define WOLFSSL_ESPIDF_ERROR_PAUSE
+/* #define WOLFSSL_ESPIDF_ERROR_PAUSE */
+/* #define WOLFSSL_ESP32_HW_LOCK_DEBUG */
 
-/* #define WOLFSSL_HW_METRICS */
+#define WOLFSSL_HW_METRICS
 
 /* for test.c */
 /* #define HASH_SIZE_LIMIT */
@@ -453,8 +915,9 @@
 ** [Z = X * Y mod M] in esp_mp_mulmod()                         */
 /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD                */
 
-#define WOLFSSL_PUBLIC_MP /* used by benchmark */
-#define USE_CERT_BUFFERS_2048
+
+/* used by benchmark: */
+#define WOLFSSL_PUBLIC_MP
 
 /* when turning on ECC508 / ECC608 support
 #define WOLFSSL_ESPWROOM32SE
@@ -463,12 +926,81 @@
 #define ATCA_WOLFSSL
 */
 
-/* optional SM4 Ciphers. See https://github.com/wolfSSL/wolfsm
+/***************************** Certificate Macros *****************************
+ *
+ * The section below defines macros used in typically all of the wolfSSL
+ * examples such as the client and server for certs stored in header files.
+ *
+ * There are various certificate examples in this header file:
+ * https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/certs_test.h
+ *
+ * To use the sample certificates in code (not recommended for production!):
+ *
+ *    #if defined(USE_CERT_BUFFERS_2048) || defined(USE_CERT_BUFFERS_1024)
+ *        #include <wolfssl/certs_test.h>
+ *    #endif
+ *
+ * To use the sets of macros below, define *one* of these:
+ *
+ *    USE_CERT_BUFFERS_1024  - ECC 1024 bit encoded ASN1
+ *    USE_CERT_BUFFERS_2048  - RSA 2048 bit encoded ASN1
+ *    WOLFSSL_SM[2,3,4]      - SM Ciphers
+ *
+ * For example: define USE_CERT_BUFFERS_2048 to use CA Certs used in this
+ *  wolfSSL function for the `ca_cert_der_2048` buffer, size and types:
+ *
+ *     ret = wolfSSL_CTX_load_verify_buffer(ctx,
+ *                                          CTX_CA_CERT,
+ *                                          CTX_CA_CERT_SIZE,
+ *                                          CTX_CA_CERT_TYPE);
+ *
+ * See https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_load_verify_buffer
+ *
+ * In this case the CTX_CA_CERT will be defined as `ca_cert_der_2048` as
+ * defined here: https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/certs_test.h
+ *
+ * The CTX_CA_CERT_SIZE and CTX_CA_CERT_TYPE are similarly used to reference
+ * array size and cert type respectively.
+ *
+ * Similarly for loading the private client key:
+ *
+ *  ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+ *                                          CTX_CLIENT_KEY,
+ *                                          CTX_CLIENT_KEY_SIZE,
+ *                                          CTX_CLIENT_KEY_TYPE);
+ *
+ * see https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_privatekey_buffer
+ *
+ * Similarly, the other macros are for server certificates and keys:
+ *   `CTX_SERVER_CERT` and `CTX_SERVER_KEY` are available.
+ *
+ * The certificate and key names are typically `static const unsigned char`
+ * arrays. The [NAME]_size are typically `sizeof([array name])`, and the types
+ * are the known wolfSSL encoding type integers (e.g. WOLFSSL_FILETYPE_PEM).
+ *
+ * See `SSL_FILETYPE_[name]` in
+ *   https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/ssl.h
+ *
+ * See Abstract Syntax Notation One (ASN.1) in:
+ *   https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/wolfcrypt/asn.h
+ *
+ * Optional SM4 Ciphers:
+ *
+ * Although the SM ciphers are shown here, the `certs_test_sm.h` may not yet
+ * be available. See:
+ *   https://github.com/wolfSSL/wolfssl/pull/6825
+ *   https://github.com/wolfSSL/wolfsm
+ *
+ * Uncomment these 3 macros to enable the SM Ciphers and use the macros below.
+ */
+
+/*
 #define WOLFSSL_SM2
 #define WOLFSSL_SM3
 #define WOLFSSL_SM4
 */
 
+/* Conditional macros used in wolfSSL TLS client and server examples */
 #if defined(WOLFSSL_SM2) || defined(WOLFSSL_SM3) || defined(WOLFSSL_SM4)
     #include <wolfssl/certs_test_sm.h>
     #define CTX_CA_CERT          root_sm2
@@ -484,19 +1016,77 @@
     #undef  WOLFSSL_BASE16
     #define WOLFSSL_BASE16
 #else
-    #define USE_CERT_BUFFERS_2048
-    #define USE_CERT_BUFFERS_256
-    #define CTX_CA_CERT          ca_cert_der_2048
-    #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_2048
-    #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
-    #define CTX_SERVER_CERT      server_cert_der_2048
-    #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_2048
-    #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
-    #define CTX_SERVER_KEY       server_key_der_2048
-    #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_2048
-    #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
-#endif
+    #if defined(USE_CERT_BUFFERS_2048)
+        #define USE_CERT_BUFFERS_256
+        /* Be sure to include in app when using example certs: */
+        /* #include <wolfssl/certs_test.h>                     */
+        #define CTX_CA_CERT          ca_cert_der_2048
+        #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_2048
+        #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
 
+        #define CTX_SERVER_CERT      server_cert_der_2048
+        #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_2048
+        #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_SERVER_KEY       server_key_der_2048
+        #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_2048
+        #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_CLIENT_CERT      client_cert_der_2048
+        #define CTX_CLIENT_CERT_SIZE sizeof_client_cert_der_2048
+        #define CTX_CLIENT_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_CLIENT_KEY       client_key_der_2048
+        #define CTX_CLIENT_KEY_SIZE  sizeof_client_key_der_2048
+        #define CTX_CLIENT_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+    #elif defined(USE_CERT_BUFFERS_1024)
+        #define USE_CERT_BUFFERS_256
+        /* Be sure to include in app when using example certs: */
+        /* #include <wolfssl/certs_test.h>                     */
+        #define CTX_CA_CERT          ca_cert_der_1024
+        #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_1024
+        #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_CLIENT_CERT      client_cert_der_1024
+        #define CTX_CLIENT_CERT_SIZE sizeof_client_cert_der_1024
+        #define CTX_CLIENT_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_CLIENT_KEY       client_key_der_1024
+        #define CTX_CLIENT_KEY_SIZE  sizeof_client_key_der_1024
+        #define CTX_CLIENT_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_SERVER_CERT      server_cert_der_1024
+        #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_1024
+        #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_SERVER_KEY       server_key_der_1024
+        #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_1024
+        #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+    #else
+        /* Optionally define custom cert arrays, sizes, and types here */
+        #error "Must define USE_CERT_BUFFERS_2048 or USE_CERT_BUFFERS_1024"
+    #endif
+#endif /* Conditional key and cert constant names */
+
+/******************************************************************************
+** Sanity Checks
+******************************************************************************/
+#if defined(CONFIG_ESP_MAIN_TASK_STACK_SIZE)
+    #if defined(WOLFCRYPT_HAVE_SRP)
+        #if defined(FP_MAX_BITS)
+            #if FP_MAX_BITS <  (8192 * 2)
+                #define ESP_SRP_MINIMUM_STACK_8K (24 * 1024)
+            #else
+                #define ESP_SRP_MINIMUM_STACK_8K (28 * 1024)
+            #endif
+        #else
+            #error "Please define FP_MAX_BITS when using WOLFCRYPT_HAVE_SRP."
+        #endif
+
+        #if (CONFIG_ESP_MAIN_TASK_STACK_SIZE < ESP_SRP_MINIMUM_STACK)
+            #warning "WOLFCRYPT_HAVE_SRP enabled with small stack size"
+        #endif
+    #endif
+#else
+    #warning "CONFIG_ESP_MAIN_TASK_STACK_SIZE not defined!"
+#endif
 /* See settings.h for some of the possible hardening options:
  *
  *  #define NO_ESPIDF_DEFAULT

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 #  [wolfSSL Project]/main/CMakeLists.txt
 #
-#  Copyright (C) 2014-2024 wolfSSL Inc.
+#  Copyright (C) 2014-2025 wolfSSL Inc.
 #
 #  This file is part of wolfSSH.
 #
@@ -28,28 +28,26 @@ message(STATUS "main cmake found WOLFSSL_COMPONENT_NAME = ${WOLFSSL_COMPONENT_NA
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
-endif()
-if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected UNIX")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
-    # Windows-specific configuration here
+    # Apple-specific configuration here
+    message(STATUS "Detected APPLE")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 set (git_cmd "git")
 

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
@@ -1,6 +1,6 @@
 /* echoserver.c
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/echoserver.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/echoserver.h
@@ -1,6 +1,6 @@
 /* echoserver.h
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/main.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/main.h
@@ -1,6 +1,6 @@
 /* template main.h
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/time_helper.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/time_helper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/wifi_connect.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/include/wifi_connect.h
@@ -1,6 +1,6 @@
 /* wifi_connect.h
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *
@@ -62,7 +62,7 @@
     #else
         #warning "did not detect environment. using ~/my_private_config.h"
         #include "~/my_private_config.h"
-	#endif
+    #endif
 #else
 
     /*
@@ -72,17 +72,44 @@
     ** If you'd rather not, just change the below entries to strings with
     ** the config you want - ie #define EXAMPLE_WIFI_SSID "mywifissid"
     */
+    /* Some older versions use ESP_WIFI_SSID via Kconfig */
     #ifdef CONFIG_ESP_WIFI_SSID
+        /* Overwrite the example SSID with the value set in menuconfig */
+        #undef  EXAMPLE_ESP_WIFI_SSID
         #define EXAMPLE_ESP_WIFI_SSID CONFIG_ESP_WIFI_SSID
-    #else
-        #define EXAMPLE_ESP_WIFI_SSID "MYSSID_WIFI_CONNECT"
     #endif
 
-    #ifdef CONFIG_ESP_WIFI_PASSWORD
-        #define EXAMPLE_ESP_WIFI_PASS CONFIG_ESP_WIFI_PASSWORD
-    #else
-        #define EXAMPLE_ESP_WIFI_PASS "MYPASSWORD_WIFI_CONNECT"
+    /* Newer versions of the ESP-IDF use EXAMPLE_WIFI_SSID via Kconfig */
+    #ifdef CONFIG_EXAMPLE_WIFI_SSID
+        /* Overwrite the example SSID with the value set in menuconfig */
+        #undef  EXAMPLE_ESP_WIFI_SSID
+        #define EXAMPLE_ESP_WIFI_SSID CONFIG_EXAMPLE_WIFI_SSID
     #endif
+
+    /* Some older versions use ESP_WIFI_PASSWORD via Kconfig */
+    #ifdef CONFIG_ESP_WIFI_PASSWORD
+        /* Overwrite the example password with the value set in menuconfig */
+        #undef  EXAMPLE_ESP_WIFI_PASS
+        #define EXAMPLE_ESP_WIFI_PASS CONFIG_ESP_WIFI_PASSWORD
+    #endif
+
+    /* Newer versions use CONFIG_ESP_WIFI_PASSWORD via Kconfig */
+    #ifdef CONFIG_EXAMPLE_WIFI_PASSWORD
+        /* Overwrite the example SSID with the value set in menuconfig */
+        #undef  EXAMPLE_ESP_WIFI_PASS
+        #define EXAMPLE_ESP_WIFI_PASS CONFIG_EXAMPLE_WIFI_PASSWORD
+    #endif
+
+#endif
+
+ /* Ensure EXAMPLE_ESP_WIFI_SSID and EXAMPLE_ESP_WIFI_PASS are not blank: */
+#ifndef EXAMPLE_ESP_WIFI_SSID
+    #warning "Setting default WiFi SSID: MYSSID_WIFI_CONNECT"
+    #define EXAMPLE_ESP_WIFI_SSID "MYSSID_WIFI_CONNECT"
+#endif
+#ifndef EXAMPLE_ESP_WIFI_PASS
+    #warning "Setting default WiFi SSID Password: MYSSID_WIFI_CONNECT"
+    #define EXAMPLE_ESP_WIFI_PASS "MYPASSWORD_WIFI_CONNECT"
 #endif
 
 /* ESP lwip */

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/main.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/main.c
@@ -1,6 +1,6 @@
 /* main.c
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/time_helper.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/time_helper.c
@@ -1,6 +1,6 @@
 /* time_helper.c
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/wifi_connect.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/wifi_connect.c
@@ -1,6 +1,6 @@
 /* wifi_connect.c
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/CMakeLists.txt
@@ -1,3 +1,26 @@
+#  [wolfSSL Project]/CMakeLists.txt
+#
+#  Copyright (C) 2014-2025 wolfSSL Inc.
+#
+#  This file is part of wolfSSH.
+#
+#  wolfSSH is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  wolfSSH is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+#
+# cmake for WOLFSSH Espressif projects
+#
+# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
+
 # wolfSSL Espressif Example Project CMakeLists.txt
 #   v1.0
 #
@@ -9,9 +32,15 @@ cmake_minimum_required(VERSION 3.16)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
 set(WOLFSSL_USER_SETTINGS ON)
 
+# Assume we have a ESP_ENABLE_WOLFSSH section in user_settings.h
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DESP_ENABLE_WOLFSSH")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSH_TERM")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDEBUG_WOLFSSH")
+# Managed wolfSSL Components prior to 5.7.4 need a manual setting for WOLFSSL_WOLFSSH
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_WOLFSSH")
+
+# Optional:
+# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSH_TERM")
+# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDEBUG_WOLFSSH")
 
 # The wolfSSL CMake file should be able to find the source code.
 # Otherwise, assign an environment variable or set it here:
@@ -32,28 +61,28 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDEBUG_WOLFSSH")
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
+    message(STATUS "Detected UNIX")
 endif()
 if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected APPLE")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -76,6 +105,18 @@ if( EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/wolfssl__wolfssl" AND EXI
                         "or rename the idf_component.yml file typically found in ./main/")
 else()
     message(STATUS "No conflicting wolfSSL components found.")
+endif()
+
+
+# This example uses an extra component for common functions such as Wi-Fi and Ethernet connection.
+set (PROTOCOL_EXAMPLES_DIR $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+
+if (EXISTS "${PROTOCOL_EXAMPLES_DIR}")
+    message(STATUS "Found PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
+    set(EXTRA_COMPONENT_DIRS $ENV{IDF_PATH}/examples/common_components/protocol_examples_common)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFOUND_PROTOCOL_EXAMPLES_DIR")
+else()
+    message("NOT FOUND: PROTOCOL_EXAMPLES_DIR=${PROTOCOL_EXAMPLES_DIR}")
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssh/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssh/CMakeLists.txt
@@ -1,6 +1,6 @@
-#  Espressif component/wolfssh/CMakeLists.txt
+#  [wolfSSL Project]/components/wolfssh/CMakeLists.txt
 #
-#  Copyright (C) 2014-2024 wolfSSL Inc.
+#  Copyright (C) 2014-2025 wolfSSL Inc.
 #
 #  This file is part of wolfSSH.
 #
@@ -17,27 +17,105 @@
 #  You should have received a copy of the GNU General Public License
 #  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
 #
-# cmake for WOLFSSH Espressif projects
+# cmake for WOLFSSH Espressif projects v5.6.6 r1
 #
 # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
 #
 
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSH_USER_SETTINGS")
+
+set(VERBOSE_COMPONENT_MESSAGES 1)
+
+# The scope of this CMAKE_C_FLAGS is just this component:
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+
 set(CMAKE_CURRENT_SOURCE_DIR ".")
+
+message(STATUS "CMAKE_CURRENT_LIST_DIR = ${CMAKE_CURRENT_LIST_DIR}")
+
+get_filename_component(THIS_DIR "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+message(STATUS "THIS_DIR = ${THIS_DIR}")
+
+# The root of the project is two directories up from here. (we are typically in [project name]components/mywolfssh)
+get_filename_component(PROJECT_ROOT "${THIS_DIR}" DIRECTORY)      # Up one directory from here is "components"
+get_filename_component(PROJECT_ROOT "${PROJECT_ROOT}" DIRECTORY)  # up one more directory should be the root of our project
+message(STATUS "PROJECT_ROOT = ${PROJECT_ROOT}")
+
+# in case wolfssl user_settings.h is missing, we'll look for one in the ESP32/lib directory:
+get_filename_component(LIB_USER_SETTINGS "${PROJECT_ROOT}/../lib/user_settings.h" ABSOLUTE)
+message(STATUS "wolfssl user_settings.h lib  = ${LIB_USER_SETTINGS}")
+
+get_filename_component(THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH "${PROJECT_ROOT}/components/wolfssl/include" ABSOLUTE)
+message(STATUS "wolfssl user_settings.h path = ${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
+
+# Optionally set your source to wolfSSL in your project CMakeLists.txt like this:
+# set(WOLFSSH_ROOT "c:/some/workspace/wolfssh" )
+
+if ( "${WOLFSSH_ROOT}" STREQUAL "")
+    set(WOLFSSH_ROOT "$ENV{WOLFSSH_ROOT}" )
+endif()
+
+# Optional compiler definitions to help with system name detection (typically printed by app diagnostics)
+if( VERBOSE_COMPONENT_MESSAGES )
+    if(WIN32)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
+        message(STATUS "Detected Windows")
+    endif()
+    if(CMAKE_HOST_UNIX)
+        message(STATUS "Detected UNIX")
+    endif()
+    if(APPLE)
+        message(STATUS "Detected APPLE")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
+        message(STATUS "Detected WSL")
+    endif()
+    if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
+        message(STATUS "Detected Linux")
+    endif()
+    if(APPLE)
+        # Windows-specific configuration here
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
+        message(STATUS "Detected Apple")
+    endif()
+endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
+
+message(STATUS "CONFIG_TARGET_PLATFORM = ${CONFIG_TARGET_PLATFORM}")
+
+# find the user name to search for possible "wolfssh-username"
+# find the user name to search for possible "wolfssh-username"
+message(STATUS "USERNAME = $ENV{USERNAME}")
+if(  "$ENV{USER}" STREQUAL "" ) # the bash user
+    if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
+        message(STATUS "could not find USER or USERNAME")
+    else()
+        # the bash user is not blank, so we'll use it.
+        set(THIS_USER "$ENV{USERNAME}")
+    endif()
+else()
+    # the bash user is not blank, so we'll use it.
+    set(THIS_USER "$ENV{USER}")
+endif()
+message(STATUS "THIS_USER = ${THIS_USER}")
 
 # Attention!
 #
 # When editing component CMake files, consider the following :
 #
-# NO Managed Componenets: Normal stand-alone app, "as cloned" from github.
-#   There's no notion of staging names (e.g. mywolfmqtt) regardless of environment settings.
+# NO Managed Components: Normal stand-alone app, "as cloned" from github.
+#   There's no notion of staging names (e.g. mywolfssh) regardless of environment settings.
 #   All of the component source is locall. See settings such s WOLFSSL_ROOT=[your path]
 #
 # Partially Managed Components. This one is tricky. When publishing a component with examples,
 #    those examples will have a chicken-and-egg problem: the required component is not yet published.
 #    Adding to the complexity is the notion of staging components, that are purposely prefixed with
-#    "my" (e.g. mywolfmqtt) to distinguish from production, live components (e.g. wolfmqtt)
+#    "my" (e.g. mywolfssh) to distinguish from production, live components (e.g. wolfssh)
 #
 #    Partially Managed Component Examples are typically only encountered by the component publisher
 #    and only at publish time, such as when performing the pre-publish build check.
@@ -45,49 +123,185 @@ set(CMAKE_CURRENT_SOURCE_DIR ".")
 #    A partially managed component may also be manually created, when adding a managed component to
 #    and existing project. For example:
 #
-#       idf.py add-dependency "wolfssl/wolfssh^1.4.15-stable"
+#       idf.py add-dependency "wolfssl/wolfssh^1.4.18"
 #
-# Fully Managaged Componenets. This is the typical example as created from the Component Registry:
+# Fully Managed Components. This is the typical example as created from the Component Registry:
 #    For example:
 #
-#       idf.py create-project-from-example "wolfssl/wolfssh^1.4.15-stable:wolfssh_server"
+#       idf.py create-project-from-example "wolfssl/wolfssh^1.4.18"
 #
 # In all cases, keep in mind that components other than wolfssl will depend on the wolfssl component.
 #
+message(STATUS "CMAKE_CURRENT_LIST_DIR = ${CMAKE_CURRENT_LIST_DIR}")
+
+get_filename_component(THIS_DIR "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)
+message(STATUS "THIS_DIR = ${THIS_DIR}")
+
+# The root of the project is two directories up from here. (we are typically in [project name]components/mywolfssh)
+get_filename_component(PROJECT_ROOT "${THIS_DIR}" DIRECTORY)      # Up one directory from here is "components"
+get_filename_component(PROJECT_ROOT "${PROJECT_ROOT}" DIRECTORY)  # up one more directory should be the root of our project
+message(STATUS "PROJECT_ROOT = ${PROJECT_ROOT}")
+
 
 # Component naming is only adjusted when using Managed Components, and only when using staging site.
 if( "$ENV{IDF_COMPONENT_REGISTRY_URL}" STREQUAL "https://components-staging.espressif.com" )
     # TODO: Is checking these two variables really the best way to detect an active Component Manager?
     message(STATUS "component_manager_interface_version = ${component_manager_interface_version}")
     message(STATUS "managed_components = ${managed_components}")
-    if( ("${managed_components}" STREQUAL "") AND ("${component_manager_interface_version}" STREQUAL "") )
+    message(STATUS "Checking if wolfssl is in ${PROJECT_ROOT}/managed_components/${THIS_USER}__mywolfssl")
+
+    if(EXISTS "${PROJECT_ROOT}/managed_components/${THIS_USER}__mywolfssl/CMakeLists.txt")
+        message(STATUS "Found user-specific, managed, staging component. The wolfssl component will be named mywolfssl.")
+        set(WOLFSSL_COMPONENT_NAME "mywolfssl")
+    elseif( ("${managed_components}" STREQUAL "") AND ("${component_manager_interface_version}" STREQUAL "") )
         # We've found a staging component, but did not detect the component manager
+        message(STATUS "No component manager interface component wolfssl ${CMAKE_HOME_DIRECTORY}")
         set(WOLFSSL_COMPONENT_NAME "wolfssl")
     else()
+        message(STATUS "else mywolfssl")
         set(WOLFSSL_COMPONENT_NAME "mywolfssl")
     endif()
+elseif(EXISTS "${CMAKE_HOME_DIRECTORY}/managed_components/${THIS_USER}__mywolfssl/CMakeLists.txt")
+    message(STATUS "Found managed_components mywolfssl")
+    set(WOLFSSL_COMPONENT_NAME "mywolfssl")
 else()
+    message(STATUS "Not staging environment, no managed_components wolfssl")
     set(WOLFSSL_COMPONENT_NAME "wolfssl")
 endif()
 
 set(COMPONENT_REQUIRES lwip "${WOLFSSL_COMPONENT_NAME}")
 
+# function: IS_WOLFSSH_SOURCE
+#  parameter: DIRECTORY_PARAMETER = the directory to test
+#  output:    RESULT = contains contents of DIRECTORY_PARAMETER for wolfssh directory, otherwise blank.
+function(IS_WOLFSSH_SOURCE DIRECTORY_PARAMETER RESULT)
+    if (EXISTS "${DIRECTORY_PARAMETER}/wolfssh/ssh.h")
+        if (EXISTS "${DIRECTORY_PARAMETER}/wolfssh")
+            message(STATUS "1")
+        endif()
+        if (EXISTS "${DIRECTORY_PARAMETER}")
+            message(STATUS "2")
+        endif()
+        if (EXISTS "${DIRECTORY_PARAMETER}/src")
+            message(STATUS "3")
+        endif()
+        set(${RESULT} "${DIRECTORY_PARAMETER}" PARENT_SCOPE)
+    else()
+        set(${RESULT} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+# function: FIND_WOLFSSH_DIRECTORY
+#  parameter: OUTPUT_FOUND_WOLFSSH_DIRECTORY contains root of source code, otherwise blank
+#
+function(FIND_WOLFSSH_DIRECTORY OUTPUT_FOUND_WOLFSSH_DIRECTORY)
+    message(STATUS "Starting FIND_WOLFSSH_DIRECTORY")
+
+    message(STATUS "OUTPUT_FOUND_WOLFSSH_DIRECTORY = ${${OUTPUT_FOUND_WOLFSSH_DIRECTORY}}")
+    IS_WOLFSSH_SOURCE("${${OUTPUT_FOUND_WOLFSSH_DIRECTORY}}" FOUND_WOLFSSH)
+    if( FOUND_WOLFSSH )
+        set(${OUTPUT_FOUND_WOLFSSH_DIRECTORY} ${${OUTPUT_FOUND_WOLFSSH_DIRECTORY}} PARENT_SCOPE)
+        return()
+    endif()
+    message(STATUS "")
+
+    if ( "${${OUTPUT_FOUND_WOLFSSH_DIRECTORY}}" STREQUAL "" )
+        set(CURRENT_SEARCH_DIR "$ENV{WOLFSSH_ROOT}")
+        if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
+            message(STATUS "The WOLFSSH_ROOT environment variable is not set. Searching...")
+        else()
+            get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSH_ROOT}" ABSOLUTE)
+            IS_WOLFSSH_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSH)
+            if( FOUND_WOLFSSH )
+                message(STATUS "Found WOLFSSH_ROOT via Environment Variable:")
+            else()
+                message(FATAL_ERROR "WOLFSSH_ROOT Environment Variable defined, but path not found:")
+                message(STATUS "$ENV{WOLFSSH_ROOT}")
+            endif()
+        endif()
+    else()
+        # There's a non-blank WOLFSSH_ROOT environment variable. Is it a valid wolfssh directory?
+        get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSH_ROOT}" ABSOLUTE)
+        IS_WOLFSSH_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSH)
+        if("${FOUND_WOLFSSH}")
+            message(STATUS "Found WOLFSSH_ROOT via Environment Variable:")
+        else()
+            message(FATAL_ERROR "WOLFSSH_ROOT Environment Variable defined, but path not found: $ENV{WOLFSSH_ROOT}")
+            #message(STATUS "Exit CMake")
+        endif()
+    endif()
+
+    # we'll start in the THIS_CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/wolfssh
+    message(STATUS "THIS_CMAKE_CURRENT_SOURCE_DIR = ${THIS_CMAKE_CURRENT_SOURCE_DIR}")
+    get_filename_component(CURRENT_SEARCH_DIR "${THIS_CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+    message(STATUS "CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+    string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
+
+    # loop through all the parents, looking for wolfssh
+    while(NOT CURRENT_SEARCH_DIR STREQUAL "/" AND NOT CURRENT_SEARCH_DIR STREQUAL "" )
+        string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
+        # wolfssh may simply be in a parent directory, such as for local examples in wolfssh repo
+        IS_WOLFSSH_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSH)
+        if( FOUND_WOLFSSH )
+            message(STATUS "Found wolfssh in CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+            set(${OUTPUT_FOUND_WOLFSSH_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+            return()
+        endif()
+
+        if( THIS_USER )
+            # Check for "wolfssh-[username]" subdirectory as we recurse up the directory tree
+            set(CURRENT_SEARCH_DIR_ALT "${CURRENT_SEARCH_DIR}/wolfssh-${THIS_USER}")
+            message(STATUS "Looking in ${CURRENT_SEARCH_DIR}")
+
+            #if(EXISTS ${CURRENT_SEARCH_DIR_ALT} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR_ALT} AND EXISTS "${CURRENT_SEARCH_DIR_ALT}/wolfcrypt/src")
+            IS_WOLFSSH_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSH )
+            if ( FOUND_WOLFSSH )
+               message(STATUS "Found wolfssh in user-suffix CURRENT_SEARCH_DIR_ALT = ${CURRENT_SEARCH_DIR_ALT}")
+                set(${OUTPUT_FOUND_WOLFSSH_DIRECTORY} ${CURRENT_SEARCH_DIR_ALT} PARENT_SCOPE)
+                return()
+            endif()
+        endif()
+
+        # Next check for no user suffix "wolfssh" subdirectory as we recurse up the directory tree
+        set(CURRENT_SEARCH_DIR_ALT ${CURRENT_SEARCH_DIR}/wolfssh)
+        # if(EXISTS ${CURRENT_SEARCH_DIR} AND IS_DIRECTORY ${CURRENT_SEARCH_DIR} AND EXISTS "${CURRENT_SEARCH_DIR}/wolfcrypt/src")
+        IS_WOLFSSH_SOURCE("${CURRENT_SEARCH_DIR_ALT}" FOUND_WOLFSSH )
+        if ( FOUND_WOLFSSH )
+            message(STATUS "Found wolfssh in CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+            set(${OUTPUT_FOUND_WOLFSSH_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+            return()
+        endif()
+
+        # Move up one directory level
+        set(PRIOR_SEARCH_DIR "${CURRENT_SEARCH_DIR}")
+        get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" DIRECTORY)
+        message(STATUS "Next CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+        if( "${PRIOR_SEARCH_DIR}" STREQUAL "${CURRENT_SEARCH_DIR}" )
+            # when the search directory is empty, we'll give up
+            set(CURRENT_SEARCH_DIR "")
+        endif()
+    endwhile()
+
+    # If not found, set the output variable to empty before exiting
+    set(${OUTPUT_FOUND_WOLFSSH_DIRECTORY} "" PARENT_SCOPE)
+endfunction()
+
 # COMPONENT_NAME = wolfssh
 # The component name is the directory name. "No feature to change this".
 # See https://github.com/espressif/esp-idf/issues/8978#issuecomment-1129892685
 
-# set the root of WOLFSSH in top-level project CMakelists.txt:
+# set the root of wolfssh in top-level project CMakelists.txt:
 #   set(WOLFSSH_ROOT  "C:/some path/with/spaces")
-#   set(WOLFSSH_ROOT  "c:/workspace/WOLFSSH-[username]")
+#   set(WOLFSSH_ROOT  "c:/workspace/wolfssh-[username]")
 #   set(WOLFSSH_ROOT  "/mnt/c/some path/with/spaces")
 #   or use this logic to assign value from Environment Variable WOLFSSH_ROOT,
 #   or assume this is an example 7 subdirectories below:
 
-# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/WOLFSSH_test/components/WOLFSSH
-# The root of WOLFSSH is 7 directories up from here:
+# We are typically in [root]/IDE/Espressif/ESP-IDF/examples/wolfssh_test/components/wolfssh
+# The root of wolfssh is 7 directories up from here:
 
 if(CMAKE_BUILD_EARLY_EXPANSION)
-    message(STATUS "WOLFSSH component CMAKE_BUILD_EARLY_EXPANSION:")
+    message(STATUS "wolfssh component CMAKE_BUILD_EARLY_EXPANSION:")
     idf_component_register(
                             REQUIRES "${COMPONENT_REQUIRES}"
                             PRIV_REQUIRES
@@ -101,6 +315,7 @@ else()
     message(STATUS "************************************************************************************************")
     message(STATUS "wolfssh component config:")
     message(STATUS "************************************************************************************************")
+    FIND_WOLFSSH_DIRECTORY(WOLFSSH_ROOT)
 
     # Check to see if we're already in WOLFSSH, and only if WOLFSSH_ROOT not specified
     if ("${WOLFSSH_ROOT}" STREQUAL "")
@@ -233,86 +448,97 @@ else()
     message(STATUS "EXCLUDE_ASM = ${EXCLUDE_ASM}")
 
     #
-    # Check to see if there's both a local copy and EDP-IDF copy of the WOLFSSH and/or wolfssh components.
+    # Check to see if there's both a local copy and EDP-IDF copy of the wolfssh and/or wolfssh components.
     #
-    if( EXISTS "${WOLFSSH_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/WOLFSSH/" )
+    if( EXISTS "${WOLFSSH_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssh/" )
         #
-        # WOLFSSH found in both ESP-IDF and local project - needs to be resolved by user
+        # wolfssh found in both ESP-IDF and local project - needs to be resolved by user
         #
         message(STATUS "")
         message(STATUS "**************************************************************************************")
         message(STATUS "")
-        message(STATUS "Error: Found components/WOLFSSH in both local project and IDF_PATH")
+        message(STATUS "Error: Found components/wolfssh in both local project and IDF_PATH")
         message(STATUS "")
         message(STATUS "To proceed: ")
         message(STATUS "")
         message(STATUS "Remove either the local project component: ${WOLFSSH_PROJECT_DIR} ")
-        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/WOLFSSH/ ")
+        message(STATUS "or the Espressif shared component installed at: $ENV{IDF_PATH}/components/wolfssh/ ")
         message(STATUS "")
-        message(FATAL_ERROR "Please use WOLFSSH in either local project or Espressif components, but not both.")
+        message(FATAL_ERROR "Please use wolfssh in either local project or Espressif components, but not both.")
         message(STATUS "")
         message(STATUS "**************************************************************************************")
         message(STATUS "")
+
+        message(STATUS "Please use wolfSSL in either local project or Espressif components, but not both.")
 
         # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSH_MULTI_INSTALL_WARNING")
 
     else()
-        if( EXISTS "$ENV{IDF_PATH}/components/WOLFSSH/" )
+        if( EXISTS "$ENV{IDF_PATH}/components/wolfssh/" )
             #
-            # WOLFSSH found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
+            # wolfssh found in ESP-IDF components and is assumed to be already configured in user_settings.h via setup.
             #
             message(STATUS "")
-            message(STATUS "Using components/WOLFSSH in IDF_PATH = $ENV{IDF_PATH}")
+            message(STATUS "Using components/wolfssh in IDF_PATH = $ENV{IDF_PATH}")
             message(STATUS "")
         else()
             #
-            # WOLFSSH is not an ESP-IDF component.
-            # We need to now determine if it is local and if so if it is part of the WOLFSSH repo,
-            # or if  WOLFSSH is simply installed as a local component.
+            # wolfssh is not an ESP-IDF component.
+            # We need to now determine if it is local and if so if it is part of the wolfssh repo,
+            # or if  wolfssh is simply installed as a local component.
             #
 
             if( EXISTS "${WOLFSSH_PROJECT_DIR}" )
                 #
-                # WOLFSSH found in local project.
+                # wolfssh found in local project.
                 #
                 if( EXISTS "${WOLFSSH_PROJECT_DIR}/wolfcrypt/" )
                     message(STATUS "")
-                    message(STATUS "Using installed project ./components/WOLFSSH in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "Using installed project ./components/wolfssh in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
                     message(STATUS "")
                     #
-                    # Note we already checked above and confirmed there's not another WOLFSSH installed in the ESP-IDF components.
+                    # Note we already checked above and confirmed there's not another wolfssh installed in the ESP-IDF components.
                     #
                     # We won't do anything else here, as it will be assumed the original install completed successfully.
                     #
-                else() # full WOLFSSH not installed in local project
+                else() # full wolfssh not installed in local project
                     #
-                    # This is the developer repo mode. WOLFSSH will be assumed to be not installed to ESP-IDF nor local project
-                    # In this configuration, we are likely running a WOLFSSH example found directly in the repo.
+                    # This is the developer repo mode. wolfssh will be assumed to be not installed to ESP-IDF nor local project
+                    # In this configuration, we are likely running a wolfssh example found directly in the repo.
                     #
                     message(STATUS "")
-                    message(STATUS "Using developer repo ./components/WOLFSSH in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
+                    message(STATUS "Using developer repo ./components/wolfssh in CMAKE_HOME_DIRECTORY = ${CMAKE_HOME_DIRECTORY}")
                     message(STATUS "")
 
                     message(STATUS "************************************************************************************************")
-                    # When in developer mode, we are typically running WOLFSSH examples such as benchmark or test directories.
-                    # However, the as-cloned or distributed WOLFSSH does not have the ./include/ directory, so we'll add it as needed.
+                    # When in developer mode, we are typically running wolfssh examples such as benchmark or test directories.
+                    # However, the as-cloned or distributed wolfssh does not have the ./include/ directory, so we'll add it as needed.
                     #
                     # first check if there's a [root]/include/user_settings.h
                     if( EXISTS "${WOLFSSH_ROOT}/include/user_settings.h" )
-                        message(FATAL_ERROR "Found stray WOLFSSH user_settings.h in "
+                        message(FATAL_ERROR "Found stray wolfssh user_settings.h in "
                                             "${WOLFSSH_ROOT}/include/user_settings.h "
-                                            " (please move it to ${WOLFSSH_PROJECT_DIR}/include/user_settings.h )")
+                                            " (please move it to ${WOLFSSH_PROJECT_DIR}/components/wolfssl/include/user_settings.h )")
                     else()
                         # we won't overwrite an existing user settings file, just note that we already have one:
-                        if( EXISTS "${WOLFSSH_PROJECT_DIR}/include/user_settings.h" )
-                            message(STATUS "Using existing WOLFSSH user_settings.h in "
-                                           "${WOLFSSH_PROJECT_DIR}/include/user_settings.h")
+                        if( EXISTS "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}/user_settings.h" )
+                            message(STATUS "Using existing wolfssh user_settings.h in "
+                                           "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
                         else()
-                            message(STATUS "Installing WOLFSSH user_settings.h to "
-                                           "${WOLFSSH_PROJECT_DIR}/include/user_settings.h")
-                            # file(COPY "${WOLFSSH_ROOT}/IDE/Espressif/ESP-IDF/user_settings.h"
-                            # DESTINATION "${CMAKE_HOME_DIRECTORY}/WOLFSSH/include/")
+                            if(EXISTS "${LIB_USER_SETTINGS}" )
+                                message(STATUS "Installing wolfssh user_settings.h to "
+                                               "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
+                                file(COPY        "${LIB_USER_SETTINGS}"
+                                     DESTINATION "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
+                                if( EXISTS "${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}/user_settings.h" )
+                                    message(STATUS "Confirmed  wolfssl user_settings.h in ${THIS_PROJECT_WOLFSSH_USER_SETTINGS_PATH}")
+                                else()
+                                    message(ERROR "ERROR: Failed to copy wolfssl user_settings.h from ${LIB_USER_SETTINGS} to ${LIB_USER_SETTINGS}")
+                                endif()
+                            else()
+                                message(ERROR "wolfssl user_settings.h not in project, and not found in ${LIB_USER_SETTINGS}")
+                            endif()
                         endif()
                     endif() # user_settings.h
 
@@ -321,19 +547,19 @@ else()
                 endif()
 
             else()
-                # we did not find a ./components/WOLFSSH/include/ directory from this pass of cmake.
+                # we did not find a ./components/wolfssh/include/ directory from this pass of cmake.
                 if($WOLFSSH_FOUND_IDF)
                     message(STATUS "")
-                    message(STATUS "WARNING: WOLFSSH not found.")
+                    message(STATUS "WARNING: wolfssh not found.")
                     message(STATUS "")
                 else()
                     # probably needs to be re-parsed by Espressif
-                    message(STATUS "WOLFSSH found IDF. Project Source:${PROJECT_SOURCE_DIR}")
+                    message(STATUS "wolfssh found IDF. Project Source:${PROJECT_SOURCE_DIR}")
                 endif() # else we have not found ESP-IDF yet
-            endif() # else not a local WOLFSSH component
+            endif() # else not a local wolfssh component
 
         endif() #else not an ESP-IDF component
-    endif() # else not local copy and EDP-IDF WOLFSSH
+    endif() # else not local copy and EDP-IDF wolfssh
 
 
     # RTOS_IDF_PATH is typically:
@@ -422,17 +648,17 @@ else()
         message(STATUS "")
     endif()
 
-    # target_sources(WOLFSSH PRIVATE  "\"${WOLFSSH_ROOT}/WOLFSSH/\""  "\"${WOLFSSH_ROOT}/WOLFSSH/wolfcrypt\"")
+    # target_sources(wolfssh PRIVATE  "\"${WOLFSSH_ROOT}/wolfssh/\""  "\"${WOLFSSH_ROOT}/wolfssh/wolfcrypt\"")
 endif() # CMAKE_BUILD_EARLY_EXPANSION
 
 
 
-# check to see if there's both a local copy and EDP-IDF copy of the WOLFSSH components
-if( EXISTS "${WOLFSSH_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/WOLFSSH/" )
+# check to see if there's both a local copy and EDP-IDF copy of the wolfssh components
+if( EXISTS "${WOLFSSH_PROJECT_DIR}" AND EXISTS "$ENV{IDF_PATH}/components/wolfssh/" )
     message(STATUS "")
     message(STATUS "")
     message(STATUS "********************************************************************")
-    message(STATUS "WARNING: Found components/WOLFSSH in both local project and IDF_PATH")
+    message(STATUS "WARNING: Found components/wolfssh in both local project and IDF_PATH")
     message(STATUS "********************************************************************")
     message(STATUS "")
 endif()
@@ -502,6 +728,6 @@ if(NOT CMAKE_BUILD_EARLY_EXPANSION)
     LIBWOLFSSH_SAVE_INFO(LIBWOLFSSH_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
 
     message(STATUS "************************************************************************************************")
-    message(STATUS "WOLFSSH component config complete!")
+    message(STATUS "wolfssh component config complete!")
     message(STATUS "************************************************************************************************")
 endif()

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2014-2024 wolfSSL Inc.
+#  Copyright (C) 2014-2025 wolfSSL Inc.
 #
 #  This file is part of wolfSSH.
 #
@@ -18,17 +18,67 @@
 #
 # cmake for wolfssl Espressif projects
 #
-# Version 5.7.0 template update + THIS_IDF_PATH
+# Version 5.7.2 Espressif ESP-IDF integration
 #
 # See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html
 #
-
+message(STATUS "Begin wolfssl ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
 cmake_minimum_required(VERSION 3.16)
 
 set(VERBOSE_COMPONENT_MESSAGES 1)
 
+# Optional requires include:
+# set(THIS_ESP_TLS "esp-tls")
+set(THIS_ESP_TLS "")
+
+# function: IS_ESP_IDF_COMPONENT
+#  output:    RESULT = 1 (true) if this component is located in the ESP-IDF components
+#             otherwise 0 (false)
+function( IS_ESP_IDF_COMPONENT  RESULT )
+    # NOTE: Component location is based on the location of the CMakeList.txt
+    # and *not* the location of the wolfSSL source code. (which may be anywhere)
+
+    # Normalize the paths to remove any trailing slashes
+    get_filename_component(NORMALIZED_IDF_PATH  "${IDF_PATH}"      REALPATH)
+    get_filename_component(NORMALIZED_TEST_PATH "${COMPONENT_DIR}" REALPATH)
+
+    # Check if the test path starts with the IDF_PATH
+    string(FIND "${NORMALIZED_TEST_PATH}" "${NORMALIZED_IDF_PATH}" pos)
+
+    if(${pos} EQUAL 0)
+        message(STATUS "${COMPONENT_DIR} is within IDF_PATH.")
+        set(${RESULT} 1 PARENT_SCOPE)
+    else()
+        message(STATUS "${COMPONENT_DIR} is not within IDF_PATH.")
+        set(${RESULT} 0 PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Determine if this cmake file is located in the ESP-IDF component directory or not,
+# and if so, if it is being ignored (allowing the use of a local project one, instead).
+IS_ESP_IDF_COMPONENT( IS_WOLSSL_ESP_IDF_COMPONENT )
+if( IS_WOLSSL_ESP_IDF_COMPONENT )
+    message(STATUS "This wolfSSL is a component in ESP-IDF.")
+    if ( CONFIG_IGNORE_ESP_IDF_WOLFSSL_COMPONENT )
+        idf_component_register()
+        message(STATUS "Warning: wolfSSL component in ESP-IDF is being ignored.")
+        return()
+    endif()
+endif()
+
+
+if( "${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}" STREQUAL "" )
+    # nothing to do
+else()
+    # Only forward slashes, or double backslashes are supported.
+    # By the time we get here the sdkconfig file has a value for wolfSSL source code root.
+    string(REPLACE "\\" "/" CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT})
+    message(STATUS "Cleaned wolfssl path: ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
+endif()
+
 # The scope of this CMAKE_C_FLAGS is just this component:
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWOLFSSL_USER_SETTINGS")
 
 set(CMAKE_CURRENT_SOURCE_DIR ".")
 # set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
@@ -41,7 +91,7 @@ if ( "${WOLFSSL_ROOT}" STREQUAL "")
 endif()
 
 if(  "$ENV{IDF_PATH}" STREQUAL "" )
-     message(FATAL_ERROR "IDF_PATH Environment variable not set!")
+    message(FATAL_ERROR "IDF_PATH Environment variable not set!")
 else()
     string(REPLACE "\\" "/" THIS_IDF_PATH "$ENV{IDF_PATH}")
 endif()
@@ -51,28 +101,28 @@ if(VERBOSE_COMPONENT_MESSAGES)
     if(WIN32)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-        message("Detected Windows")
+        message(STATUS "Detected Windows")
     endif()
     if(CMAKE_HOST_UNIX)
-        message("Detected UNIX")
+        message(STATUS "Detected UNIX")
     endif()
     if(APPLE)
-        message("Detected APPLE")
+        message(STATUS "Detected APPLE")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-        message("Detected WSL")
+        message(STATUS "Detected WSL")
     endif()
     if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-        message("Detected Linux")
+        message(STATUS "Detected Linux")
     endif()
     if(APPLE)
         # Windows-specific configuration here
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-        message("Detected Apple")
+        message(STATUS "Detected Apple")
     endif()
 endif() # End optional WOLFSSL_CMAKE_SYSTEM_NAME
 
@@ -105,10 +155,11 @@ if( ("${CMAKE_PROJECT_NAME}" STREQUAL "wolfssl_benchmark") OR ("${CMAKE_PROJECT_
     message(STATUS "Not including lwip for ${CMAKE_PROJECT_NAME}")
 else()
     # benchmark and test do not need wifi, everything else probably does:
-    set(COMPONENT_REQUIRES lwip) # we typically don't need lwip directly in wolfssl component
+    set(COMPONENT_REQUIRES lwip "${THIS_ESP_TLS}") # we typically don't need lwip directly in wolfssl component
 endif()
 
-# find the user name to search for possible "wolfssl-username"
+# Find the user name to search for possible "wolfssl-username"
+# Reminder: Windows is  %USERNAME%, Linux is $USER
 message(STATUS "USERNAME = $ENV{USERNAME}")
 if(  "$ENV{USER}" STREQUAL "" ) # the bash user
     if(  "$ENV{USERNAME}" STREQUAL "" ) # the Windows user
@@ -123,6 +174,30 @@ else()
 endif()
 message(STATUS "THIS_USER = ${THIS_USER}")
 
+if( "$ENV{IDF_PATH}" STREQUAL "" )
+    message(FATAL_ERROR "IDF_PATH Environment variable not set!")
+else()
+    string(REPLACE "\\" "/" THIS_IDF_PATH "$ENV{IDF_PATH}")
+endif()
+
+# ENVIRONMENT_VAR_TO_MACRO
+# Check environment variable name EVARPARAM as [name]
+# If defined, and has a value of EVARVALUE as [value],
+# then assign a compiler definition "-D[name]=[value]"
+function(ENVIRONMENT_VAR_TO_MACRO EVARPARAM EVARVALUE)
+    # If the EVARPARAM environment variable name is set to EVARVALUE,
+    # set the compiler flag definition to enable CSV output.
+    if ( "$ENV{${EVARPARAM}}" STREQUAL "${EVARVALUE}")
+        message(STATUS "Appending compile definition: -D${EVARPARAM}=${EVARVALUE}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D${EVARPARAM}=${EVARVALUE}")
+    else()
+        if(DEFINED ENV{${EVARPARAM}})
+            message(STATUS "Environment variable ${EVARPARAM} detected but set to $ENV{${EVARPARAM}}, not appending compile definition.")
+        else()
+            message(STATUS "Environment variable ${EVARPARAM} not detected, not appending compile definition.")
+        endif()
+    endif()
+endfunction()
 
 # COMPONENT_NAME = wolfssl
 # The component name is the directory name. "No feature to change this".
@@ -141,7 +216,8 @@ message(STATUS "THIS_USER = ${THIS_USER}")
 # function: IS_WOLFSSL_SOURCE
 #  parameter: DIRECTORY_PARAMETER - the directory to test
 #  output:    RESULT = contains contents of DIRECTORY_PARAMETER for wolfssl directory, otherwise blank.
-function(IS_WOLFSSL_SOURCE DIRECTORY_PARAMETER RESULT)
+function( IS_WOLFSSL_SOURCE  DIRECTORY_PARAMETER
+          RESULT )
     if (EXISTS "${DIRECTORY_PARAMETER}/wolfcrypt/src")
         set(${RESULT} "${DIRECTORY_PARAMETER}" PARENT_SCOPE)
     else()
@@ -160,26 +236,56 @@ function(FIND_WOLFSSL_DIRECTORY OUTPUT_FOUND_WOLFSSL_DIRECTORY)
     message(STATUS "Starting FIND_WOLFSSL_DIRECTORY: ${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
 
     if ( "${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}" STREQUAL "" )
+        # The parameter is empty, so we certainly need to search.
+        # First, see if there's an environment variable. This takes highest priority (unless already found as hard-coded, above)
         set(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}")
         if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
             message(STATUS "The WOLFSSL_ROOT environment variable is not set. Searching...")
-        else()
-            get_filename_component(CURRENT_SEARCH_DIR "$ENV{WOLFSSL_ROOT}" ABSOLUTE)
-            IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
-            if( FOUND_WOLFSSL )
-                message(STATUS "Found WOLFSSL_ROOT via Environment Variable:")
+            # Next, if not found, see if wolfSSL was selected for ESP-TLS Kconfig
+            if(CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT)
+                set(CURRENT_SEARCH_DIR ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT})
+                get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" ABSOLUTE)
+                message(STATUS "WOLFSSL_ROOT found in sdkconfig/KConfig: ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
             else()
-                message(FATAL_ERROR "WOLFSSL_ROOT Environment Variable defined, but path not found:")
-                message(STATUS "$ENV{WOLFSSL_ROOT}")
-            endif()
-        endif()
+                message(STATUS "wolfSSL not defined in [Component Config] [wolfssl]. Continuing search...")
+                # If not specified as a search hint in OUTPUT_FOUND_WOLFSSL_DIRECTORY:
+                # This wolfSSL component CMakeLists.txt may be found EITHER in:
+                #   1) local project component
+                #   2) ESP-IDF share components
+                # We'll start in the CMAKE_CURRENT_SOURCE_DIR, typically [something]/projectname/components/wolfssl
+                # That option might find wolfSSL source code as a copy in the component directory (e.g. Managed Components)
+                # Unless cmake is in the ESP-IDF, in which case it is unlikely to find wolfSSL source in any parent.
+                message(STATUS "CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+                get_filename_component(CURRENT_SEARCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+                message(STATUS "CURRENT_SEARCH_DIR = ${CURRENT_SEARCH_DIR}")
+                string(LENGTH ${CURRENT_SEARCH_DIR} CURRENT_SEARCH_DIR_LENGTH)
+            endif() # CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT
+        endif() # check environment var blank
     else()
-        get_filename_component(CURRENT_SEARCH_DIR "${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}" ABSOLUTE)
+        message(STATUS "Parameter found for FIND_WOLFSSL_DIRECTORY")
+        message(STATUS "Setting wolfSSL search directory to: ${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+        set(CURRENT_SEARCH_DIR "${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+    endif() # parameter empty
+
+    # Check to see if we found a path in environment or config settings, above.
+    if( "${CURRENT_SEARCH_DIR}" STREQUAL "" )
+        message(STATUS "Source for wolfSSL not specified in path nor config settings.")
+        # We'll continue the search by recursing up the directory tree, below.
+    else()
+        # Setting found! Does it contain a valid path?
+        string(REPLACE "\\" "/" CURRENT_SEARCH_DIR ${CURRENT_SEARCH_DIR})
+        get_filename_component(CURRENT_SEARCH_DIR "${CURRENT_SEARCH_DIR}" ABSOLUTE)
         IS_WOLFSSL_SOURCE("${CURRENT_SEARCH_DIR}" FOUND_WOLFSSL)
         if( FOUND_WOLFSSL )
-            message(STATUS "Found WOLFSSL_ROOT via prior specification.")
+            message(STATUS "Found wolfSSL source code via setting: ${CURRENT_SEARCH_DIR}")
+            set(${OUTPUT_FOUND_WOLFSSL_DIRECTORY} ${CURRENT_SEARCH_DIR} PARENT_SCOPE)
+            return()
         else()
-            message(FATAL_ERROR "WOLFSSL_ROOT Variable defined, but path not found: ${${OUTPUT_FOUND_WOLFSSL_DIRECTORY}}")
+            if(WIN32)
+                message(STATUS "When specifying a path for Windows, use forward slahes, or double backslashes.")
+            endif()
+            message(STATUS "CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT sdkconfig setting = ${CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT}")
+            message(STATUS "WOLFSSL_ROOT Variable defined, but source code not found: ${CURRENT_SEARCH_DIR}")
         endif()
     endif()
 
@@ -280,6 +386,11 @@ endfunction()
 
 message(STATUS "CONFIG_TARGET_PLATFORM = ${CONFIG_TARGET_PLATFORM}")
 
+# Check for environment variable that may be assigned to macros
+ENVIRONMENT_VAR_TO_MACRO("GENERATE_MACHINE_PARSEABLE_REPORT" "1")
+ENVIRONMENT_VAR_TO_MACRO("WOLFSSL_BENCHMARK_FIXED_CSV"       "1")
+
+# Optional variable inspection
 if (0)
     get_cmake_property(_variableNames VARIABLES)
     list (SORT _variableNames)
@@ -296,15 +407,25 @@ endif()
 
 if ( ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266") OR ("${IDF_TARGET}" STREQUAL "esp8266") )
     # There's no esp_timer, no driver components for the ESP8266
-    message(STATUS "Early expansion EXCLUDES esp_timer: ${THIS_INCLUDE_TIMER}")
-    message(STATUS "Early expansion EXCLUDES driver: ${THIS_INCLUDE_DRIVER}")
-    set(THIS_INCLUDE_TIMER "")
-    set(THIS_INCLUDE_DRIVER "")
+    message(STATUS "Early expansion EXCLUDES for esp8266:")
+    message(STATUS "THIS_INCLUDE_DRIVER:  '${THIS_INCLUDE_DRIVER}'")
+    message(STATUS "THIS_INCLUDE_TIMER:   '${THIS_INCLUDE_TIMER}'")
+    message(STATUS "Early expansion INCLUDE for esp8266:")
+    message(STATUS "THIS_INCLUDE_PTHREAD: '${THIS_INCLUDE_PTHREAD}'")
+    set(THIS_ESP_TLS         "")
+    set(THIS_INCLUDE_DRIVER  "")
+    set(THIS_INCLUDE_TIMER   "")
+    set(THIS_INCLUDE_PTHREAD "pthread")
 else()
     message(STATUS "Early expansion includes esp_timer: ${THIS_INCLUDE_TIMER}")
     message(STATUS "Early expansion includes driver: ${THIS_INCLUDE_DRIVER}")
-    set(THIS_INCLUDE_TIMER "esp_timer")
+    set(THIS_ESP_TLS        "esp-tls")
     set(THIS_INCLUDE_DRIVER "driver")
+    set(THIS_INCLUDE_TIMER  "esp_timer")
+    set(THIS_INCLUDE_PTHREAD "")
+    # Let the app know that we've included the esp-tls component requirement.
+    # This is critical for use the the esp-tls component. See wolfssl esp_crt_bundle.c file.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_REQUIRED_ESP_TLS=1")
 endif()
 
 if(CMAKE_BUILD_EARLY_EXPANSION)
@@ -312,8 +433,10 @@ if(CMAKE_BUILD_EARLY_EXPANSION)
     idf_component_register(
                             REQUIRES "${COMPONENT_REQUIRES}"
                             PRIV_REQUIRES # esp_hw_support
-                                          ${THIS_INCLUDE_TIMER}
-                                          ${THIS_INCLUDE_DRIVER} # this will typically only be needed for wolfSSL benchmark
+                                          "${THIS_ESP_TLS}"
+                                          "${THIS_INCLUDE_PTHREAD}"
+                                          "${THIS_INCLUDE_TIMER}"
+                                          "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
                            )
 
 else()
@@ -321,6 +444,15 @@ else()
     message(STATUS "************************************************************************************************")
     message(STATUS "wolfssl component config:")
     message(STATUS "************************************************************************************************")
+
+    if ( "${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266")
+        # There's no esp_timer, no driver components for the ESP8266
+        set(THIS_INCLUDE_TIMER "")
+        set(THIS_INCLUDE_DRIVER "")
+    else()
+        set(THIS_INCLUDE_TIMER "esp_timer")
+        set(THIS_INCLUDE_DRIVER "driver")
+    endif()
 
     # search for wolfSSL
     FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
@@ -335,7 +467,9 @@ else()
             # Abort CMake after fatal error.
         endif()
     else()
-        message(STATUS "Searching for wolfSL source code...")
+        message(STATUS "Source code for wolfSSL still not found.")
+        message(STATUS "Searching from project home: ${CMAKE_HOME_DIRECTORY} ...")
+        set(WOLFSSL_ROOT "${CMAKE_HOME_DIRECTORY}")
         FIND_WOLFSSL_DIRECTORY(WOLFSSL_ROOT)
     endif()
 
@@ -343,11 +477,18 @@ else()
     if(WOLFSSL_ROOT)
         message(STATUS "Confirmed wolfssl directory at: ${WOLFSSL_ROOT}")
     else()
-        message(STATUS "Failed: wolfssl directory not found.")
+        # Try to allow a more intuitive error that the source code was not found in cmake:
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_WARNING_SOURCE_NOT_FOUND")
+
+        message(STATUS "Failed: wolfssl source code directory not found.")
         # Abort. We need wolfssl _somewhere_.
-        message(FATAL_ERROR "Could not find wolfssl in any parent directory named wolfssl-${THIS_USER}, wolfssl-master, or wolfssl.\n"
-                            "Try setting WOLFSSL_ROOT environment variable, cmake variable in project, copy source, or use managed components.")
-        # Abort CMake after fatal error.
+        message(STATUS "")
+        message(STATUS "")
+        message(STATUS "Could not find wolfssl in any parent directory named wolfssl-${THIS_USER}, wolfssl-master, or wolfssl.\n"
+                       "Try setting WOLFSSL_ROOT environment variable, cmake variable in project, copy source, or use managed components.")
+        message(STATUS "")
+        message(STATUS "")
+        # Abort CMake after fatal error. (or not?)
     endif()
 
     set(INCLUDE_PATH ${WOLFSSL_ROOT})
@@ -373,22 +514,24 @@ else()
         endif()
     endif()
 
+    message(STATUS "WOLFSSL_EXTRA_PROJECT_DIR = ${WOLFSSL_EXTRA_PROJECT_DIR}")
     set(COMPONENT_SRCDIRS "\"${WOLFSSL_ROOT}/src/\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif\""
+                          "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/esp_crt_bundle\""
                           "\"${WOLFSSL_ROOT}/wolfcrypt/src/port/atmel\""
                           "\"${WOLFSSL_EXTRA_PROJECT_DIR}\""
                          ) # COMPONENT_SRCDIRS
 
     message(STATUS "This COMPONENT_SRCDIRS = ${COMPONENT_SRCDIRS}")
 
-    # wolfSSL user_settings.h is in the local project.
+    # wolfSSL user_settings.h may be in the local project.
+    # TODO check if exists and possibly set to ESP-IDF
     set(WOLFSSL_PROJECT_DIR "${CMAKE_HOME_DIRECTORY}/components/wolfssl")
-    # add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${WOLFSSL_PROJECT_DIR}/include/user_settings.h")
 
     string(REPLACE "/" "//" STR_WOLFSSL_PROJECT_DIR "${WOLFSSL_PROJECT_DIR}")
-    add_definitions(-DWOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h")
-
+    add_compile_definitions(WOLFSSL_USER_SETTINGS_DIR="${STR_WOLFSSL_PROJECT_DIR}/include/user_settings.h")
+    message(STATUS "Added definition for user_settings.h: -DWOLFSSL_USER_SETTINGS_DIR=\"${STR_WOLFSSL_PROJECT_DIR}//include//user_settings.h\"")
     # Espressif may take several passes through this makefile. Check to see if we found IDF
     string(COMPARE EQUAL "${PROJECT_SOURCE_DIR}" "" WOLFSSL_FOUND_IDF)
 
@@ -421,8 +564,7 @@ else()
         message(STATUS "**************************************************************************************")
         message(STATUS "")
 
-        message(FATAL_ERROR "Please use wolfSSL in either local project or Espressif components, but not both.")
-        # Abort CMake after fatal error.
+        message(STATUS "Please use wolfSSL in either local project or Espressif components, but not both.")
 
         # Optional: if you change the above FATAL_ERROR to STATUS you can warn at runtime with this macro definition:
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_MULTI_INSTALL_WARNING")
@@ -530,7 +672,9 @@ else()
     # depending on the environment, we may need to swap backslashes with forward slashes
     string(REPLACE "\\" "/" RTOS_IDF_PATH "$ENV{IDF_PATH}/components/freertos/FreeRTOS-Kernel/include/freertos")
 
-    string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+    if(WOLFSSL_ROOT)
+        string(REPLACE "\\" "/" WOLFSSL_ROOT ${WOLFSSL_ROOT})
+    endif()
 
     if(IS_DIRECTORY "${RTOS_IDF_PATH}")
         message(STATUS "Found current RTOS path: ${RTOS_IDF_PATH}")
@@ -546,12 +690,16 @@ else()
     message(STATUS "THIS_IDF_PATH = $THIS_IDF_PATH")
     # wolfSSL-specific include directories
     set(COMPONENT_ADD_INCLUDEDIRS
-        "./include" # this is the location of wolfssl user_settings.h
+        "./include" # this is the location of local project wolfssl user_settings.h
         "\"${WOLFSSL_ROOT}/\""
         "\"${WOLFSSL_ROOT}/wolfssl/\""
         "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/\""
         "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/port/Espressif\""
         "\"${RTOS_IDF_PATH}/\""
+        # wolfSSL release after v5.7 includes WiFi, time, and mem/debug helpers
+        "${THIS_IDF_PATH}/components/esp_event/include"
+        "${THIS_IDF_PATH}/components/esp_netif/include"
+        "${THIS_IDF_PATH}/components/esp_wifi/include"
         )
 
     # Optionally include cryptoauthlib if present
@@ -579,8 +727,8 @@ else()
         "\"${WOLFSSL_ROOT}/src/ssl_sess.c\""    # included by ssl.c
         "\"${WOLFSSL_ROOT}/src/x509.c\""
         "\"${WOLFSSL_ROOT}/src/x509_str.c\""
-        "\"${WOLFSSL_ROOT}/wolfcrypt/src/ext_kyber.c\""     # external Kyber disabled by default
-        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/ext_kyber.h\"" # external Kyber disabled by default
+        "\"${WOLFSSL_ROOT}/wolfcrypt/src/ext_kyber.c\""     # external non-wolfssl Kyber disabled by default
+        "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt/ext_kyber.h\"" # external non-wolfssl Kyber disabled by default
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/evp.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/misc.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_arm32.c\""
@@ -591,6 +739,7 @@ else()
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_cortexm.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_x86_64.c\""
         "\"${WOLFSSL_ROOT}/wolfcrypt/src/sp_sm2_x86_64_asm.S\""
+        "\"${WOLFSSL_ROOT}/examples\"" # Examples are distributed in Managed Components, but not part of a project.
         "\"${EXCLUDE_ASM}\""
         )
 
@@ -612,15 +761,120 @@ else()
     # see https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/build-system.html?highlight=space%20path
     #
     set(EXTRA_COMPONENT_DIRS "${COMPONENT_SRCDIRS}")
-    idf_component_register(
-                            SRC_DIRS "${COMPONENT_SRCDIRS}"
-                            INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
-                            REQUIRES "${COMPONENT_REQUIRES}"
-                            EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
-                            PRIV_REQUIRES
-                              "${THIS_INCLUDE_TIMER}"
-                              "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
-                           )
+
+    if(WOLFSSL_ROOT)
+        # Only register the component if we found wolfSSL source.
+        # This is important to allow Cmake to finish to completion, otherwise the UI
+        # may not be able to display the Kconfig settings to fix a bad or missing source.
+        idf_component_register(
+                                SRC_DIRS "${COMPONENT_SRCDIRS}"
+                                INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
+                                REQUIRES "${COMPONENT_REQUIRES}"
+                                EXCLUDE_SRCS "${COMPONENT_SRCEXCLUDE}"
+                                PRIV_REQUIRES
+                                  "${THIS_ESP_TLS}"
+                                  "${THIS_INCLUDE_TIMER}"
+                                  "${THIS_INCLUDE_DRIVER}" # this will typically only be needed for wolfSSL benchmark
+                               )
+    else()
+        # Register the component simply to allow CMake to complete, but there's no wolfSSL source.
+        # Expect many other errors, but the project should at least be loadable and UI can edit Kconfig settings.
+        idf_component_register()
+        message(STATUS "Warning: wolfSSL component not registered as no source code found (WOLFSSL_ROOT is blank)")
+    endif()
+
+# function(WOLFSSL_INIT_CERT_BUNDLE)
+if( CONFIG_WOLFSSL_CERTIFICATE_BUNDLE
+    AND NOT CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+    AND NOT ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266")
+  )
+    if (CMAKE_BUILD_EARLY_EXPANSION)
+        message(ERROR "Bundle Cert initialization must occur during CMAKE_BUILD_EARLY_EXPANSION")
+    endif()
+    # reminder: we need a value for wolfSSL root first!
+    if( "${WOLFSSL_ROOT}" STREQUAL "" )
+        message(ERROR "Certificate bundles need a value for WOLFSSL_ROOT")
+    endif()
+    set(WOLFSSL_ESP_CRT_BUNDLE_DIR ${WOLFSSL_ROOT}/wolfcrypt/src/port/Espressif/esp_crt_bundle)
+    message(STATUS "WOLFSSL_ESP_CRT_BUNDLE_DIR=${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+    if(EXISTS "${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+        set(bundle_name "x509_crt_bundle_wolfssl")
+
+        # For now the certs are in the same directory
+        set(DEFAULT_CRT_DIR "${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+
+        # Generate custom certificate bundle using the generate_cert_bundle utility
+        set(GENERATE_CERT_BUNDLEPY ${python} ${WOLFSSL_ESP_CRT_BUNDLE_DIR}/gen_crt_bundle.py)
+
+        if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_all.pem ${DEFAULT_CRT_DIR}/cacrt_local.pem)
+        elseif(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_CMN)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_all.pem ${DEFAULT_CRT_DIR}/cacrt_local.pem)
+            list(APPEND args --filter ${DEFAULT_CRT_DIR}/cmn_crt_authorities.csv)
+        endif()
+
+        # Add deprecated root certs if enabled. This config is not visible if the default cert
+        # bundle is not selected
+        if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE_DEPRECATED_LIST)
+            list(APPEND crt_paths ${DEFAULT_CRT_DIR}/cacrt_deprecated.pem)
+        endif()
+
+        if(CONFIG_WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE)
+            get_filename_component(custom_bundle_path
+              ${CONFIG_WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE_PATH} ABSOLUTE BASE_DIR "${project_dir}")
+            list(APPEND crt_paths ${custom_bundle_path})
+            message(STATUS "Using a custom wolfSSL bundle path: ${custom_bundle_path}")
+        else()
+            message(STATUS "Not using a custom wolfSSL bundle path.")
+        endif()
+        list(APPEND args --input ${crt_paths} -q)
+
+        message(STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
+        get_filename_component(crt_bundle
+            ${bundle_name}
+            ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+        message(STATUS "Setting up bundle generate: ${GENERATE_CERT_BUNDLEPY} ${args}")
+        message(STATUS "Depends on custom bundle path: ${custom_bundle_path}")
+        message(STATUS "crt_bundle ${crt_bundle}")
+        message(STATUS "COMPONENT_LIB ${COMPONENT_LIB}")
+        message(STATUS "GENERATE_CERT_BUNDLEPY ${GENERATE_CERT_BUNDLEPY}")
+        message(STATUS "args ${args}")
+        message(STATUS "cert_bundle ${cert_bundle}")
+
+        # Generate bundle according to config
+        # File is generated at build time, not cmake load
+        add_custom_command(OUTPUT ${crt_bundle}
+            COMMAND ${GENERATE_CERT_BUNDLEPY} ARGS ${args}
+            DEPENDS ${custom_bundle_path}
+            VERBATIM)
+
+        if(EXISTS "${crt_bundle}")
+            message(STATUS "Bundle file exists from prior build: ${crt_bundle}")
+        else()
+            message(STATUS "Bundle file expected during next build: ${crt_bundle}")
+        endif()
+
+        # Reminder the file is generated at build time, not cmake load time.
+        message(STATUS "wolfSSL Cert Bundle File to be created at build time in: ${crt_bundle}")
+
+        add_custom_target(custom_wolfssl_bundle DEPENDS ${cert_bundle})
+
+        # the wolfSSL crtificate bundle is baked into wolfSSL
+        add_dependencies(${COMPONENT_LIB} custom_wolfssl_bundle)
+
+        # COMPONENT_LIB may vary: __idf_wolfssl, __idf_esp_wolfssl, etc
+        # target_add_binary_data(__idf_wolfssl ${crt_bundle} BINARY)
+        target_add_binary_data(${COMPONENT_LIB} ${crt_bundle} BINARY)
+        set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+                     APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+                     "${crt_bundle}")
+    else()
+        message(STATUS "WARNING: CONFIG_WOLFSSL_CERTIFICATE_BUNDLE enabled but directory not found: ${WOLFSSL_ESP_CRT_BUNDLE_DIR}")
+    endif()
+endif()
+
+# endfunction() # WOLFSSL_INIT_CERT_BUNDLE
 
     # Some optional diagnostics. Verbose ones are truncated.
     if (VERBOSE_COMPONENT_MESSAGES)
@@ -652,6 +906,12 @@ else()
     endif()
 
     # target_sources(wolfssl PRIVATE  "\"${WOLFSSL_ROOT}/wolfssl/\""  "\"${WOLFSSL_ROOT}/wolfssl/wolfcrypt\"")
+    message(STATUS "DETECTED_PROJECT_NAME=${CMAKE_PROJECT_NAME}")
+    message(STATUS "COMPONENT_TARGET=${COMPONENT_TARGET}")
+    target_compile_definitions(${COMPONENT_TARGET} PRIVATE DETECTED_PROJECT_NAME="${CMAKE_PROJECT_NAME}")
+    if( "${CMAKE_PROJECT_NAME}" STREQUAL "esp_http_client_example" )
+        target_compile_definitions(${COMPONENT_TARGET} PRIVATE APP_ESP_HTTP_CLIENT_EXAMPLE="y")
+    endif()
 
 endif() # CMAKE_BUILD_EARLY_EXPANSION
 
@@ -697,7 +957,7 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
         message(STATUS "Found ${VAR_OUPUT}=${VAR_VALUE}")
 
         # the interesting part is defining the VAR_OUPUT name a value to use in the app
-        add_definitions(-D${VAR_OUPUT}=\"${VAR_VALUE}\")
+        add_compile_definitions(${VAR_OUPUT}=\"${VAR_VALUE}\")
     else()
         # if we get here, check the execute_process command and parameters.
         message(STATUS "LIBWOLFSSL_SAVE_INFO encountered a non-zero VAR_RESULT")
@@ -705,35 +965,89 @@ function ( LIBWOLFSSL_SAVE_INFO VAR_OUPUT THIS_VAR VAR_RESULT )
     endif()
 endfunction() # LIBWOLFSSL_SAVE_INFO
 
+execute_process(
+    COMMAND ${git_cmd} "rev-parse" "--is-inside-work-tree"
+    OUTPUT_VARIABLE IS_GIT_REPO
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
 # create some programmatic #define values that will be used by ShowExtendedSystemInfo().
 # see wolfcrypt\src\port\Espressif\esp32_utl.c
-if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+if(NOT CMAKE_BUILD_EARLY_EXPANSION AND WOLFSSL_ROOT AND (IS_GIT_REPO STREQUAL "true"))
     set (git_cmd "git")
     message(STATUS "Adding macro definitions:")
 
     # LIBWOLFSSL_VERSION_GIT_ORIGIN: git config --get remote.origin.url
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "config" "--get" "remote.origin.url"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_ORIGIN "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_BRANCH: git rev-parse --abbrev-ref HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--abbrev-ref" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_BRANCH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_HASH: git rev-parse HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_SHORT_HASH: git rev-parse --short HEAD
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "rev-parse" "--short" "HEAD"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES ERROR_QUIET )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_SHORT_HASH "${TMP_OUT}" "${TMP_RES}")
 
     # LIBWOLFSSL_VERSION_GIT_HASH_DATE git show --no-patch --no-notes --pretty=\'\%cd\'
-    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd} "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'" OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
+    execute_process(WORKING_DIRECTORY ${WOLFSSL_ROOT} COMMAND ${git_cmd}
+                    "show" "--no-patch" "--no-notes" "--pretty=\'\%cd\'"
+                    OUTPUT_VARIABLE TMP_OUT RESULT_VARIABLE TMP_RES  )
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_GIT_HASH_DATE "${TMP_OUT}" "${TMP_RES}")
 
     LIBWOLFSSL_SAVE_INFO(LIBWOLFSSL_VERSION_WOLFSSL_ROOT "${WOLFSSL_ROOT}" "${TMP_RES}")
 
-    message(STATUS "************************************************************************************************")
-    message(STATUS "wolfssl component config complete!")
-    message(STATUS "************************************************************************************************")
 endif()
+
+# Ensure flag "-DWOLFSSL_ESPIDF" is already in CMAKE_C_FLAGS if not yet found from project
+string(FIND "${CMAKE_C_FLAGS}" "-DWOLFSSL_ESPIDF" FLAG_ALRREADY_FOUND_WOLFSSL_ESPIDF)
+
+if(FLAG_ALRREADY_FOUND_WOLFSSL_ESPIDF EQUAL -1)
+    # Flag not found, append it
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_ESPIDF")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_USER_SETTINGS")
+endif()
+
+if(WOLFSSL_ROOT)
+    message(STATUS "Using wolfSSL in ${WOLFSSL_ROOT}")
+
+    # PlatformIO does not process script from from the Espressif cmake process.
+    # We need to know where wolfSSL source code was found, so save it in the
+    # PIO_WOLFSSL_ROOT environment variable to later be read by extra_script.py
+
+    set(ENV{PIO_WOLFSSL_ROOT} "${WOLFSSL_ROOT}")
+    message(STATUS "PIO_WOLFSSL_ROOT =  $ENV{PIO_WOLFSSL_ROOT}")
+    message(STATUS "PLATFORMIO_BUILD_DIR = $ENV{PLATFORMIO_BUILD_DIR}")
+    # See esp-tls Kconfig; menu "ESP-TLS", ESP_TLS_LIBRARY_CHOOSE
+    if(CONFIG_ESP_TLS_USING_WOLFSSL)
+        if ( ("${CONFIG_TARGET_PLATFORM}" STREQUAL "esp8266") OR ("${IDF_TARGET}" STREQUAL "esp8266") )
+            message(STATUS "This version of wolfSSL is not supported on the ESP8266 esp-tls at this time. Check ESP-TLS config")
+        else()
+            message(STATUS "wolfSSL will be used for ESP-TLS")
+        endif()
+    else()
+        message(STATUS "WARNING: wolfSSL NOT selected for ESP-TLS. Features and performance will be limited.")
+    endif()
+else()
+    message(STATUS "")
+    message(STATUS "Consider setting WOLFSSL_ROOT environment variable, use Kconfig setting, or set manually in this cmake file, above.")
+    message(STATUS "")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "ERROR: Could not find wolfSSL Source Code")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+    message(STATUS "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+endif()
+
+message(STATUS "************************************************************************************************")
+message(STATUS "wolfSSL component config complete!")
+message(STATUS "************************************************************************************************")

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/Kconfig
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/Kconfig
@@ -1,0 +1,522 @@
+# Kconfig template
+#
+#  Copyright (C) 2014-2025 wolfSSL Inc.
+#
+#  This file is part of wolfSSH.
+#
+#  wolfSSH is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  wolfSSH is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Kconfig File Version 5.7.2.001 for esp-idf integration
+
+# Kconfig Format Rules
+#
+# See:
+#  https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/kconfig.html
+#
+# Format rules for Kconfig files are as follows:
+#
+# Option names in any menus should have consistent prefixes. The prefix
+# currently should have at least 3 characters.
+#
+# The unit of indentation should be 4 spaces. All sub-items belonging to a
+# parent item are indented by one level deeper. For example, menu is indented
+# by 0 spaces, config menu by 4 spaces, help in config by 8 spaces, and the
+# text under help by 12 spaces.
+#
+# No trailing spaces are allowed at the end of the lines.
+#
+# The maximum length of options is NOT 50 characters as documented.
+#   kconfcheck will complain that options should be 40 at most.
+#
+# Fix option lengths first. Superfluous errors on other lines may occur.
+#
+# The maximum length of lines is 120 characters.
+#
+# python -m kconfcheck <path_to_kconfig_file>
+#
+# ---------------------------------------------------------------------------------------------------------------------
+# Begin main wolfSSL configuration menu
+# ---------------------------------------------------------------------------------------------------------------------
+#   See ESP-IDF esp-tls component for config TLS_STACK_WOLFSSL
+
+menu "wolfSSL"
+
+    menu "Hardening"
+        config ESP_WOLFSSL_WC_NO_HARDEN
+            bool "Disable wolfSSL hardening"
+            default n
+            help
+                Sets WC_NO_HARDEN
+
+        config ESP_WOLFSSL_TFM_TIMING_RESISTANT
+            bool "Enable TFM Timing Resistant Code"
+            default n
+            help
+                Sets TFM_TIMING_RESISTANT.
+
+    endmenu # Hardening
+
+    config ESP_WOLFSSL_ENABLE_BENCHMARK
+        bool "Enable wolfSSL Benchmark Library"
+        default n
+        help
+            Enables wolfcrypt/benchmark/benchmark.c code for benchmark metrics. Disables NO_CRYPT_BENCHMARK.
+
+
+    menu "Benchmark Debug"
+        config ESP_DEBUG_WOLFSSL_BENCHMARK_TIMING
+            bool "Enable benchmark timing debug"
+            depends on ESP_WOLFSSL_ENABLE_BENCHMARK
+            default n
+            help
+                Enable wolfssl debug for benchmark metric timing (CPU Cycles, RTOS ticks, etc).
+
+        config ESP_WOLFSSL_BENCHMARK_TIMER_DEBUG
+            bool "Enable benchmark timer debug"
+            depends on ESP_WOLFSSL_ENABLE_BENCHMARK
+            default n
+            help
+                Turn on timer debugging (used when CPU cycles not available)
+
+    endmenu # Benchmark Debug
+
+    # -----------------------------------------------------------------------------------------------------------------
+    # wolfCrypt Test
+    # -----------------------------------------------------------------------------------------------------------------
+    config ESP_WOLFSSL_ENABLE_TEST
+        bool "Enable wolfCrypt Test Library"
+        default n
+        help
+            Enables wolfcrypt/test/test.c code for testing. Disables NO_CRYPT_TEST.
+
+    menu "wolfCrypt tests"
+        config WOLFSSL_HAVE_WOLFCRYPT_TEST_OPTIONS
+            bool "Enable wolfCrypt Test Options"
+            depends on ESP_WOLFSSL_ENABLE_TEST
+            default n
+            help
+                Enables HAVE_WOLFCRYPT_TEST_OPTIONS
+
+        config TEST_ESPIDF_ALL_WOLFSSL
+            bool "Enable all features to use in tests"
+            depends on ESP_WOLFSSL_ENABLE_TEST
+            default n
+            help
+                Enables TEST_ESPIDF_ALL_WOLFSSL
+
+    endmenu # wolfCrypt tests
+
+    # -----------------------------------------------------------------------------------------------------------------
+    # Apple HomeKit Options
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Apple HomeKit"
+        config WOLFSSL_APPLE_HOMEKIT
+            bool "Enable Apple HomeKit options"
+            default n
+            help
+                Enables FP_MAX_BITS (8192 * 2), SRP, ChaCha, Poly1305, Base64 encoding needed for Apple HomeKit.
+    endmenu # Apple HomeKit
+    # -----------------------------------------------------------------------------------------------------------------
+
+    config ESP_WOLFSSL_DISABLE_MY_ECC
+        bool "Disable ECC in my project"
+        default "n"
+        help
+            ECC is enabled by default. Select this option to disable.
+
+    config ESP_WOLFSSL_ENABLE_MY_USE_RSA
+        bool "Enable RSA in my project"
+        default "n"
+        help
+            RSA is disabled by default. Select this option to enable.
+
+    config ESP_WOLFSSL_BENCHMARK
+        bool "Enable wolfSSL Benchmark"
+        default n
+        help
+            Enables user settings relevant to benchmark code
+
+    config ESP_TLS_USING_WOLFSSL_SPECIFIED
+        bool "Use the specified wolfssl for ESP-TLS"
+        default Y
+        help
+            Includes wolfSSL from specified directory (not using esp-wolfssl).
+
+    config ESP_WOLFSSL_NO_USE_FAST_MATH
+        bool "Disable FAST_MATH library and all ESP32 Hardware Acceleration"
+        select ESP_WOLFSSL_NO_HW
+        select ESP_WOLFSSL_NO_HW_AES
+        select ESP_WOLFSSL_NO_HW_HASH
+        select ESP_WOLFSSL_NO_HW_RSA_PRI
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+        select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+        default n
+        help
+            When disabling all hardware acceleration for smaller memory footprint,
+            disabling TFM fast math provides faster wolfSSL software algorithms in an
+            even smaller flash memory footprint.
+
+    menu "Protocol Config"
+        config WOLFSSL_HAVE_ALPN
+            bool "Enable ALPN (Application Layer Protocol Negotiation) in wolfSSL"
+            default y
+
+        config WOLFSSL_ALLOW_TLS13
+            bool "Allow TLS 1.3"
+            default y
+            help
+                Allow TLS to fallback to TLS1.2. Memory footprint will likely be larger for TLS1.2.
+                When disabled HTTPS and MQTT over TLS connections will fail if TLS1.3 not accepted.
+
+        config WOLFSSL_ALLOW_TLS12
+            bool "Allow TLS 1.2"
+            default n
+            help
+                Allow TLS to fallback to TLS1.2. Memory footprint will likely be larger for TLS1.2.
+                When disabled HTTPS and MQTT over TLS connections will fail if TLS1.3 not accepted.
+
+        config WOLFSSL_HAVE_TLS_EXTENSIONS
+            bool "Enable TLS Extensions"
+            default y
+            help
+                Sets HAVE_TLS_EXTENSIONS which is needed for TLS 1.3, SNI, ALPN, and more.
+
+        config WOLFSSL_ALT_CERT_CHAINS
+            bool "Enable Alternate Certificate Chains"
+            default n
+            help
+                The option relaxes the default strict wolfSSL certificate chain processing. This
+                will typically need to be enabled when loading only a CA file. Typically solves
+                the -188 ASN_NO_SIGNER_E error. Use with caution.
+
+        config WOLFSSL_HAVE_OCSP
+            bool "Enable OCSP (Online Certificate Status Protocol) in wolfSSL"
+            default n
+            help
+                Sets HAVE_OCSP
+
+    endmenu # Protocol Config
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    config TLS_STACK_WOLFSSL
+        # Invisible option that locks TLS_STACK_WOLFSSL to ESP_TLS_USING_WOLFSSL
+        bool
+        default n
+        select FREERTOS_ENABLE_BACKWARD_COMPATIBILITY
+        help
+            Includes wolfSSL in ESP-TLS so that it can be compiled with wolfSSL as its SSL/TLS library.
+            Enabled when wolfSSL is selected in ESP_TLS_LIBRARY_CHOOSE.
+
+    menu "wolfSSL ESP-TLS"
+        depends on ESP_TLS_USING_WOLFSSL
+
+        menu "Certificate Bundle"
+            depends on ESP_TLS_USING_WOLFSSL
+
+            config WOLFSSL_CERTIFICATE_BUNDLE
+                bool "Enable trusted root certificate bundle"
+                default y if ESP_TLS_USING_WOLFSSL
+                default n
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Enable support for large number of default root certificates
+
+                    When enabled this option allows user to store default as well
+                    as customer specific root certificates in compressed format rather
+                    than storing full certificate. For the root certificates the public key and the subject name
+                    will be stored.
+
+            config WOLFSSL_NO_ASN_STRICT
+                bool "Relax Certificate ASN Strict Checks"
+                default n
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Allows sub-optimal certificate ASN checks. Unless using a bundle with known issues,
+                    it is recommended to NOT enable this.
+
+            config WOLFSSL_ASN_ALLOW_0_SERIAL
+                bool "Allow cert missing an ASN Serial Number"
+                default y
+                depends on ESP_TLS_USING_WOLFSSL
+                help
+                    Although not recommended, there may be certificates in the bundle that are missing
+                    a serial number. This option allows the missing value without having to fully
+                    disable strict ASN checking with WOLFSSL_NO_ASN_STRICT.
+
+            choice WOLFSSL_DEFAULT_CERTIFICATE_BUNDLE
+                bool "Default certificate bundle options"
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                default WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL
+
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL
+                    bool "Use the full default certificate bundle"
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_CMN
+                    bool "Use only the most common certificates from the default bundles"
+                    help
+                        Use only the most common certificates from the default bundles, reducing the size with 50%,
+                        while still having around 99% coverage.
+                config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+                    bool "Do not use the default certificate bundle"
+            endchoice
+
+            config WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                default n
+                bool "Add custom certificates to the default bundle"
+            config WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE_PATH
+                depends on WOLFSSL_CUSTOM_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+                string "Custom certificate bundle path"
+                help
+                    Name of the custom certificate directory or file. This path is evaluated
+                    relative to the project root directory.
+
+            config WOLFSSL_CERTIFICATE_BUNDLE_DEPRECATED_LIST
+                bool "Add deprecated root certificates"
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL && !WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+                help
+                    Include the deprecated list of root certificates in the bundle.
+                    This list gets updated when a certificate is removed from the Mozilla's
+                    NSS root certificate store. This config can be enabled if you would like
+                    to ensure that none of the certificates that were deployed in the product
+                    are affected because of the update to bundle. In turn, enabling this
+                    config keeps expired, retracted certificates in the bundle and it may
+                    pose a security risk.
+
+                    - Deprecated cert list may grow based based on sync with upstream bundle
+                    - Deprecated certs would be be removed in ESP-IDF (next) major release
+
+            config WOLFSSL_CERTIFICATE_BUNDLE_MAX_CERTS
+                int "Maximum no of certificates allowed in certificate bundle"
+                default 200
+                depends on WOLFSSL_CERTIFICATE_BUNDLE && ESP_TLS_USING_WOLFSSL
+
+        endmenu
+    endmenu # wolfSSL ESP-TLS
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    config ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+        bool "Modify default hardware acceleration settings"
+        default n
+        help
+            When disabling all hardware acceleration for smaller memory footprint,
+            disabling TFM fast math provides faster wolfSSL software algorithms in an
+            even smaller flash memory footprint.
+            Typically used for debugging, analysis, or optimizations. The default
+            hardware acceleration features can be each manually adjusted.
+
+    menu "wolfSSL Hardware Acceleration"
+
+        config ESP_WOLFSSL_NO_ESP32_CRYPT
+            bool "Disable all ESP32 Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            select ESP_WOLFSSL_NO_HW_AES
+            select ESP_WOLFSSL_NO_HW_HASH
+            select ESP_WOLFSSL_NO_HW_RSA_PRI
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_ESP32_CRYPT.
+                Consider disabling FASTMATH (other libraries are faster in software and smaller)
+
+        config ESP_WOLFSSL_NO_HW_AES
+            bool "Disable all ESP32 AES Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default.When selected defines: NO_HW_AES
+
+        config ESP_WOLFSSL_NO_HW_HASH
+            bool "Disable all ESP32 SHA Hash Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_HASH
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI
+            bool "Disable all ESP32 RSA Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            select ESP_WOLFSSL_NO_HW_PRI_MP_MUL
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            select ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_MP_MUL
+            bool "Disable all ESP32 Multiplication Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI_MP_MUL
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_MULMOD
+            bool "Disable all ESP32 Modular Multiplication Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default. When selected defines: NO_HW_RSA_PRI_MULMOD
+
+        config ESP_WOLFSSL_NO_HW_RSA_PRI_EXPTMOD
+            bool "Disable all ESP32 RSA Exponential Math Hardware Acceleration"
+            depends on ESP_WOLFSSL_ALT_HARDWARE_ACCELERATION
+            default n
+            help
+                Hardware acceleration enabled by default.
+                Select this option to force disable: NO_HW_RSA_PRI_EXPTMOD
+
+        config ESP_WOLFSSL_DEBUG_ESP_HW_MULTI_RSAMAX_BITS
+            bool "Enable debugging of RSA Multiplication operand length"
+            default n
+            help
+                Prints an esp log warning to the default console UART when one of the
+                multiplication operands exceeds the maximum size supported by hardware,
+                requiring fallback to software. This can be helpful to pick key sizes
+                when performance is critical. See also metrics for counting instances.
+
+        config ESP_WOLFSSL_DEBUG_ESP_HW_MOD_RSAMAX_BITS
+            bool "Enable debugging of RSA Modular operand length"
+            default n
+            help
+                Prints an esp log warning to the default console UART when one of the
+                modular math operands exceeds the maximum size supported by hardware,
+                requiring fallback to software. This can be helpful to pick key sizes
+                when performance is critical. See also metrics for counting instances.
+
+    endmenu # wolfSSL Hardware Acceleration
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Experimental Options"
+
+        config ESP_WOLFSSL_EXPERIMENTAL_SETTINGS
+            bool "Enable wolfSSL Experimental Settings"
+            default n
+            help
+                Enables experimental settings for wolfSSL. See documentation.
+
+        config ESP_WOLFSSL_ENABLE_KYBER
+            bool "Enable wolfSSL Kyber"
+            default n
+            help
+                Enable debugging messages for wolfSSL. See user_settings.h for additional debug options.
+
+    endmenu # wolfSSL Experimental Options
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Debug Options"
+        config ESP_WOLFSSL_DEBUG_WOLFSSL
+            bool "Enable wolfSSL Debugging"
+            default n
+            help
+                Enable debugging messages for wolfSSL. See user_settings.h for additional debug options.
+
+        config ESP_WOLFSSL_TEST_LOOP
+            bool "Run test apps in a loop until failure"
+            default y
+            help
+                Enable a loop wrapper for benchmark, http_client, and wolfssl test apps.
+
+    endmenu # wolfSSL Debug Options
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "wolfSSL Customization"
+        config CUSTOM_SETTING_WOLFSSL_ROOT
+            string "Enter a path for wolfSSL source code"
+            default "~/workspace/wolfssl"
+            help
+                This option lets you specify a directory for the wolfSSL source code (typically a git clone).
+                Enter the path using forward slashes (e.g., C:/myfolder/mysubfolder) or double backslashes
+                (e.g., C:\\myfolder\\mysubfolder).
+
+    endmenu # wolfSSL Customization
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Component Config"
+        config IGNORE_ESP_IDF_WOLFSSL_COMPONENT
+            bool "Ignore the ESP-IDF component of wolfSSL (if present)"
+            default n
+            help
+                Ignores wolfSSL present in the esp-idf/components directory. Requires wolfssl as a local component.
+
+        config IGNORE_LOCAL_WOLFSSL_COMPONENT
+            bool "Ignore the local component of wolfSSL (if present)"
+            default n
+            help
+                Ignores wolfSSL present in the local project components directory.
+                Requires wolfssl as a ESP-IDF component.
+
+    endmenu # Component Config
+    # -----------------------------------------------------------------------------------------------------------------
+
+    # -----------------------------------------------------------------------------------------------------------------
+    menu "Utility Config"
+        config USE_WOLFSSL_ESP_SDK_TIME
+            bool "Enable wolfSSL time helper functions"
+            default n
+            help
+                Enables use of various time and date setting functions found in the esp-sdk-lib.h file.
+
+        config USE_WOLFSSL_ESP_SDK_WIFI
+            bool "Enable wolfSSL WiFi helper functions"
+            default n
+            help
+                Enables use of various time and date setting functions found in the esp-sdk-lib.h file.
+
+    endmenu # Utility Config
+endmenu # wolfSSL
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+menu "wolfSSH"
+    config ESP_ENABLE_WOLFSSH
+        bool "Enable wolfSSH options"
+        default n
+        help
+            Enables WOLFSSH_TERM, WOLFSSL_KEY_GEN, WOLFSSL_PTHREADS, WOLFSSH_TEST_SERVER, WOLFSSH_TEST_THREADING
+
+    config ESP_WOLFSSL_DEBUG_WOLFSSH
+        bool "Enable wolfSSH debugging"
+        default n
+        help
+            Enable wolfSSH debugging macro. See user_settings.h
+
+endmenu # wolfSSH
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+menu "wolfMQTT"
+    config ESP_ENABLE_WOLFMQTT
+        bool "Enable wolfMQTT options"
+        default n
+        help
+            Enables WOLFMQTT
+
+    config ESP_WOLFSSL_DEBUG_WOLFMQTT
+        bool "Enable wolfMQTT debugging"
+        default n
+        help
+            Enable wolfMQTT debugging macro. See user_settings.h
+
+endmenu # wolfMQTT
+# ---------------------------------------------------------------------------------------------------------------------

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/README.md
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/README.md
@@ -1,9 +1,162 @@
-# Component wolfSSL
+# wolfSSL Espressif Component
 
-This `wolfssl` directory exists only for the stand-alone examples.
+This is the directory for wolfSSL as an Espressif ESP-IDF component.
 
-The only files of interest are the [CMakeLists.txt](./CMakeLists.txt) that should point
-to the wolfSSL source code and the respective [include/user_settings.h](./include/user_settings.h).
+Other options are available, such as installing wolfSSL as a local _project_ component using the [Managed Component](https://www.wolfssl.com/wolfssl-now-available-in-espressif-component-registry/).
 
-This directory is _not_ included in the publish to the Espressif Registry, as that
-mechanism copies the published source code to the local component directory as needed. 
+Enabling this wolfSSL ESP-IDF component allows other ESP-IDF libraries such as those that depend on [ESP-TLS](https://github.com/espressif/esp-idf/tree/master/components/esp-tls)
+to also use the wolfSSL library. (See [github.com/wolfSSL/wolfssl](https://github.com/wolfSSL/wolfssl))
+
+The wolfSSL source code is not included here. Instead, the `idf.py menuconfig` option can be used to configure the
+`sdkconfig` file setting: `CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT` to point to the desired wolfSSL code.
+
+## Directory Contents
+
+This directory must contain, at a minimum:
+
+- `CMakeLists.txt`
+- `./include/user_settings.h`
+
+The directory should also contain:
+- `Kconfig`
+- `component.mk`
+
+The directory may contain wolfSSL source, for example with a [Managed Component](https://www.wolfssl.com/wolfssl-now-available-in-espressif-component-registry/),
+or if the `setup.sh` script was used from [wolfSSL/IDE/Espressif/ESP-IDF](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF).
+
+
+Under normal circumstances when the wolfSSL source is not included here, the `CMakeLists.txt` will search for it in this order:
+
+- A hard-coded `WOLFSSL_ROOT` cmake variable.
+- `WOLFSSL_ROOT` Environment Variable
+- The `CONFIG_CUSTOM_SETTING_WOLFSSL_ROOT` value in the `sdkconfig` file, from the `Kconfig` option.
+- Any parent directories, up to the root (if this directory is in the ESP-IDF components)
+- Any parent directories, up to the root (if this directory is a project component)
+
+While recursing up the directory tree, the following names of wolfSSL directories will be considered:
+
+- `wolfssl-[current user name]`
+- `wolfssl-master`
+- `wolfssl`
+
+## Getting Started
+
+See the `Espressif Getting Started Guide`.
+
+```
+# Set environment variable to ESP-IDF location
+# For example, VisualGDB in WSL
+WRK_IDF_PATH=/mnt/c/SysGCC/esp32/esp-idf/v5.2
+WRK_IDF_PATH=/mnt/c/SysGCC/esp32-master/esp-idf/v5.3-master
+
+# Or wherever the ESP-IDF is installed:
+WRK_IDF_PATH=~/esp/esp-idf
+
+echo "Run export.sh from ${WRK_IDF_PATH}"
+. ${WRK_IDF_PATH}/export.sh
+
+cd [your project]
+
+idf.py menuconfig
+```
+
+Enable wolfSSL to be used in the ESP-TLS:
+
+```
+Component config  --->
+    ESP-TLS  --->
+        Choose SSL/TLS library for ESP-TLS (See help for more Info)
+            (X) wolfSSL (License info in wolfSSL directory README)
+```
+
+Adjust wolfSSL settings, such as path to source code as needed:
+
+```
+Component config  --->
+    wolfSSL  --->
+        [*] Include wolfSSL in ESP-TLS
+        [*] Use the specified wolfssl for ESP-TLS
+        (~/workspace/wolfssl) Enter a path for wolfSSL source code
+```
+
+## Configuration
+
+All settings for wolfSSL are adjusted in the [include/user_settings.h](./include/user_settings.h) file.
+
+The `user_settings.h` file should not be included directly. Instead, `#include <wolfssl/wolfcrypt/settings.h>`
+before any other wolfSSL headers, like this:
+
+
+```c
+/* ESP-IDF */
+#include <esp_log.h>
+#include "sdkconfig.h"
+
+/* wolfSSL */
+/* Always include wolfcrypt/settings.h before any other wolfSSL file.    */
+/* Reminder: settings.h pulls in user_settings.h; don't include it here. */
+#if defined(WOLFSSL_USER_SETTINGS)
+    #include <wolfssl/wolfcrypt/settings.h>
+    #if defined(WOLFSSL_ESPIDF)
+        #include <wolfssl/version.h>
+        #include <wolfssl/wolfcrypt/types.h>
+        #include <wolfcrypt/test/test.h>
+        #include <wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h>
+        #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
+    #else
+        #error "Problem with wolfSSL user_settings. "           \
+               "Check components/wolfssl/include "              \
+               "and confirm WOLFSSL_USER_SETTINGS is defined, " \
+               "typically in the component CMakeLists.txt"
+    #endif
+#else
+    /* Define WOLFSSL_USER_SETTINGS project wide for settings.h to include   */
+    /* wolfSSL user settings in ./components/wolfssl/include/user_settings.h */
+    #error "Missing WOLFSSL_USER_SETTINGS in CMakeLists or Makefile:\
+    CFLAGS +=-DWOLFSSL_USER_SETTINGS"
+#endif
+```
+
+## Examples
+
+See the wolfSSL examples:
+
+- [wolfSSL Core Examples](https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples)
+- [wolfSSL Additional Examples](https://github.com/wolfSSL/wolfssl-examples/tree/master/ESP32)
+- [wolfSSH Core Examples](https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples)
+- [wolfSSH Additional Examples](https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif)
+- [wolfMQTT Examples](https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples)
+
+## Platforms
+
+The ESP-IDF wolfSSL is also available for PlatformIO:
+
+- [Release wolfSSL](https://registry.platformio.org/search?q=owner%3Awolfssl)
+- [Staging / Preview wolfSSL](https://registry.platformio.org/search?q=owner%3Awolfssl-staging)
+
+The wolfSSL library can also be used for Espressif with Arduino:
+
+- [arduino.cc/reference/en/libraries/wolfssl](https://www.arduino.cc/reference/en/libraries/wolfssl/)
+- [github.com/wolfSSL/Arduino-wolfSSL](https://github.com/wolfSSL/Arduino-wolfSSL)
+
+
+## Additional Information
+
+- [wolfSSL Documentation](https://www.wolfssl.com/documentation/manuals/wolfssl/index.html) and [docs/espressif](https://www.wolfssl.com/docs/espressif/)
+- [wolfSSL FAQ](https://www.wolfssl.com/docs/frequently-asked-questions-faq/)
+- [wolfSSL Products](https://www.wolfssl.com/products/)
+- [www.wolfssl.com/espressif](https://www.wolfssl.com/espressif/)
+- [More...](https://www.wolfssl.com/?s=espressif)
+
+## Contact
+
+Have a specific request or questions? We'd love to hear from you! Please contact us at support@wolfssl.com or open an issue on GitHub.
+
+## Licensing and Support
+
+wolfSSL (formerly known as CyaSSL) and wolfCrypt are either licensed for use under the GPLv2 (or at your option any later version) or a standard commercial license. For our users who cannot use wolfSSL under GPLv2 (or any later version), a commercial license to wolfSSL and wolfCrypt is available.
+
+See the LICENSE.txt, visit wolfssl.com/license, contact us at licensing@wolfssl.com or call +1 425 245 8247
+
+View Commercial Support Options: [wolfssl.com/products/support-and-maintenance](wolfssl.com/products/support-and-maintenance)
+

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/component.mk
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/component.mk
@@ -1,0 +1,305 @@
+#
+#  Copyright (C) 2014-2025 wolfSSL Inc.
+#
+#  This file is part of wolfSSH.
+#
+#  wolfSSH is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  wolfSSH is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+$(info ***********  wolfssl component ************)
+
+#
+# Component Makefile
+#
+#
+# The Espressif Managed Components are only for newer versions of the ESP-IDF
+# Typically only for ESP32[-x] targets and only for ESP-IDF v4.3 or later:
+# See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html
+#     https://components.espressif.com/
+#
+# Usage:
+#
+#   make flash
+#
+#   make flash ESPPORT=/dev/ttyS55
+#
+#   make flash ESPBAUD=9600
+#
+#   make monitor ESPPORT=COM1
+#
+#   make monitor ESPPORT=/dev/ttyS55 MONITORBAUD=115200
+#
+#   export ESPPORT=/dev/ttyS55
+#
+# https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/get-started/index.html
+#
+
+# Although the project should define WOLFSSL_USER_SETTINGS, we'll also
+# define it here:
+CFLAGS +=-DWOLFSSL_USER_SETTINGS
+
+# Note that 4 source files created by autogen are excluded here.
+#
+# See these files commented out, below. Adjust as needed for your application:
+#
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/async.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/selftest.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_first.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_last.o
+
+
+# NOTICE: the WOLFSSL_ROOT setting MUST be relative!
+# See https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/api-guides/build-system.html?highlight=must+relative#optional-component-specific-variables
+# In the wolfSSL GitHub examples for Espressif:
+#   https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples
+# When this wolfssl component.mk makefile is in [project]/components/wolfssl
+# The root is 7 directories up from here (the location of of this component.mk):
+#
+WOLFSSL_ROOT     ?= ../../../../../../..
+THIS_DIR         := $(shell pwd)
+WOLFSSL_ROOT_OBJ := $(THIS_DIR)
+
+# When running make from commandline or VisualGDB, the current path varies:
+ifeq ("$(VISUALGDB_DIR)","")
+    # current path is typically /mnt/c/workspace/wolfssl-gojimmypi/IDE/Espressif/ESP-IDF/examples/wolfssl_test/build/wolfssl
+    $(info VISUALGDB_DIR build not detected. shell: $(shell echo $$SHELL))
+else
+    # current path is typically /C/workspace/wolfssl-gojimmypi/IDE/Espressif/ESP-IDF/examples/wolfssl_test/build/Debug/wolfssl
+    $(info Detected VisualGDB in: $(VISUALGDB_DIR) shell: $(shell echo $$SHELL))
+endif
+
+# To set the location of a different location, it is best to use relative paths.
+#
+# Set WOLFSSL_ROOT to a relative path from the current component directory.
+# For example, if the wolfssl_client is copied from the examples to test:
+#
+# cp -r /IDE/Espressif/ESP-IDF/examples/wolfssl_client/* /mnt/c/test/demo
+#
+# we run make in   /mnt/c/test/demo
+# component is in  /mnt/c/test/demo/components/wolfssl
+# wolfssl is in    /mnt/c/workspace/wolfssl-master
+#
+# "/mnt/c" is 4 directories up:
+#             2 for `./test/demo` from where we run `make`, plus
+#             2 more from the location of `component.mk` located
+#               in `[current directory]/components/wolfssl`.
+#
+# Thus we need 4 parent reference to find the relative path to wolfSSL:
+# WOLFSSL_ROOT := ../../../../workspace/wolfssl-master
+
+# Optional CFLAGS (make works without these; for reference only)
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl/wolfcrypt
+# CFLAGS += -I$(WOLFSSL_ROOT)/wolfssl/wolfcrypt/port/Espressif
+
+abs_WOLFSSL_ROOT     := $(shell realpath $(WOLFSSL_ROOT))
+
+# print-wolfssl-path-value:
+#	@echo "WOLFSSL_ROOT defined: $(WOLFSSL_ROOT)"
+#	@echo "WOLFSSL_ROOT actual:  $(abs_WOLFSSL_ROOT)"
+
+$(info WOLFSSL_ROOT     defined: $(WOLFSSL_ROOT))
+$(info WOLFSSL_ROOT     actual:  $(abs_WOLFSSL_ROOT))
+$(info THIS_DIR         defined: $(THIS_DIR))
+$(info WOLFSSL_ROOT_OBJ defined: $(WOLFSSL_ROOT_OBJ))
+
+# NOTE: The wolfSSL include directory (e.g. user_settings.h) is
+# located HERE in THIS project, and *not* in the wolfSSL root.
+COMPONENT_ADD_INCLUDEDIRS := .
+COMPONENT_ADD_INCLUDEDIRS += include
+COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/.
+COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl
+COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl/wolfcrypt
+COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfssl/wolfcrypt/port/Espressif
+
+# COMPONENT_ADD_INCLUDEDIRS += $ENV(IDF_PATH)/components/freertos/include/freertos
+# COMPONENT_ADD_INCLUDEDIRS += "$ENV(IDF_PATH)/soc/esp32s3/include/soc"
+
+# wolfSSL
+COMPONENT_SRCDIRS := $(WOLFSSL_ROOT)/src
+
+# wolfcrypt
+COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/src
+
+# Espressif
+COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif
+COMPONENT_SRCDIRS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/atmel
+
+COMPONENT_OBJEXCLUDE := $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/aes_asm.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/evp.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/misc.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/sha512_asm.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/fe_x25519_asm.o
+COMPONENT_OBJEXCLUDE += $(WOLFSSL_ROOT_OBJ)/wolfcrypt/src/aes_gcm_x86_asm.o
+
+##
+## wolfSSL
+##
+## reminder object files may end up in `./build` or `build/debug` or `build/release`, depending on build environment & settings.
+##
+# COMPONENT_OBJS := $(WOLFSSL_ROOT)/src/bio.o  # part of ssl.c, omitted to avoid "does not need to be compiled separately"
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/conf.o # part of ssl.c
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/crl.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/dtls.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/dtls13.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/internal.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/keys.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/ocsp.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/pk.o   # part of ssl.c
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/quic.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/sniffer.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/ssl.o
+# COMPONENT_OBJS += src/ssl_asn1.o
+# COMPONENT_OBJS += src/ssl_bn.o
+# COMPONENT_OBJS += src/ssl_certman.o
+# COMPONENT_OBJS += src/ssl_crypto.o
+# COMPONENT_OBJS += src/ssl_misc.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/tls.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/tls13.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/wolfio.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/x509.o     # part of ssl.c
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/src/x509_str.o # part of ssl.c
+
+##
+## wolfcrypt
+##
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/aes.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/arc4.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/asm.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/asn.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/async.o # autogen exclusion
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/blake2b.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/blake2s.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/camellia.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/chacha.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/chacha20_poly1305.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/cmac.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/coding.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/compress.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/cpuid.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/cryptocb.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/curve25519.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/curve448.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/des3.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/dh.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/dilithium.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/dsa.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ecc.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/eccsi.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ecc_fp.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ed25519.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ed448.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/error.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/evp.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_kyber.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_lms.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ext_xmss.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/falcon.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fe_448.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fe_low_mem.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fe_operations.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fips.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/fips_test.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ge_448.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ge_low_mem.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ge_operations.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/hash.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/hmac.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/hpke.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/integer.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/kdf.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/logging.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/md2.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/md4.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/md5.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/memory.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/misc.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/pkcs12.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/pkcs7.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/poly1305.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/pwdbased.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/random.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/rc2.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/ripemd.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/rsa.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sakke.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/selftest.o # autogen exclusion
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha256.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha3.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sha512.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/signature.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/siphash.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sm2.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sm3.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sm4.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sphincs.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_arm32.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_arm64.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_armthumb.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_c32.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_c64.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_cortexm.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_dsp32.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_int.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_arm32.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_arm64.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_armthumb.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_c32.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_c64.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_cortexm.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_sm2_x86_64.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/sp_x86_64.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/srp.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/tfm.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_dsp.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_encrypt.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_kyber.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_kyber_poly.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_lms.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_pkcs11.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_port.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wc_xmss.o
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_first.o # autogen exclusion
+# COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfcrypt_last.o  # autogen exclusion
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfevent.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/wolfmath.o
+
+##
+## Espressif
+##
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp32_aes.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp32_mp.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp32_sha.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp32_util.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp_sdk_mem_lib.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp_sdk_time_lib.o
+COMPONENT_OBJS += $(WOLFSSL_ROOT)/wolfcrypt/src/port/Espressif/esp_sdk_wifi_lib.o
+
+##
+## wolfcrypt benchmark  (optional)
+##
+## COMPONENT_OBJS            += $(WOLFSSL_ROOT)/wolfcrypt/benchmark/benchmark.o
+## COMPONENT_SRCDIRS         += $(WOLFSSL_ROOT)/wolfcrypt/benchmark
+## COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfcrypt/benchmark
+
+
+##
+## wolfcrypt test (optional)
+##
+## COMPONENT_OBJS            += $(WOLFSSL_ROOT)/wolfcrypt/test/test.o
+## COMPONENT_SRCDIRS         += $(WOLFSSL_ROOT)/wolfcrypt/test
+## COMPONENT_ADD_INCLUDEDIRS += $(WOLFSSL_ROOT)/wolfcrypt/test/include
+
+$(info ********** end wolfssl component **********)

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/include/user_settings.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/components/wolfssl/include/user_settings.h
@@ -1,6 +1,6 @@
-/* user_settings.h
+/* wolfssl-component include/user_settings.h
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *
@@ -17,20 +17,61 @@
  * You should have received a copy of the GNU General Public License
  * along with wolfSSH.  If not, see <http://www.gnu.org/licenses/>.
  */
+#define WOLFSSL_ESPIDF_COMPONENT_VERSION 0x01
 
-#include <sdkconfig.h> /* essential to chip set detection */
+/* Examples such as test and benchmark are known to cause watchdog timeouts.
+ * Note this is often set in project Makefile:
+ * CFLAGS += -DWOLFSSL_ESP_NO_WATCHDOG=1 */
+#define WOLFSSL_ESP_NO_WATCHDOG 1
 
-#undef WOLFSSL_ESPIDF
-#undef WOLFSSL_ESP32
-#undef WOLFSSL_ESPWROOM32SE
-#undef WOLFSSL_ESP32
-#undef WOLFSSL_ESP8266
+/* The Espressif project config file. See also sdkconfig.defaults */
+#include "sdkconfig.h"
 
-#define WOLFSSL_ESPIDF
+/* This user_settings.h is for Espressif ESP-IDF
+ *
+ * Standardized wolfSSL Espressif ESP32 + ESP8266 user_settings.h V5.7.0-1
+ *
+ * Do not include any wolfssl headers here.
+ *
+ * When editing this file:
+ * ensure all examples match. The template example is the reference.
+ */
+
+/* Naming convention: (see also esp32-crypt.h for the reference source).
+ *
+ * CONFIG_
+ *      This prefix indicates the setting came from the sdkconfig / Kconfig.
+ *
+ *      May or may not be related to wolfSSL.
+ *
+ *      The name after this prefix must exactly match that in the Kconfig file.
+ *
+ * WOLFSSL_
+ *      Typical of many, but not all wolfSSL macro names.
+ *
+ *      Applies to all wolfSSL products such as wolfSSH, wolfMQTT, etc.
+ *
+ *      May or may not have a corresponding sdkconfig / Kconfig control.
+ *
+ * ESP_WOLFSSL_
+ *      These are NOT valid wolfSSL macro names. These are names only used in
+ *      the ESP-IDF Kconfig files. When parsed, they will have a "CONFIG_"
+ *      suffix added. See next section.
+ *
+ * CONFIG_ESP_WOLFSSL_
+ *      This is a wolfSSL-specific macro that has been defined in the ESP-IDF
+ *      via the sdkconfig / menuconfig. Any text after this prefix should
+ *      exactly match an existing wolfSSL macro name.
+ *
+ *      Applies to all wolfSSL products such as wolfSSH, wolfMQTT, etc.
+ *
+ *      These macros may also be specific to only the project or environment,
+ *      and possibly not used anywhere else in the wolfSSL libraries.
+ */
 
 /* The Espressif sdkconfig will have chipset info.
 **
-** Possible values:
+** Some possible values:
 **
 **   CONFIG_IDF_TARGET_ESP32
 **   CONFIG_IDF_TARGET_ESP32S2
@@ -39,17 +80,229 @@
 **   CONFIG_IDF_TARGET_ESP32C6
 */
 
+#undef  WOLFSSL_ESPIDF
+#define WOLFSSL_ESPIDF
+
+/* Test various user_settings between applications by selecting example apps
+ * in `idf.py menuconfig` for Example wolfSSL Configuration settings: */
+
+/* Turn on messages that are useful to see only in examples. */
+#define WOLFSSL_EXAMPLE_VERBOSITY
+
+/* Paths can be long, ensure the entire value printed during debug */
+#define WOLFSSL_MAX_ERROR_SZ 500
+
+/* wolfSSL Examples: set macros used in example applications.
+ *
+ * These Settings NOT available in ESP-IDF (e.g. esp-tls)
+ *
+ * Any settings needed by ESP-IDF components should be explicitly set,
+ * and not by these example-specific settings via CONFIG_WOLFSSL_EXAMPLE_n
+ *
+ * ESP-IDF settings should be Kconfig "CONFIG_[name]" values when possible. */
+#if defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TEMPLATE)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/template */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TEST)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_test */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+    #define TEST_ESPIDF_ALL_WOLFSSL
+
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_BENCHMARK)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark */
+    /* We don't use WiFi, so don't compile in the esp-sdk-lib WiFi helpers: */
+    /* #define USE_WOLFSSL_ESP_SDK_WIFI */
+    #define WOLFSSL_BENCHMARK_FIXED_UNITS_KB
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_CLIENT)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_client */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_TLS_SERVER)
+    /* See https://github.com/wolfSSL/wolfssl/tree/master/IDE/Espressif/ESP-IDF/examples/wolfssl_server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfSSH Examples */
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_TEMPLATE)
+    /* See https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples/wolfssh_template */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFSSH_ECHOSERVER)
+    /* See https://github.com/wolfSSL/wolfssh/tree/master/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_ESP32_SSH_SERVER)
+    /* See https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif/ESP32/ESP32-SSH-Server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_ESP8266_SSH_SERVER)
+    /* See https://github.com/wolfSSL/wolfssh-examples/tree/main/Espressif/ESP8266/ESP8266-SSH-Server */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfMQTT Examples */
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_TEMPLATE)
+    /* See https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples/wolfmqtt_template */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_WOLFMQTT_AWS_IOT_MQTT)
+    /* See https://github.com/wolfSSL/wolfMQTT/tree/master/IDE/Espressif/ESP-IDF/examples/AWS_IoT_MQTT */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* wolfTPM Examples */
+#elif defined(CONFIG_WOLFTPM_EXAMPLE_NAME_ESPRESSIF)
+    /* See https://github.com/wolfSSL/wolfTPM/tree/master/IDE/Espressif */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* Apple HomeKit Examples */
+#elif defined(CONFIG_WOLFSSL_APPLE_HOMEKIT)
+    /* See https://github.com/AchimPieters/esp32-homekit-demo */
+
+/* no example selected */
+#elif defined(CONFIG_WOLFSSL_EXAMPLE_NAME_NONE)
+    /* We'll assume the app needs to use wolfSSL sdk lib function */
+    #define USE_WOLFSSL_ESP_SDK_WIFI
+
+/* Other applications detected by cmake */
+#elif defined(APP_ESP_HTTP_CLIENT_EXAMPLE)
+    /* The wolfSSL Version of the client example */
+    #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C2)
+        /* Less memory available, so smaller key sizes: */
+        #define FP_MAX_BITS (4096 * 2)
+    #else
+        #define FP_MAX_BITS (8192 * 2)
+    #endif
+    #define HAVE_ALPN
+    #define HAVE_SNI
+    #define OPENSSL_EXTRA_X509_SMALL
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+    #define OPENSSL_EXTRA
+    #ifndef WOLFSSL_ALWAYS_VERIFY_CB
+       #define WOLFSSL_ALWAYS_VERIFY_CB
+    #endif
+    #ifndef WOLFSSL_VERIFY_CB_ALL_CERTS
+        #define WOLFSSL_VERIFY_CB_ALL_CERTS
+    #endif
+    #ifndef KEEP_PEER_CERT
+        #define KEEP_PEER_CERT
+    #endif
+
+#elif defined(APP_ESP_HTTP_CLIENT)
+    /* The ESP-IDF Version */
+    #define FP_MAX_BITS (8192 * 2)
+    #define HAVE_ALPN
+    #define HAVE_SNI
+    #define OPENSSL_EXTRA_X509_SMALL
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+    #define OPENSSL_EXTRA
+    #ifndef WOLFSSL_ALWAYS_VERIFY_CB
+       #define WOLFSSL_ALWAYS_VERIFY_CB
+    #endif
+    #ifndef WOLFSSL_VERIFY_CB_ALL_CERTS
+        #define WOLFSSL_VERIFY_CB_ALL_CERTS
+    #endif
+    #ifndef KEEP_PEER_CERT
+        #define KEEP_PEER_CERT
+    #endif
+#else
+    #ifdef WOLFSSL_ESPIDF
+        /* #warning "App config undetected" */
+    #endif
+    /* the code is older or does not have application name defined. */
+#endif /* Example wolfSSL Configuration app settings */
+
+/* Experimental Kyber */
+#ifdef CONFIG_WOLFSSL_ENABLE_KYBER
+    /* Kyber typically needs a minimum 10K stack */
+    #define WOLFSSL_EXPERIMENTAL_SETTINGS
+    #define WOLFSSL_HAVE_KYBER
+    #define WOLFSSL_WC_KYBER
+    #define WOLFSSL_SHA3
+    #if defined(CONFIG_IDF_TARGET_ESP8266)
+        /* With limited RAM, we'll disable some of the Kyber sizes: */
+        #define WOLFSSL_NO_KYBER1024
+        #define WOLFSSL_NO_KYBER768
+        #define NO_SESSION_CACHE
+    #endif
+#endif
+
+/* Enable AES for all examples */
+#ifdef NO_AES
+    #warning "Found NO_AES, wolfSSL AES Cannot be enabled. Check config."
+#else
+    #define WOLFSSL_AES
+    #define WOLFSSL_AES_COUNTER
+
+    /* Typically only needed for wolfssl_test, see docs. */
+    #define WOLFSSL_AES_DIRECT
+#endif
+
+/* Pick a cert buffer size: */
+/* #define USE_CERT_BUFFERS_2048 */
+/* #define USE_CERT_BUFFERS_1024 */
+#define USE_CERT_BUFFERS_2048
+
+/* The Espressif sdkconfig will have chipset info.
+**
+** Some possible values:
+**
+**   CONFIG_IDF_TARGET_ESP32
+**   CONFIG_IDF_TARGET_ESP32S2
+**   CONFIG_IDF_TARGET_ESP32S3
+**   CONFIG_IDF_TARGET_ESP32C3
+**   CONFIG_IDF_TARGET_ESP32C6
+*/
+
+/* Optionally enable Apple HomeKit from compiler directive or Kconfig setting */
+#if defined(WOLFSSL_APPLE_HOMEKIT) || defined(CONFIG_WOLFSSL_APPLE_HOMEKIT)
+     /* SRP is known to need 8K; slow on some devices */
+     #define FP_MAX_BITS (8192 * 2)
+     #define WOLFCRYPT_HAVE_SRP
+     #define HAVE_CHACHA
+     #define HAVE_POLY1305
+     #define WOLFSSL_BASE64_ENCODE
+ #endif /* Apple HomeKit settings */
+
+/* Used by ESP-IDF components: */
+#if defined(CONFIG_ESP_TLS_USING_WOLFSSL)
+    /* The ESP-TLS */
+    #ifndef FP_MAX_BITS
+        #if defined(CONFIG_IDF_TARGET_ESP32C2) || \
+            defined(CONFIG_IDF_TARGET_ESP8684) || \
+            defined(CONFIG_IDF_TARGET_ESP8266)
+            /* Optionally set smaller size here */
+            #define FP_MAX_BITS MIN_FFDHE_FP_MAX_BITS
+        #else
+            #define FP_MAX_BITS (4096 * 2)
+        #endif
+    #endif
+    #define HAVE_ALPN
+    #ifndef CONFIG_IDF_TARGET_ESP8266
+        /* Unless installed in the ESP8266 RTOS SDK locally, the wolfSSL
+         * API for SNI will not be seen in the components/esp-tls layer.
+         * Only enable SNI for non-ESP8266 targets by default: */
+        #define HAVE_SNI
+    #endif
+    #define OPENSSL_EXTRA_X509_SMALL
+
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+#endif
+
 /* Optionally enable some wolfSSH settings */
-#ifdef ESP_ENABLE_WOLFSSH
-    /* The default SSH Windows size is massive for an embedded target. Limit it: */
+#if defined(ESP_ENABLE_WOLFSSH) || defined(CONFIG_ESP_ENABLE_WOLFSSH)
+    /* Enable wolfSSH. Espressif examples need a few more settings, below */
+    #undef  WOLFSSL_WOLFSSH
+    #define WOLFSSL_WOLFSSH
+
+    /* The default SSH Windows size is massive for an embedded target.
+     * Limit it: */
     #define DEFAULT_WINDOW_SZ 2000
 
     /* These may be defined in cmake for other examples: */
     #undef  WOLFSSH_TERM
     #define WOLFSSH_TERM
 
-    #undef  DEBUG_WOLFSSH
-    #define DEBUG_WOLFSSH
+    /* optional debug */
+    /* #undef  DEBUG_WOLFSSH */
+    /* #define DEBUG_WOLFSSH */
 
     #undef  WOLFSSL_KEY_GEN
     #define WOLFSSL_KEY_GEN
@@ -59,21 +312,54 @@
 
     #define WOLFSSH_TEST_SERVER
     #define WOLFSSH_TEST_THREADING
-
 #endif /* ESP_ENABLE_WOLFSSH */
 
-/* when you want to use SINGLE THREAD */
-/* #define SINGLE_THREADED */
+
+/* Not yet using WiFi lib, so don't compile in the esp-sdk-lib WiFi helpers: */
+/* #define USE_WOLFSSL_ESP_SDK_WIFI */
 
 /*
- * choose ONE of these Espressif chips to define:
+ * ONE of these Espressif chip families will be detected from sdkconfig:
  *
  * WOLFSSL_ESP32
  * WOLFSSL_ESPWROOM32SE
  * WOLFSSL_ESP8266
+ *
+ * following ifdef detection only for syntax highlighting:
  */
+#ifdef WOLFSSL_ESPWROOM32SE
+    #undef WOLFSSL_ESPWROOM32SE
+#endif
+#ifdef WOLFSSL_ESP8266
+    #undef WOLFSSL_ESP8266
+#endif
+#ifdef WOLFSSL_ESP32
+    #undef WOLFSSL_ESP32
+#endif
+/* See below for chipset detection from sdkconfig.h */
 
-#define WOLFSSL_ESP32
+/* when you want to use SINGLE THREAD. Note Default ESP-IDF is FreeRTOS */
+#define SINGLE_THREADED
+
+/* Small session cache saves a lot of RAM for ClientCache and SessionCache.
+ * Memory requirement is about 5KB, otherwise 20K is needed when not specified.
+ * If extra small footprint is needed, try MICRO_SESSION_CACHE (< 1K)
+ * When really desperate or no TLS used, try NO_SESSION_CACHE.  */
+#define NO_SESSION_CACHE
+
+/* Small Stack uses more heap. */
+#define WOLFSSL_SMALL_STACK
+
+/* Full debugging turned off, but show malloc failure detail */
+/* #define DEBUG_WOLFSSL */
+#define DEBUG_WOLFSSL_MALLOC
+
+/* See test.c that sets cert buffers; we'll set them here: */
+#define USE_CERT_BUFFERS_256
+#define USE_CERT_BUFFERS_2048
+
+/* RSA_LOW_MEM: Half as much memory but twice as slow. */
+#define RSA_LOW_MEM
 
 /* optionally turn off SHA512/224 SHA512/256 */
 /* #define WOLFSSL_NOSHA512_224 */
@@ -87,37 +373,84 @@
 /* #define NO_OLD_TLS */
 
 #define BENCH_EMBEDDED
-#define USE_CERT_BUFFERS_2048
 
-#define NO_OLD_TLS
-/* TLS 1.3
- #define WOLFSSL_TLS13
- #define HAVE_TLS_EXTENSIONS
- #define WC_RSA_PSS
- #define HAVE_SUPPORTED_CURVES
-*/
+/* TLS 1.3                                 */
+#ifdef CONFIG_WOLFSSL_ALLOW_TLS13
+    #define WOLFSSL_TLS13
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_HKDF
 
-#define HAVE_HKDF
-#define HAVE_AEAD
+    /* May be required */
+    #ifndef HAVE_AEAD
+    #endif
+
+    /* Required for ECC */
+    #define HAVE_SUPPORTED_CURVES
+
+    /* Required for RSA */
+    #define WC_RSA_PSS
+
+    /* TLS 1.3 normally requires HAVE_FFDHE */
+    #if defined(HAVE_FFDHE_2048) || \
+        defined(HAVE_FFDHE_3072) || \
+        defined(HAVE_FFDHE_4096) || \
+        defined(HAVE_FFDHE_6144) || \
+        defined(HAVE_FFDHE_8192)
+    #else
+        #define HAVE_FFDHE_2048
+        /* #error "TLS 1.3 requires HAVE_FFDHE_[nnnn]" */
+    #endif
+#endif
+
+#if defined(CONFIG_IDF_TARGET_ESP32C2) || \
+    defined(CONFIG_IDF_TARGET_ESP8684)
+    /* Optionally set smaller size here */
+    #ifdef HAVE_FFDHE_4096
+        /* this size may be problematic on the C2 */
+    #endif
+    #define HAVE_FFDHE_2048
+#else
+    #define HAVE_FFDHE_4096
+#endif
 
 #define NO_FILESYSTEM
 
+#define NO_OLD_TLS
+
 #define HAVE_AESGCM
 
-#define WOLFSSL_RIPEMD
-/* when you want to use SHA224 */
-/* #define WOLFSSL_SHA224      */
+/* Optional RIPEMD: RACE Integrity Primitives Evaluation Message Digest */
+/* #define WOLFSSL_RIPEMD */
 
+/* when you want to use SHA224 */
+#define WOLFSSL_SHA224
 
 /* when you want to use SHA384 */
-/* #define WOLFSSL_SHA384 */
+#define WOLFSSL_SHA384
 
-/* #define WOLFSSL_SHA3 */
+/* Some features not enabled for ESP8266: */
+#if defined(CONFIG_IDF_TARGET_ESP8266) || \
+    defined(CONFIG_IDF_TARGET_ESP32C2)
+    /* Some known low-memory devices have features not enabled by default. */
+    /* TODO determine low memory configuration for ECC. */
+#else
+    /* when you want to use SHA512 */
+    #define WOLFSSL_SHA512
 
-#define WOLFSSL_SHA512
+    /* when you want to use SHA3 */
+    /* #define WOLFSSL_SHA3 */
 
-#define MY_USE_ECC 1
-#define MY_USE_RSA 0
+    /* ED25519 requires SHA512 */
+    #define HAVE_ED25519
+#endif
+
+#if defined(CONFIG_IDF_TARGET_ESP8266) || defined(CONFIG_IDF_TARGET_ESP32C2)
+    #define MY_USE_ECC 0
+    #define MY_USE_RSA 1
+#else
+    #define MY_USE_ECC 1
+    #define MY_USE_RSA 0
+#endif
 
 /* We can use either or both ECC and RSA, but must use at least one. */
 #if MY_USE_ECC || MY_USE_RSA
@@ -126,7 +459,7 @@
         #define HAVE_ECC
         #define HAVE_CURVE25519
         #define HAVE_ED25519
-
+        #define WOLFSSL_SHA512
         /*
         #define HAVE_ECC384
         #define CURVE25519_SMALL
@@ -151,24 +484,42 @@
     #error "Either RSA or ECC must be enabled"
 #endif
 
+/* Optional OpenSSL compatibility */
+/* #define OPENSSL_EXTRA */
 
-/* when you want to use pkcs7 */
+/* #Optional HAVE_PKCS7 */
 /* #define HAVE_PKCS7 */
 
 #if defined(HAVE_PKCS7)
+    /* HAVE_PKCS7 may enable HAVE_PBKDF2 see settings.h */
+    #define NO_PBKDF2
+
     #define HAVE_AES_KEYWRAP
     #define HAVE_X963_KDF
     #define WOLFSSL_AES_DIRECT
 #endif
 
-/* when you want to use aes counter mode */
+/* when you want to use AES counter mode */
 /* #define WOLFSSL_AES_DIRECT */
 /* #define WOLFSSL_AES_COUNTER */
 
-/* debug options */
-/* #define DEBUG_WOLFSSL */
-/* #define WOLFSSL_ESP32_CRYPT_DEBUG */
-/* #define WOLFSSL_ATECC508A_DEBUG          */
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
+/* WC_NO_CACHE_RESISTANT: slower but more secure */
+/* #define WC_NO_CACHE_RESISTANT */
+
+/* TFM_TIMING_RESISTANT: slower but more secure */
+/* #define TFM_TIMING_RESISTANT */
+
+/* #define WOLFSSL_ATECC508A_DEBUG         */
 
 /* date/time                               */
 /* if it cannot adjust time in the device, */
@@ -176,15 +527,21 @@
 /* #define NO_ASN_TIME */
 /* #define XTIME time */
 
-/* adjust wait-timeout count if you see timeout in RSA HW acceleration */
-#define ESP_RSA_TIMEOUT_CNT    0x249F00
 
+/* Adjust wait-timeout count if you see timeout in RSA HW acceleration.
+ * Set to very large number and enable WOLFSSL_HW_METRICS to determine max. */
+#ifndef ESP_RSA_TIMEOUT_CNT
+    #define ESP_RSA_TIMEOUT_CNT 0xFF0000
+#endif
+
+/* hash limit for test.c */
+#define HASH_SIZE_LIMIT
 
 /* USE_FAST_MATH is default */
 #define USE_FAST_MATH
 
 /*****      Use SP_MATH      *****/
-/* #undef USE_FAST_MATH          */
+/* #undef  USE_FAST_MATH         */
 /* #define SP_MATH               */
 /* #define WOLFSSL_SP_MATH_ALL   */
 /* #define WOLFSSL_SP_RISCV32    */
@@ -193,11 +550,65 @@
 /* #undef USE_FAST_MATH          */
 /* #define USE_INTEGER_HEAP_MATH */
 
+/* Just syntax highlighting to check math libraries: */
+#if defined(SP_MATH)               || \
+    defined(USE_INTEGER_HEAP_MATH) || \
+    defined(USE_INTEGER_HEAP_MATH) || \
+    defined(USE_FAST_MATH)         || \
+    defined(WOLFSSL_SP_MATH_ALL)   || \
+    defined(WOLFSSL_SP_RISCV32)
+#endif
 
 #define WOLFSSL_SMALL_STACK
 
-/* The ESP32 has some detailed statup information available:*/
+
 #define HAVE_VERSION_EXTENDED_INFO
+/* #define HAVE_WC_INTROSPECTION */
+
+#ifndef NO_SESSION_CACHE
+    #define  HAVE_SESSION_TICKET
+#endif
+
+/* #define HAVE_HASHDRBG */
+
+#if 0
+/* Example for additional cert functions */
+#define WOLFSSL_KEY_GEN
+    #define WOLFSSL_CERT_REQ
+    #define WOLFSSL_CERT_GEN
+    #define WOLFSSL_CERT_EXT
+    #define WOLFSSL_SYS_CA_CERTS
+
+
+    #define WOLFSSL_CERT_TEXT
+
+    /* command-line options
+    --enable-keygen
+    --enable-certgen
+    --enable-certreq
+    --enable-certext
+    --enable-asn-template
+    */
+
+#endif
+
+#define WOLFSSL_ASN_TEMPLATE
+
+/*
+#undef  WOLFSSL_KEY_GEN
+#undef  WOLFSSL_CERT_REQ
+#undef  WOLFSSL_CERT_GEN
+#undef  WOLFSSL_CERT_EXT
+#undef  WOLFSSL_SYS_CA_CERTS
+*/
+
+/* command-line options
+--enable-keygen
+--enable-certgen
+--enable-certreq
+--enable-certext
+--enable-asn-template
+*/
 
 /* optional SM4 Ciphers. See https://github.com/wolfSSL/wolfsm */
 /*
@@ -251,20 +662,14 @@
     #define USE_CERT_BUFFERS_2048
 #endif
 
-/* esp32-wroom-32se specific definition */
-#if defined(WOLFSSL_ESPWROOM32SE)
-    #define WOLFSSL_ATECC508A
-    #define HAVE_PK_CALLBACKS
-    /* when you want to use a custom slot allocation for ATECC608A */
-    /* unless your configuration is unusual, you can use default   */
-    /* implementation.                                             */
-    /* #define CUSTOM_SLOT_ALLOCATION                              */
-#endif
-
-/* Default is HW enabled unless turned off.
-** Uncomment these lines to force SW instead of HW acceleration */
-
+/* Chipset detection from sdkconfig.h
+ * Default is HW enabled unless turned off.
+ * Uncomment lines to force SW instead of HW acceleration */
 #if defined(CONFIG_IDF_TARGET_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ESP32
+    /*  Alternatively, if there's an ECC Secure Element present: */
+    /* #define WOLFSSL_ESPWROOM32SE */
+
     /* wolfSSL HW Acceleration supported on ESP32. Uncomment to disable: */
     /*  #define NO_ESP32_CRYPT                 */
     /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
@@ -275,23 +680,14 @@
     /*  #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_EXPTMOD */
 
     /*  These are defined automatically in esp32-crypt.h, here for clarity:  */
-    /* no SHA224 HW on ESP32  */
-    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224
+    #define NO_WOLFSSL_ESP32_CRYPT_HASH_SHA224 /* no SHA224 HW on ESP32  */
 
-    /* Define USE_FAST_MATH and SMALL_STACK                        */
-    #define ESP32_USE_RSA_PRIMITIVE
-
-    /* threshold for performance adjustment for HW primitive use   */
-    /* X bits of G^X mod P greater than                            */
-    #define EPS_RSA_EXPT_XBTIS           32
-
-    /* X and Y of X * Y mod P greater than                         */
     #undef  ESP_RSA_MULM_BITS
-    #define ESP_RSA_MULM_BITS            16
-
+    #define ESP_RSA_MULM_BITS 16 /* TODO add compile-time warning */
     /***** END CONFIG_IDF_TARGET_ESP32 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    #define WOLFSSL_ESP32
     /* wolfSSL HW Acceleration supported on ESP32-S2. Uncomment to disable: */
     /*  #define NO_ESP32_CRYPT                 */
     /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH    */
@@ -304,6 +700,7 @@
     /***** END CONFIG_IDF_TARGET_ESP32S2 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    #define WOLFSSL_ESP32
     /* wolfSSL HW Acceleration supported on ESP32-S3. Uncomment to disable: */
     /*  #define NO_ESP32_CRYPT                         */
     /*  #define NO_WOLFSSL_ESP32_CRYPT_HASH            */
@@ -317,6 +714,7 @@
 
 #elif defined(CONFIG_IDF_TARGET_ESP32C2) || \
       defined(CONFIG_IDF_TARGET_ESP8684)
+    #define WOLFSSL_ESP32
     /* ESP8684 is essentially ESP32-C2 chip + flash embedded together in a
      * single QFN 4x4 mm package. Out of released documentation, Technical
      * Reference Manual as well as ESP-IDF Programming Guide is applicable
@@ -342,6 +740,7 @@
     /***** END CONFIG_IDF_TARGET_ESP32C2 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    #define WOLFSSL_ESP32
     /* wolfSSL HW Acceleration supported on ESP32-C3. Uncomment to disable: */
 
     /*  #define NO_ESP32_CRYPT                 */
@@ -359,6 +758,7 @@
     /***** END CONFIG_IDF_TARGET_ESP32C3 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32C6)
+    #define WOLFSSL_ESP32
     /* wolfSSL HW Acceleration supported on ESP32-C6. Uncomment to disable: */
 
     /*  #define NO_ESP32_CRYPT                 */
@@ -375,6 +775,7 @@
     /***** END CONFIG_IDF_TARGET_ESP32C6 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP32H2)
+    #define WOLFSSL_ESP32
     /*  wolfSSL Hardware Acceleration not yet implemented */
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH
@@ -383,11 +784,19 @@
     /***** END CONFIG_IDF_TARGET_ESP32H2 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP8266)
-    /*  TODO: Revisit ESP8266 */
+    #define WOLFSSL_ESP8266
+
+    /* There's no hardware encryption on the ESP8266 */
+    /* Consider using the ESP32-C2/C3/C6             */
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH
     #define NO_WOLFSSL_ESP32_CRYPT_AES
     #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
+    #ifndef FP_MAX_BITS
+        /* FP_MAX_BITS matters in wolfssl_test, not just TLS setting.   */
+        /* MIN_FFDHE_FP_MAX_BITS = (MIN_FFDHE_BITS * 2); see settings.h */
+        #define FP_MAX_BITS MIN_FFDHE_FP_MAX_BITS
+    #endif
     /***** END CONFIG_IDF_TARGET_ESP266 *****/
 
 #elif defined(CONFIG_IDF_TARGET_ESP8684)
@@ -399,33 +808,86 @@
     /***** END CONFIG_IDF_TARGET_ESP8684 *****/
 
 #else
-    /* Anything else encountered, disable HW accleration */
+    /* Anything else encountered, disable HW acceleration */
+    #warning "Unexpected CONFIG_IDF_TARGET_NN value"
     #define NO_ESP32_CRYPT
     #define NO_WOLFSSL_ESP32_CRYPT_HASH
     #define NO_WOLFSSL_ESP32_CRYPT_AES
     #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI
 #endif /* CONFIG_IDF_TARGET Check */
 
+/* RSA primitive specific definition, listed AFTER the Chipset detection */
+#if defined(WOLFSSL_ESP32) || defined(WOLFSSL_ESPWROOM32SE)
+    /* Consider USE_FAST_MATH and SMALL_STACK                        */
+
+    #ifndef NO_RSA
+        #define ESP32_USE_RSA_PRIMITIVE
+
+        #if defined(CONFIG_IDF_TARGET_ESP32)
+            #ifdef CONFIG_ESP_MAIN_TASK_STACK_SIZE
+                #if CONFIG_ESP_MAIN_TASK_STACK_SIZE < 10500
+                    #warning "RSA may be difficult with less than 10KB Stack "/
+                #endif
+            #endif
+
+            /* NOTE HW unreliable for small values! */
+            /* threshold for performance adjustment for HW primitive use   */
+            /* X bits of G^X mod P greater than                            */
+            #undef  ESP_RSA_EXPT_XBITS
+            #define ESP_RSA_EXPT_XBITS 32
+
+            /* X and Y of X * Y mod P greater than                         */
+            #undef  ESP_RSA_MULM_BITS
+            #define ESP_RSA_MULM_BITS  16
+        #endif
+    #endif
+#endif
+
 /* Debug options:
+See wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h for details on debug options
+
+optionally increase error message size for very long paths.
+#define WOLFSSL_MAX_ERROR_SZ 500
+
+Turn wolfSSL debugging on/off:
+    wolfSSL_Debugging_ON();
+    wolfSSL_Debugging_OFF();
 
 #define ESP_VERIFY_MEMBLOCK
 #define DEBUG_WOLFSSL
 #define DEBUG_WOLFSSL_VERBOSE
 #define DEBUG_WOLFSSL_SHA_MUTEX
+#define WOLFSSL_DEBUG_IGNORE_ASN_TIME
+#define WOLFSSL_DEBUG_CERT_BUNDLE
+#define WOLFSSL_DEBUG_CERT_BUNDLE_NAME
 #define WOLFSSL_ESP32_CRYPT_DEBUG
 #define WOLFSSL_ESP32_CRYPT_HASH_SHA224_DEBUG
 #define NO_RECOVER_SOFTWARE_CALC
 #define WOLFSSL_TEST_STRAY 1
 #define USE_ESP_DPORT_ACCESS_READ_BUFFER
 #define WOLFSSL_ESP32_HW_LOCK_DEBUG
+#define WOLFSSL_DEBUG_MUTEX
 #define WOLFSSL_DEBUG_ESP_RSA_MULM_BITS
+#define WOLFSSL_DEBUG_ESP_HW_MOD_RSAMAX_BITS
+#define WOLFSSL_DEBUG_ESP_HW_MULTI_RSAMAX_BITS
 #define ESP_DISABLE_HW_TASK_LOCK
+#define ESP_MONITOR_HW_TASK_LOCK
+#define USE_ESP_DPORT_ACCESS_READ_BUFFER
+
+See wolfcrypt/benchmark/benchmark.c for debug and other settings:
+
+Turn on benchmark timing debugging (CPU Cycles, RTOS ticks, etc)
+#define DEBUG_WOLFSSL_BENCHMARK_TIMING
+
+Turn on timer debugging (used when CPU cycles not available)
+#define WOLFSSL_BENCHMARK_TIMER_DEBUG
 */
 
 /* Pause in a loop rather than exit. */
-#define WOLFSSL_ESPIDF_ERROR_PAUSE
+/* #define WOLFSSL_ESPIDF_ERROR_PAUSE */
+/* #define WOLFSSL_ESP32_HW_LOCK_DEBUG */
 
-/* #define WOLFSSL_HW_METRICS */
+#define WOLFSSL_HW_METRICS
 
 /* for test.c */
 /* #define HASH_SIZE_LIMIT */
@@ -453,8 +915,9 @@
 ** [Z = X * Y mod M] in esp_mp_mulmod()                         */
 /* #define NO_WOLFSSL_ESP32_CRYPT_RSA_PRI_MULMOD                */
 
-#define WOLFSSL_PUBLIC_MP /* used by benchmark */
-#define USE_CERT_BUFFERS_2048
+
+/* used by benchmark: */
+#define WOLFSSL_PUBLIC_MP
 
 /* when turning on ECC508 / ECC608 support
 #define WOLFSSL_ESPWROOM32SE
@@ -463,12 +926,81 @@
 #define ATCA_WOLFSSL
 */
 
-/* optional SM4 Ciphers. See https://github.com/wolfSSL/wolfsm
+/***************************** Certificate Macros *****************************
+ *
+ * The section below defines macros used in typically all of the wolfSSL
+ * examples such as the client and server for certs stored in header files.
+ *
+ * There are various certificate examples in this header file:
+ * https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/certs_test.h
+ *
+ * To use the sample certificates in code (not recommended for production!):
+ *
+ *    #if defined(USE_CERT_BUFFERS_2048) || defined(USE_CERT_BUFFERS_1024)
+ *        #include <wolfssl/certs_test.h>
+ *    #endif
+ *
+ * To use the sets of macros below, define *one* of these:
+ *
+ *    USE_CERT_BUFFERS_1024  - ECC 1024 bit encoded ASN1
+ *    USE_CERT_BUFFERS_2048  - RSA 2048 bit encoded ASN1
+ *    WOLFSSL_SM[2,3,4]      - SM Ciphers
+ *
+ * For example: define USE_CERT_BUFFERS_2048 to use CA Certs used in this
+ *  wolfSSL function for the `ca_cert_der_2048` buffer, size and types:
+ *
+ *     ret = wolfSSL_CTX_load_verify_buffer(ctx,
+ *                                          CTX_CA_CERT,
+ *                                          CTX_CA_CERT_SIZE,
+ *                                          CTX_CA_CERT_TYPE);
+ *
+ * See https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_load_verify_buffer
+ *
+ * In this case the CTX_CA_CERT will be defined as `ca_cert_der_2048` as
+ * defined here: https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/certs_test.h
+ *
+ * The CTX_CA_CERT_SIZE and CTX_CA_CERT_TYPE are similarly used to reference
+ * array size and cert type respectively.
+ *
+ * Similarly for loading the private client key:
+ *
+ *  ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+ *                                          CTX_CLIENT_KEY,
+ *                                          CTX_CLIENT_KEY_SIZE,
+ *                                          CTX_CLIENT_KEY_TYPE);
+ *
+ * see https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_use_privatekey_buffer
+ *
+ * Similarly, the other macros are for server certificates and keys:
+ *   `CTX_SERVER_CERT` and `CTX_SERVER_KEY` are available.
+ *
+ * The certificate and key names are typically `static const unsigned char`
+ * arrays. The [NAME]_size are typically `sizeof([array name])`, and the types
+ * are the known wolfSSL encoding type integers (e.g. WOLFSSL_FILETYPE_PEM).
+ *
+ * See `SSL_FILETYPE_[name]` in
+ *   https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/ssl.h
+ *
+ * See Abstract Syntax Notation One (ASN.1) in:
+ *   https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/wolfcrypt/asn.h
+ *
+ * Optional SM4 Ciphers:
+ *
+ * Although the SM ciphers are shown here, the `certs_test_sm.h` may not yet
+ * be available. See:
+ *   https://github.com/wolfSSL/wolfssl/pull/6825
+ *   https://github.com/wolfSSL/wolfsm
+ *
+ * Uncomment these 3 macros to enable the SM Ciphers and use the macros below.
+ */
+
+/*
 #define WOLFSSL_SM2
 #define WOLFSSL_SM3
 #define WOLFSSL_SM4
 */
 
+/* Conditional macros used in wolfSSL TLS client and server examples */
 #if defined(WOLFSSL_SM2) || defined(WOLFSSL_SM3) || defined(WOLFSSL_SM4)
     #include <wolfssl/certs_test_sm.h>
     #define CTX_CA_CERT          root_sm2
@@ -484,19 +1016,77 @@
     #undef  WOLFSSL_BASE16
     #define WOLFSSL_BASE16
 #else
-    #define USE_CERT_BUFFERS_2048
-    #define USE_CERT_BUFFERS_256
-    #define CTX_CA_CERT          ca_cert_der_2048
-    #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_2048
-    #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
-    #define CTX_SERVER_CERT      server_cert_der_2048
-    #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_2048
-    #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
-    #define CTX_SERVER_KEY       server_key_der_2048
-    #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_2048
-    #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
-#endif
+    #if defined(USE_CERT_BUFFERS_2048)
+        #define USE_CERT_BUFFERS_256
+        /* Be sure to include in app when using example certs: */
+        /* #include <wolfssl/certs_test.h>                     */
+        #define CTX_CA_CERT          ca_cert_der_2048
+        #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_2048
+        #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
 
+        #define CTX_SERVER_CERT      server_cert_der_2048
+        #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_2048
+        #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_SERVER_KEY       server_key_der_2048
+        #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_2048
+        #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_CLIENT_CERT      client_cert_der_2048
+        #define CTX_CLIENT_CERT_SIZE sizeof_client_cert_der_2048
+        #define CTX_CLIENT_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_CLIENT_KEY       client_key_der_2048
+        #define CTX_CLIENT_KEY_SIZE  sizeof_client_key_der_2048
+        #define CTX_CLIENT_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+    #elif defined(USE_CERT_BUFFERS_1024)
+        #define USE_CERT_BUFFERS_256
+        /* Be sure to include in app when using example certs: */
+        /* #include <wolfssl/certs_test.h>                     */
+        #define CTX_CA_CERT          ca_cert_der_1024
+        #define CTX_CA_CERT_SIZE     sizeof_ca_cert_der_1024
+        #define CTX_CA_CERT_TYPE     WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_CLIENT_CERT      client_cert_der_1024
+        #define CTX_CLIENT_CERT_SIZE sizeof_client_cert_der_1024
+        #define CTX_CLIENT_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_CLIENT_KEY       client_key_der_1024
+        #define CTX_CLIENT_KEY_SIZE  sizeof_client_key_der_1024
+        #define CTX_CLIENT_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+
+        #define CTX_SERVER_CERT      server_cert_der_1024
+        #define CTX_SERVER_CERT_SIZE sizeof_server_cert_der_1024
+        #define CTX_SERVER_CERT_TYPE WOLFSSL_FILETYPE_ASN1
+        #define CTX_SERVER_KEY       server_key_der_1024
+        #define CTX_SERVER_KEY_SIZE  sizeof_server_key_der_1024
+        #define CTX_SERVER_KEY_TYPE  WOLFSSL_FILETYPE_ASN1
+    #else
+        /* Optionally define custom cert arrays, sizes, and types here */
+        #error "Must define USE_CERT_BUFFERS_2048 or USE_CERT_BUFFERS_1024"
+    #endif
+#endif /* Conditional key and cert constant names */
+
+/******************************************************************************
+** Sanity Checks
+******************************************************************************/
+#if defined(CONFIG_ESP_MAIN_TASK_STACK_SIZE)
+    #if defined(WOLFCRYPT_HAVE_SRP)
+        #if defined(FP_MAX_BITS)
+            #if FP_MAX_BITS <  (8192 * 2)
+                #define ESP_SRP_MINIMUM_STACK_8K (24 * 1024)
+            #else
+                #define ESP_SRP_MINIMUM_STACK_8K (28 * 1024)
+            #endif
+        #else
+            #error "Please define FP_MAX_BITS when using WOLFCRYPT_HAVE_SRP."
+        #endif
+
+        #if (CONFIG_ESP_MAIN_TASK_STACK_SIZE < ESP_SRP_MINIMUM_STACK)
+            #warning "WOLFCRYPT_HAVE_SRP enabled with small stack size"
+        #endif
+    #endif
+#else
+    #warning "CONFIG_ESP_MAIN_TASK_STACK_SIZE not defined!"
+#endif
 /* See settings.h for some of the possible hardening options:
  *
  *  #define NO_ESPIDF_DEFAULT

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/CMakeLists.txt
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/CMakeLists.txt
@@ -1,6 +1,6 @@
 #  [wolfSSL Project]/main/CMakeLists.txt
 #
-#  Copyright (C) 2014-2024 wolfSSL Inc.
+#  Copyright (C) 2014-2025 wolfSSL Inc.
 #
 #  This file is part of wolfSSH.
 #
@@ -28,28 +28,26 @@ message(STATUS "main cmake found WOLFSSL_COMPONENT_NAME = ${WOLFSSL_COMPONENT_NA
 if(WIN32)
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WINDOWS")
-    message("Detected Windows")
+    message(STATUS "Detected Windows")
 endif()
 if(CMAKE_HOST_UNIX)
-    message("Detected UNIX")
-endif()
-if(APPLE)
-    message("Detected APPLE")
+    message(STATUS "Detected UNIX")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND EXISTS "/proc/sys/fs/binfmt_misc/WSLInterop")
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_WSL")
-    message("Detected WSL")
+    message(STATUS "Detected WSL")
 endif()
 if(CMAKE_HOST_UNIX AND (NOT APPLE) AND (NOT WIN32))
     # Windows-specific configuration here
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_LINUX")
-    message("Detected Linux")
+    message(STATUS "Detected Linux")
 endif()
 if(APPLE)
-    # Windows-specific configuration here
+    # Apple-specific configuration here
+    message(STATUS "Detected APPLE")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWOLFSSL_CMAKE_SYSTEM_NAME_APPLE")
-    message("Detected Apple")
+    message(STATUS "Detected Apple")
 endif()
 set (git_cmd "git")
 

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/include/main.h
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/include/main.h
@@ -1,6 +1,6 @@
 /* template main.h
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/main.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_template/main/main.c
@@ -1,6 +1,6 @@
 /* main.c
  *
- * Copyright (C) 2014-2024 wolfSSL Inc.
+ * Copyright (C) 2014-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSH.
  *
@@ -38,7 +38,7 @@ void app_main(void)
     wolfSSH_Debugging_ON();
 #else
     ESP_LOGI(TAG, "DEBUG_WOLFSSH is not defined, "
-                  "so nothing will happen for teh next statement");
+                  "so nothing will happen for the next statement");
 #endif
 
 #ifdef HAVE_VERSION_EXTENDED_INFO

--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -949,7 +949,8 @@ static INLINE void WaitTcpReady(tcp_ready* ready)
 #ifdef WOLFSSH_TEST_THREADING
 
 
-#if !defined(WOLFSSH_OLD_THREADING) && !defined(WOLFSSH_OLDER_THREADING)
+#if !defined(WOLFSSH_OLD_THREADING) && !defined(WOLFSSH_OLDER_THREADING) && \
+    !defined(SINGLE_THREADED)
 
 static INLINE void ThreadStart(THREAD_CB fun, void* args, THREAD_TYPE* thread)
 {


### PR DESCRIPTION
See https://github.com/wolfSSL/wolfssh/pull/770 that inexplicably fails a Windows build test.

This is a brute-force test to see if the error is branch-specific; #770 is based on wolfSSH v1.18 that at the time seemed to be a good idea to publish as a Managed Component with only examples updated for that version.