### PR TITLE
Simplify Test Build Flags

### DIFF
--- a/examples/echoserver/include.am
+++ b/examples/echoserver/include.am
@@ -7,5 +7,4 @@ examples_echoserver_echoserver_SOURCES      = examples/echoserver/echoserver.c \
                                               examples/echoserver/echoserver.h
 examples_echoserver_echoserver_LDADD        = src/libwolfssh.la
 examples_echoserver_echoserver_DEPENDENCIES = src/libwolfssh.la
-examples_echoserver_echoserver_CFLAGS       = $(AM_CFLAGS) ${AM_CPPFLAGS}
 endif

--- a/tests/include.am
+++ b/tests/include.am
@@ -6,67 +6,13 @@ check_PROGRAMS  += tests/unit.test tests/api.test \
                    tests/testsuite.test tests/kex.test
 
 tests_unit_test_SOURCES      = tests/unit.c tests/unit.h
-tests_unit_test_CPPFLAGS     = -DNO_MAIN_DRIVER
-if BUILD_KEYGEN
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_KEYGEN
-endif
-if BUILD_SCP
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_SCP
-endif
-if BUILD_SFTP
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_SFTP
-endif
-if BUILD_TERM
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_TERM
-endif
-if BUILD_SHELL
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_SHELL
-endif
-if BUILD_AGENT
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_AGENT
-endif
-if BUILD_FWD
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_FWD
-endif
-if BUILD_CERTS
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_CERTS
-endif
-if BUILD_KEYBOARD_INTERACTIVE
-tests_unit_test_CPPFLAGS     += -DWOLFSSH_KEYBOARD_INTERACTIVE
-endif
+tests_unit_test_CPPFLAGS     = -DNO_MAIN_DRIVER $(AM_CPPFLAGS)
 tests_unit_test_LDADD        = src/libwolfssh.la
 tests_unit_test_DEPENDENCIES = src/libwolfssh.la
 
 tests_api_test_SOURCES       = tests/api.c tests/api.h \
                                examples/echoserver/echoserver.c
-tests_api_test_CPPFLAGS      = -DNO_MAIN_DRIVER
-if BUILD_KEYGEN
-tests_api_test_CPPFLAGS     += -DWOLFSSH_KEYGEN
-endif
-if BUILD_SCP
-tests_api_test_CPPFLAGS     += -DWOLFSSH_SCP
-endif
-if BUILD_SFTP
-tests_api_test_CPPFLAGS     += -DWOLFSSH_SFTP
-endif
-if BUILD_TERM
-tests_api_test_CPPFLAGS     += -DWOLFSSH_TERM
-endif
-if BUILD_SHELL
-tests_api_test_CPPFLAGS     += -DWOLFSSH_SHELL
-endif
-if BUILD_AGENT
-tests_api_test_CPPFLAGS     += -DWOLFSSH_AGENT
-endif
-if BUILD_FWD
-tests_api_test_CPPFLAGS     += -DWOLFSSH_FWD
-endif
-if BUILD_CERTS
-tests_api_test_CPPFLAGS     += -DWOLFSSH_CERTS
-endif
-if BUILD_KEYBOARD_INTERACTIVE
-tests_api_test_CPPFLAGS     += -DWOLFSSH_KEYBOARD_INTERACTIVE
-endif
+tests_api_test_CPPFLAGS      = -DNO_MAIN_DRIVER $(AM_CPPFLAGS)
 tests_api_test_LDADD         = src/libwolfssh.la
 tests_api_test_DEPENDENCIES  = src/libwolfssh.la
 
@@ -77,65 +23,14 @@ tests_testsuite_test_SOURCES = tests/testsuite.c tests/testsuite.h \
                                examples/client/common.c \
                                examples/client/common.h \
                                examples/sftpclient/sftpclient.c
-tests_testsuite_test_CPPFLAGS  = -DNO_MAIN_DRIVER
-if BUILD_KEYGEN
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_KEYGEN
-endif
-if BUILD_SCP
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_SCP
-endif
-if BUILD_SFTP
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_SFTP
-endif
-if BUILD_TERM
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_TERM
-endif
-if BUILD_SHELL
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_SHELL
-endif
-if BUILD_AGENT
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_AGENT
-endif
-if BUILD_FWD
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_FWD
-endif
-if BUILD_CERTS
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_CERTS
-endif
-if BUILD_KEYBOARD_INTERACTIVE
-tests_testsuite_test_CPPFLAGS     += -DWOLFSSH_KEYBOARD_INTERACTIVE
-endif
+tests_testsuite_test_CPPFLAGS = -DNO_MAIN_DRIVER $(AM_CPPFLAGS)
 tests_testsuite_test_LDADD   = src/libwolfssh.la
 tests_testsuite_test_DEPENDENCIES = src/libwolfssh.la
 
 if BUILD_KEYBOARD_INTERACTIVE
 check_PROGRAMS              += tests/auth.test
 tests_auth_test_SOURCES      = tests/auth.c tests/auth.h
