### PR TITLE
Disable old threading functions when SINGLE_THREADED

### DIFF
--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -949,7 +949,8 @@ static INLINE void WaitTcpReady(tcp_ready* ready)
 #ifdef WOLFSSH_TEST_THREADING
 
 
-#if !defined(WOLFSSH_OLD_THREADING) && !defined(WOLFSSH_OLDER_THREADING)
+#if !defined(WOLFSSH_OLD_THREADING) && !defined(WOLFSSH_OLDER_THREADING) && \
+    !defined(SINGLE_THREADED)
 
 static INLINE void ThreadStart(THREAD_CB fun, void* args, THREAD_TYPE* thread)
 {


### PR DESCRIPTION
Related to my upcoming Espressif changes: the old threading functions, when enabled, encounter a compile-time error if `SINGLE_THREADED` is enabled.

See also https://github.com/wolfSSL/wolfssh/pull/770, pulled out here as a separate topic.