### PR TITLE
Ensure workflows only run for wolfssl repository_owne

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   run_cppcheck:
     name: Cppcheck
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/kyber.yml
+++ b/.github/workflows/kyber.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build_liboqs:
     name: Build liboqs
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
@@ -45,6 +46,7 @@ jobs:
 
   build_wolfssl:
     name: Build wolfssl
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
@@ -69,6 +71,7 @@ jobs:
 
   build_wolfssh:
     name: Build wolfssh
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     timeout-minutes: 4
     needs: [build_wolfssl, build_liboqs]

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   create_matrix:
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     outputs:
         versions: ${{ steps.json.outputs.versions }}
@@ -33,6 +34,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         wolfssl: ${{ fromJson(needs.create_matrix.outputs['versions']) }}
     name: Build wolfssl
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 4
     steps:
@@ -76,6 +78,7 @@ jobs:
           '--enable-shell',
         ]
     name: Build wolfssh
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 4
     steps:

--- a/.github/workflows/paramiko-sftp-test.yml
+++ b/.github/workflows/paramiko-sftp-test.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   build_wolfssl:
     name: Build wolfssl
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
@@ -38,6 +39,7 @@ jobs:
   paramiko_sftp_test:
     needs: build_wolfssl
     name: Paramiko SFTP Test
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/scp-test.yml
+++ b/.github/workflows/scp-test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   create_matrix:
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     outputs:
         versions: ${{ steps.json.outputs.versions }}
@@ -33,6 +34,7 @@ jobs:
         os: [ ubuntu-latest ]
         wolfssl: ${{ fromJson(needs.create_matrix.outputs['versions']) }}
     name: Build wolfssl
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 4
     steps:
@@ -65,6 +67,7 @@ jobs:
         os: [ ubuntu-latest ]
         wolfssl: ${{ fromJson(needs.create_matrix.outputs['versions']) }}
     name: Build and test wolfsshd
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/sftp-test.yml
+++ b/.github/workflows/sftp-test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   create_matrix:
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     outputs:
         versions: ${{ steps.json.outputs.versions }}
@@ -33,6 +34,7 @@ jobs:
         os: [ ubuntu-latest ]
         wolfssl: ${{ fromJson(needs.create_matrix.outputs['versions']) }}
     name: Build wolfssl
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 4
     steps:
@@ -65,6 +67,7 @@ jobs:
         os: [ ubuntu-latest ]
         wolfssl: ${{ fromJson(needs.create_matrix.outputs['versions']) }}
     name: Build and test wolfsftp
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/singlethread-check.yml
+++ b/.github/workflows/singlethread-check.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     name: Build wolfssl
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 4
     steps:
@@ -55,6 +56,7 @@ jobs:
           '--enable-shell',
         ]
     name: Build wolfssh
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 4
     needs: build_wolfssl

--- a/.github/workflows/sshd-test.yml
+++ b/.github/workflows/sshd-test.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   create_matrix:
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     outputs:
         versions: ${{ steps.json.outputs.versions }}
@@ -33,6 +34,7 @@ jobs:
         os: [ ubuntu-latest ]
         wolfssl: ${{ fromJson(needs.create_matrix.outputs['versions']) }}
     name: Build wolfssl
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 4
     steps:
@@ -65,6 +67,7 @@ jobs:
         os: [ ubuntu-latest ]
         wolfssl: ${{ fromJson(needs.create_matrix.outputs['versions']) }}
     name: Build and test wolfsshd
+    if: github.repository_owner == 'wolfssl'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/test-fatfs.yml
+++ b/.github/workflows/test-fatfs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   get-fatfs:
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     steps:
       - name: Set up cache key
@@ -30,6 +31,7 @@ jobs:
 
   test-fatfs:
     needs: get-fatfs
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/tpm-ssh.yml
+++ b/.github/workflows/tpm-ssh.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test-tpm-ssh:
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: github.repository_owner == 'wolfssl'
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -14,6 +14,7 @@ jobs:
         config:
           - zephyr-ref: v3.4.0
             zephyr-sdk: 0.16.1
+    if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-22.04
     # This should be a safe limit for the tests to run.
     timeout-minutes: 20


### PR DESCRIPTION
# Description

Same as https://github.com/wolfSSL/wolfssl/pull/8936, but for wolfSSH:

Continues the pattern of running [wolfssl GitHub workflows](https://github.com/wolfSSL/wolfssl/tree/master/.github/workflows) only on wolfssl repository owner:

```
    if: github.repository_owner == 'wolfssl'
    runs-on: 
```

At one point, it was only annoying when some of the job would fail in my fork.

While viewing my [GitHub Billing](https://github.com/settings/billing), I noticed a recent increase in "charges" related to workflows that run on my fork of wolfssl when I add commits.

I'm not sure if this is a new feature, perhaps something coming soon, that might have an adverse affect on forks that do not have free tiers. In any case, it is a waste of computing resources to blindly run all of the workflows in a fork. 

If desired, they can be manually enabled.

See also: https://github.com/wolfSSL/wolfssl/pull/7871


![image](https://github.com/user-attachments/assets/3681818e-4193-44a0-8409-4c96f2b8c9c2)


Fixes zd# n/a

# Testing

How did you test?

"tested" on my branch only (to confirm the workflows didn't run)

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
