### PR TITLE
DoAsn1Key now fails when WOLFSSH_NO_RSA is defined

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1737,6 +1737,7 @@ static int DoAsn1Key(const byte* in, word32 inSz, byte** out,
     }
 
     if (ret > 0 && !isPrivate) {
+#ifndef WOLFSSH_NO_RSA
         long e;
         byte n[RSA_MAX_SIZE]; /* TODO: Handle small stack */
         word32 nSz = (word32)sizeof(n), eSz = (word32)sizeof(e);
@@ -1785,6 +1786,10 @@ static int DoAsn1Key(const byte* in, word32 inSz, byte** out,
 
             *out = newKey;
         }
+#else
+        WLOG(WS_LOG_DEBUG, "DoAsn1Key failed; WOLFSSH_NO_RSA disabled RSA");
+        ret = WS_UNIMPLEMENTED_E;
+#endif
     }
     else if (ret > 0 && isPrivate) {
         if (*out == NULL) {


### PR DESCRIPTION
Updates `ssh.c` to fix compile-time error when RSA is disabled.

Without this fix, this line in `DoAsn1Key()`:

```
        ret = wc_RsaFlattenPublicKey(&key->ks.rsa.key, (byte*)&e, &eSz, n, &nSz);
```

fails to compile as there's no `.rsa.key` member property:

```
Severity Description                                   Project                File                                         Line
Error    'union <anonymous>' has no member named 'rsa' wolfssl_IDF_v5.2_ESP32 C:\workspace\wolfssh-master-update\src\ssh.c 1751
```

With this  PR, the code compiles and exits `IdentifyAsn1Key()` with error code `WS_RSA_E` and a message when debugging is enabled.

