### PR TITLE
Keyboard Interactive bug fixes

### DIFF
--- a/tests/auth.c
+++ b/tests/auth.c
@@ -586,6 +586,11 @@ int wolfSSH_AuthTest(int argc, char** argv)
     defined(NO_FILESYSTEM) || !defined(WOLFSSH_KEYBOARD_INTERACTIVE)
     return 77;
 #else
+
+#if defined(DEBUG_WOLFSSH)
+    wolfSSH_Debugging_ON();
+#endif
+
     AssertIntEQ(wolfSSH_Init(), WS_SUCCESS);
 
     #if defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,2)


### PR DESCRIPTION
* `keyboardAuthCb` was not initalized correctly, meaning we could enable the mode without callback.
* `SendUserAuthKeyboardRequest` didn't check `keyboardAuthCb` for `NULL`.
* `DoUserAuthInfoResponse` left `authData` partially uninitialized.
* `DoUserAuthInfoResponse` new checks that KB auth is in progress.