-tests_auth_test_CPPFLAGS     = -DNO_MAIN_DRIVER -DWOLFSSH_KEYBOARD_INTERACTIVE
-if BUILD_KEYGEN
-tests_auth_test_CPPFLAGS    += -DWOLFSSH_KEYGEN
-endif
-if BUILD_SCP
-tests_auth_test_CPPFLAGS    += -DWOLFSSH_SCP
-endif
-if BUILD_SFTP
-tests_auth_test_CPPFLAGS    += -DWOLFSSH_SFTP
-endif
-if BUILD_TERM
-tests_auth_test_CPPFLAGS    += -DWOLFSSH_TERM
-endif
-if BUILD_SHELL
-tests_auth_test_CPPFLAGS    += -DWOLFSSH_SHELL
-endif
-if BUILD_AGENT
-tests_auth_test_CPPFLAGS    += -DWOLFSSH_AGENT
-endif
-if BUILD_FWD
-tests_auth_test_CPPFLAGS    += -DWOLFSSH_FWD
-endif
-if BUILD_CERTS
-tests_auth_test_CPPFLAGS    += -DWOLFSSH_CERTS
-endif
+tests_auth_test_CPPFLAGS     = -DNO_MAIN_DRIVER $(AM_CPPFLAGS)
 tests_auth_test_LDADD        = src/libwolfssh.la
 tests_auth_test_DEPENDENCIES = src/libwolfssh.la
 endif
@@ -145,33 +40,6 @@ tests_kex_test_SOURCES = tests/kex.c tests/kex.h \
                                examples/client/client.c \
                                examples/client/common.c \
                                examples/client/common.h
-tests_kex_test_CPPFLAGS  = -DNO_MAIN_DRIVER
-if BUILD_KEYGEN
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_KEYGEN
-endif
-if BUILD_SCP
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_SCP
-endif
-if BUILD_SFTP
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_SFTP
-endif
-if BUILD_TERM
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_TERM
-endif
-if BUILD_SHELL
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_SHELL
-endif
-if BUILD_AGENT
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_AGENT
-endif
-if BUILD_FWD
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_FWD
-endif
-if BUILD_CERTS
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_CERTS
-endif
-if BUILD_KEYBOARD_INTERACTIVE
-tests_kex_test_CPPFLAGS     += -DWOLFSSH_KEYBOARD_INTERACTIVE
-endif
+tests_kex_test_CPPFLAGS = -DNO_MAIN_DRIVER $(AM_CPPFLAGS)
 tests_kex_test_LDADD   = src/libwolfssh.la
 tests_kex_test_DEPENDENCIES = src/libwolfssh.la

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -1490,6 +1490,15 @@ extern "C" {
 #endif
 #endif /* WOLFSSH_SFTP or WOLFSSH_SCP */
 
+#ifndef WS_MAYBE_UNUSED
+    #if (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__) || \
+            defined(__IAR_SYSTEMS_ICC__)
+        #define WS_MAYBE_UNUSED __attribute__((unused))
+    #else
+        #define WS_MAYBE_UNUSED
+    #endif
+#endif /* WS_MAYBE_UNUSED */
+
 /* setup compiler inlining */
 #ifndef INLINE
 #ifndef NO_INLINE
@@ -1502,10 +1511,10 @@ extern "C" {
     #elif defined(THREADX)
         #define INLINE _Inline
     #else
-        #define INLINE
+        #define INLINE WS_MAYBE_UNUSED
     #endif
 #else
-    #define INLINE
+    #define INLINE WS_MAYBE_UNUSED
 #endif
 #endif /* INLINE */
 

--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -962,13 +962,6 @@ static INLINE void ThreadJoin(THREAD_TYPE thread)
     (void)wolfSSL_JoinThread(thread);
 }
 
-#ifdef WOLFSSL_THREAD_NO_JOIN
-static INLINE void ThreadStartNoJoin(THREAD_CB fun, void* args)
-{
-    (void)wolfSSL_NewThreadNoJoin(fun, args);
-}
-#endif
-
 #else
 typedef THREAD_RETURN (WOLFSSH_THREAD *THREAD_FUNC)(void*);
 
@@ -1066,13 +1059,6 @@ static INLINE void ThreadDetach(THREAD_TYPE thread)
 #else
     (void)thread;
 #endif
-}
-
-static INLINE void ThreadStartNoJoin(THREAD_FUNC fun, void* args)
-{
-    THREAD_TYPE thread;
-    ThreadStart(fun, args, &thread);
-    ThreadDetach(thread);
 }
 
 #endif /* !WOLFSSH_OLD_THREADING && !WOLFSSH_OLDER_THREADING */


### PR DESCRIPTION
Modify all the test executable CPPFLAGS to only have `-DNO_MAIN_LOOP` and `AM_CPPFLAGS`. This removes a lot of duplicate setup of flags for each of the tests. Cleanup the fallout from that when disabling inlining.