### PR TITLE
Fixing a batch of issues reported by Coverity

### DIFF
--- a/apps/wolfssh/common.c
+++ b/apps/wolfssh/common.c
@@ -76,7 +76,7 @@ static int load_der_file(const char* filename, byte** out, word32* outSz)
 {
     WFILE* file;
     byte* in;
-    word32 inSz;
+    long inSz;
     int ret;
 
     if (filename == NULL || out == NULL || outSz == NULL)
@@ -90,10 +90,10 @@ static int load_der_file(const char* filename, byte** out, word32* outSz)
         WFCLOSE(NULL, file);
         return -1;
     }
-    inSz = (word32)WFTELL(NULL, file);
+    inSz = WFTELL(NULL, file);
     WREWIND(NULL, file);
 
-    if (inSz == 0) {
+    if (inSz <= 0) {
         WFCLOSE(NULL, file);
         return -1;
     }
@@ -105,7 +105,7 @@ static int load_der_file(const char* filename, byte** out, word32* outSz)
     }
 
     ret = (int)WFREAD(NULL, in, 1, inSz, file);
-    if (ret <= 0 || (word32)ret != inSz) {
+    if (ret <= 0 || ret != inSz) {
         ret = -1;
         WFREE(in, NULL, 0);
         in = 0;
@@ -115,7 +115,7 @@ static int load_der_file(const char* filename, byte** out, word32* outSz)
         ret = 0;
 
     *out = in;
-    *outSz = inSz;
+    *outSz = (word32)inSz;
 
     WFCLOSE(NULL, file);
 

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -242,7 +242,7 @@ static byte* getBufferFromFile(const char* fileName, word32* bufSz, void* heap)
 {
     FILE* file;
     byte* buf = NULL;
-    word32 fileSz;
+    long fileSz;
     word32 readSz;
 
     WOLFSSH_UNUSED(heap);
@@ -252,13 +252,17 @@ static byte* getBufferFromFile(const char* fileName, word32* bufSz, void* heap)
     if (WFOPEN(NULL, &file, fileName, "rb") != 0)
         return NULL;
     WFSEEK(NULL, file, 0, WSEEK_END);
-    fileSz = (word32)WFTELL(NULL, file);
+    fileSz = WFTELL(NULL, file);
+    if (fileSz < 0) {
+        WFCLOSE(NULL, file);
+        return NULL;
+    }
     WREWIND(NULL, file);
 
     buf = (byte*)WMALLOC(fileSz + 1, heap, DYNTYPE_SSHD);
     if (buf != NULL) {
         readSz = (word32)WFREAD(NULL, buf, 1, fileSz, file);
-        if (readSz < fileSz) {
+        if (readSz < (size_t)fileSz) {
             WFCLOSE(NULL, file);
             WFREE(buf, heap, DYNTYPE_SSHD);
             return NULL;

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1347,20 +1347,18 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
         setenv("LOGNAME", pPasswd->pw_name, 1);
         setenv("SHELL", pPasswd->pw_shell, 1);
 
-        if (pPasswd->pw_shell) {
-            if (WSTRLEN(pPasswd->pw_shell) < sizeof(shell)) {
-                char* cursor;
-                char* start;
+        if (WSTRLEN(pPasswd->pw_shell) < sizeof(shell)) {
+            char* cursor;
+            char* start;
 
-                WSTRNCPY(shell, pPasswd->pw_shell, sizeof(shell));
-                cursor = shell;
-                do {
-                    start = cursor;
-                    *cursor = '-';
-                    cursor = WSTRCHR(start, '/');
-                } while (cursor && *cursor != '\0');
-                args[0] = start;
-            }
+            WSTRNCPY(shell, pPasswd->pw_shell, sizeof(shell));
+            cursor = shell;
+            do {
+                start = cursor;
+                *cursor = '-';
+                cursor = WSTRCHR(start, '/');
+            } while (cursor && *cursor != '\0');
+            args[0] = start;
         }
 
         rc = chdir(pPasswd->pw_dir);

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1351,7 +1351,8 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
             char* cursor;
             char* start;
 
-            WSTRNCPY(shell, pPasswd->pw_shell, sizeof(shell));
+            WSTRNCPY(shell, pPasswd->pw_shell, sizeof(shell)-1);
+            shell[sizeof(shell)-1] = 0;
             cursor = shell;
             do {
                 start = cursor;

--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -262,7 +262,7 @@ static int load_der_file(const char* filename, byte** out, word32* outSz,
 {
     WFILE* file;
     byte* in;
-    word32 inSz;
+    long inSz;
     int ret;
 
     if (filename == NULL || out == NULL || outSz == NULL)
@@ -276,13 +276,12 @@ static int load_der_file(const char* filename, byte** out, word32* outSz,
         WFCLOSE(NULL, file);
         return -1;
     }
-    inSz = (word32)WFTELL(NULL, file);
-    WREWIND(NULL, file);
-
-    if (inSz == 0) {
+    inSz = WFTELL(NULL, file);
+    if (inSz <= 0) {
         WFCLOSE(NULL, file);
         return -1;
     }
+    WREWIND(NULL, file);
 
     in = (byte*)WMALLOC(inSz, heap, 0);
     if (in == NULL) {
@@ -291,7 +290,7 @@ static int load_der_file(const char* filename, byte** out, word32* outSz,
     }
 
     ret = (int)WFREAD(NULL, in, 1, inSz, file);
-    if (ret <= 0 || (word32)ret != inSz) {
+    if (ret <= 0 || ret != inSz) {
         ret = -1;
         WFREE(in, heap, 0);
         in = 0;
@@ -301,7 +300,7 @@ static int load_der_file(const char* filename, byte** out, word32* outSz,
         ret = 0;
 
     *out = in;
-    *outSz = inSz;
+    *outSz = (word32)inSz;
 
     WFCLOSE(NULL, file);
 

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -249,8 +249,14 @@ static void sig_handler(const int sig)
 static void clean_path(char* path)
 {
     int  i;
-    long sz = (long)WSTRLEN(path);
+    long sz;
     byte found;
+
+    if (path == NULL) {
+        return;
+    }
+
+    sz = (long)WSTRLEN(path);
 
     /* remove any double '/' chars */
     for (i = 0; i < sz; i++) {
@@ -272,51 +278,49 @@ static void clean_path(char* path)
         }
     }
 
-    if (path != NULL) {
-        /* go through path until no cases are found */
-        do {
-            int prIdx = 0; /* begin of cut */
-            int enIdx = 0; /* end of cut */
-            sz = (long)WSTRLEN(path);
+    /* go through path until no cases are found */
+    do {
+        int prIdx = 0; /* begin of cut */
+        int enIdx = 0; /* end of cut */
+        sz = (long)WSTRLEN(path);
 
-            found = 0;
-            for (i = 0; i < sz; i++) {
-                if (path[i] == '/') {
-                    int z;
+        found = 0;
+        for (i = 0; i < sz; i++) {
+            if (path[i] == '/') {
+                int z;
 
-                    /* if next two chars are .. then delete */
-                    if (path[i+1] == '.' && path[i+2] == '.') {
-                        enIdx = i + 3;
+                /* if next two chars are .. then delete */
+                if (path[i+1] == '.' && path[i+2] == '.') {
+                    enIdx = i + 3;
 
-                        /* start at one char before / and retrace path */
-                        for (z = i - 1; z > 0; z--) {
-                            if (path[z] == '/') {
-                                prIdx = z;
-                                break;
-                            }
+                    /* start at one char before / and retrace path */
+                    for (z = i - 1; z > 0; z--) {
+                        if (path[z] == '/') {
+                            prIdx = z;
+                            break;
                         }
-
-                        /* cut out .. and previous */
-                        WMEMMOVE(path + prIdx, path + enIdx, sz - enIdx);
-                        path[sz - (enIdx - prIdx)] = '\0';
-
-                        if (enIdx == sz) {
-                            path[prIdx] = '\0';
-                        }
-
-                        /* case of at / */
-                        if (WSTRLEN(path) == 0) {
-                           path[0] = '/';
-                           path[1] = '\0';
-                        }
-
-                        found = 1;
-                        break;
                     }
+
+                    /* cut out .. and previous */
+                    WMEMMOVE(path + prIdx, path + enIdx, sz - enIdx);
+                    path[sz - (enIdx - prIdx)] = '\0';
+
+                    if (enIdx == sz) {
+                        path[prIdx] = '\0';
+                    }
+
+                    /* case of at / */
+                    if (WSTRLEN(path) == 0) {
+                       path[0] = '/';
+                       path[1] = '\0';
+                    }
+
+                    found = 1;
+                    break;
                 }
             }
-        } while (found);
-    }
+        }
+    } while (found);
 }
 
 #define WS_MAX_EXAMPLE_RW 1024

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1658,9 +1658,13 @@ static int DoSshPubKey(const byte* in, word32 inSz, byte** out,
     /*
        SSH format is:
        type AAAABASE64ENCODEDKEYDATA comment
+
+       allocate a copy to tokenize, add a null terminator.
     */
-    c = WSTRDUP((const char*)in, heap, DYNTYPE_STRING);
+    c = (char*)WMALLOC(inSz + 1, heap, DYNTYPE_STRING);
     if (c != NULL) {
+        WMEMCPY(c, in, inSz);
+        c[inSz-1] = 0;
         type = WSTRTOK(c, " \n", &last);
         key = WSTRTOK(NULL, " \n", &last);
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -504,26 +504,38 @@ static int load_file(const char* filename, byte** buf, word32* bufSz)
     }
 
     if (ret == 0) {
-        fseek(f, 0, XSEEK_END);
-        *bufSz = (word32)ftell(f);
-        rewind(f);
-    }
-
-    if (ret == 0) {
-        *buf = (byte*)malloc(*bufSz);
-        if (*buf == NULL)
+        ret = fseek(f, 0, XSEEK_END);
+        if (ret < 0)
             ret = -3;
     }
 
     if (ret == 0) {
-        int readSz;
-        readSz = (int)fread(*buf, 1, *bufSz, f);
-        if (readSz < (int)*bufSz)
+        long sz = ftell(f);
+        if (sz < 0)
             ret = -4;
+        else
+            *bufSz = (word32)sz;
     }
 
-    if (f != NULL)
-        fclose(f);
+    if (ret == 0) {
+        rewind(f);
+        *buf = (byte*)malloc(*bufSz);
+        if (*buf == NULL)
+            ret = -5;
+    }
+
+    if (ret == 0) {
+        size_t readSz;
+        readSz = fread(*buf, 1, *bufSz, f);
+        if (readSz < *bufSz)
+            ret = -6;
+    }
+
+    if (f != NULL) {
+        ret = fclose(f);
+        if (ret < 0)
+            ret = -7;
+    }
 
     return ret;
 }


### PR DESCRIPTION
1. String not null terminated: 572834
2. Dereference before null check: 572919 572847
3. Buffer not null terminated: 572891
4. Argument cannot be negative: 573009 572928 572868