### PR TITLE
Fix SFTP Symlink Indication

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -2612,10 +2612,10 @@ static int SFTP_CreateLongName(WS_SFTPNAME* name)
         word32 tmp = atr->per;
 
         i = 0;
-        if (tmp & FILEATRB_PER_DIR) {
+        if ((tmp & FILEATRB_PER_MASK_TYPE) == FILEATRB_PER_DIR) {
             perm[i++] = 'd';
         }
-        else if (tmp & FILEATRB_PER_LINK) {
+        else if ((tmp & FILEATRB_PER_MASK_TYPE) == FILEATRB_PER_LINK) {
             perm[i++] = 'l';
         }
         else {


### PR DESCRIPTION
When connecting to the wolfSSH SFTP server, running the command `ls -l` shows all regular files as symlinks. This patch fixes the check for files being symlinks or not and update their indication in the longname.

(ZD 19554)