### PR TITLE
Fix SCP server side

### DIFF
--- a/apps/wolfsshd/test/run_all_sshd_tests.sh
+++ b/apps/wolfsshd/test/run_all_sshd_tests.sh
@@ -8,6 +8,7 @@ test_cases=(
  "sshd_term_size_test.sh"
  "sshd_large_sftp_test.sh"
  "sshd_bad_sftp_test.sh"
+ "sshd_scp_fail.sh"
  "sshd_term_close_test.sh"
  "ssh_kex_algos.sh"
 )

--- a/apps/wolfsshd/test/sshd_scp_fail.sh
+++ b/apps/wolfsshd/test/sshd_scp_fail.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# sshd local test
+
+PWD=`pwd`
+cd ../../..
+
+TEST_SCP_CLIENT="./examples/scpclient/wolfscp"
+USER=`whoami`
+PRIVATE_KEY="./keys/hansel-key-ecc.der"
+PUBLIC_KEY="./keys/hansel-key-ecc.pub"
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "expecting host and port as arguments"
+    echo "./sshd_exec_test.sh 127.0.0.1 22222"
+    exit 1
+fi
+
+mkdir test-$$
+
+OUTDIR="`pwd`/test-$$"
+
+dd if=/dev/random of=$OUTDIR/test.dat bs=1024 count=512
+
+echo "$TEST_SCP_CLIENT -u $USER -i $PRIVATE_KEY -j $PUBLIC_KEY -S$OUTDIR/test.dat:. -H $1 -p $2"
+$TEST_SCP_CLIENT -u $USER -i $PRIVATE_KEY -j $PUBLIC_KEY -S$OUTDIR/test.dat:. -H $1 -p $2
+
+RESULT=$?
+if [ "$RESULT" != "0" ]; then
+    echo "Expecting to pass transfer"
+    exit 1
+fi
+
+MD5SOURCE=`md5sum $OUTDIR/test.dat | awk '{ print $1 }'`
+MD5DEST=`md5sum test.dat | awk '{ print $1 }'`
+
+if [ "$MD5SOURCE" != "$MD5DEST" ]; then
+    echo "Files do not match $MD5SOURCE != $MD5DEST"
+    exit 1
+fi
+
+rm -rf test-$$
+rm testout.dat
+
+cd $PWD
+exit 0
+

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -344,7 +344,7 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
     wc_ecc_fp_free();  /* free per thread cache */
 #endif
 
-    if (ret != WS_SUCCESS)
+    if ((ret != WS_SUCCESS) && (ret != WS_CHANNEL_CLOSED))
         ((func_args*)args)->return_code = 1;
     return 0;
 }


### PR DESCRIPTION
SCP on the server side would get an EAGAIN around the 128KB mark, which would trigger an error. That error in-turn would cause two attempts to close the file, which would segfault.

Also fix inverted error return status on scpclient.