### PR TITLE
Soft Disable AES-CBC

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -126,7 +126,8 @@ static void ShowUsage(void)
     printf(" -X            Ignore IP checks on peer vs peer certificate\n");
 #endif
     printf(" -E            List all possible algos\n");
-    printf(" -k            set the list of key algos to use\n");
+    printf(" -k            set the list of key algos\n");
+    printf(" -C            set the list of encrypt algos\n");
     printf(" -q            turn off debugging output\n");
 }
 
@@ -651,6 +652,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     const char* cmd      = NULL;
     const char* privKeyName = NULL;
     const char* keyList = NULL;
+    const char* cipherList = NULL;
     byte imExit = 0;
     byte listAlgos = 0;
     byte nonBlock = 0;
@@ -669,7 +671,7 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
 
     (void)keepOpen;
 
-    while ((ch = mygetopt(argc, argv, "?ac:h:i:j:p:tu:xzNP:RJ:A:XeEk:qK:")) != -1) {
+    while ((ch = mygetopt(argc, argv, "?ac:C:h:i:j:p:tu:xzNP:RJ:A:XeEk:qK:")) != -1) {
         switch (ch) {
             case 'h':
                 host = myoptarg;
@@ -748,6 +750,10 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
 
             case 'k':
                 keyList = myoptarg;
+                break;
+
+            case 'C':
+                cipherList = myoptarg;
                 break;
 
         #if !defined(SINGLE_THREADED) && !defined(WOLFSSL_NUCLEUS)
@@ -839,6 +845,11 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
     if (keyList) {
         if (wolfSSH_CTX_SetAlgoListKey(ctx, NULL) != WS_SUCCESS) {
             err_sys("Error setting key list.\n");
+        }
+    }
+    if (cipherList) {
+        if (wolfSSH_CTX_SetAlgoListCipher(ctx, cipherList) != WS_SUCCESS) {
+            err_sys("Error setting cipher list.\n");
         }
     }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -147,6 +147,11 @@ Flags:
   WOLFSSH_NO_NISTP256_MLKEM768_SHA256
     Set when ML-KEM is disabled in wolfssl. Set to disable use of ECDHE with
     prime NISTP256 hybridized with post-quantum ML-KEM 768.
+  WOLFSSH_NO_AES_CBC_SOFT_DISABLE
+    AES-CBC is normally soft-disabled. The default configuration will not
+    advertise the availability of AES-CBC algorithms during KEX. AES-CBC
+    algorithms still work. Setting this flag will advertise AES-CBC
+    algorithms during KEX by default.
   WOLFSSH_NO_AES_CBC
     Set when AES or AES-CBC are disabled. Set to disable use of AES-CBC
     encryption.
@@ -803,7 +808,7 @@ static const char cannedEncAlgoNames[] =
     "aes192-ctr,"
     "aes128-ctr,"
 #endif
-#if !defined(WOLFSSH_NO_AES_CBC)
+#if !defined(WOLFSSH_NO_AES_CBC) && defined(WOLFSSH_NO_AES_CBC_SOFT_DISABLE)
     "aes256-cbc,"
     "aes192-cbc,"
     "aes128-cbc,"


### PR DESCRIPTION
1. By default, soft disable AES-CBC. It isn't offered as a default encrypt algorithm, but may be set at runtime.
2. Add guard where AES-CBC can be added back as a default.
3. Add option to example client to run it with a custom encrypt algorithm list.
4. In the client, add macro to add items to the arg lists while checking the number of items in the list.
(ZD 19606)