### PR TITLE
Zendesk Coverity changes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -15120,7 +15120,7 @@ static int GetAllowedAuth(WOLFSSH* ssh, char* authStr)
 
     typeAllowed |= WOLFSSH_USERAUTH_PASSWORD;
 #ifdef WOLFSSH_KEYBOARD_INTERACTIVE
-    if (ssh->ctx->keyboardAuthCb != NULL) {
+    if (ssh->ctx && ssh->ctx->keyboardAuthCb) {
         typeAllowed |= WOLFSSH_USERAUTH_KEYBOARD;
     }
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -3988,6 +3988,9 @@ static word32 AlgoListSz(const char* algoList)
 {
     word32 algoListSz;
 
+    if (algoList == NULL)
+        return 0;
+
     algoListSz = (word32)WSTRLEN(algoList);
     if (algoList[algoListSz-1] == ',') {
         --algoListSz;


### PR DESCRIPTION
Adds NULL checks to clear Coverity issues reported in ZD#20212.

- Dereference before NULL check
    - check `ssh->ctx != NULL` before dereferencing in `GetAllowedAuth()` (wolfSSH Project **572900**)
- Dereference after NULL check
    - Add additional NULL checks as `SendUserAuthKeyboardRequest()` does not return immediately if `ssh` or `authData` are NULL (wolfSSH Project **CI 572871** and **CI 572874**)
    - `AlgoListSz()` returns 0 if param is NULL (wolfSSH Project **572893**)