### PR TITLE
Add ED25519 key generation support.

### DIFF
--- a/tests/unit.c
+++ b/tests/unit.c
@@ -265,6 +265,23 @@ static int test_EcdsaKeyGen(void)
 }
 #endif
 
+#ifndef WOLFSSH_NO_ED25519
+static int test_Ed25519KeyGen(void)
+{
+    int result = 0;
+    byte der[1200];
+    int derSz;
+
+    derSz = wolfSSH_MakeEd25519Key(der, sizeof(der), WOLFSSH_ED25519KEY);
+    if (derSz < 0) {
+        printf("Ed25519KeyGen: MakeEd25519Key failed\n");
+        result = -105;
+    }
+
+    return result;
+}
+#endif
+
 #endif
 
 
@@ -348,6 +365,11 @@ int wolfSSH_UnitTest(int argc, char** argv)
 #ifndef WOLFSSH_NO_ECDSA
     unitResult = test_EcdsaKeyGen();
     printf("EcdsaKeyGen: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));
+    testResult = testResult || unitResult;
+#endif
+#ifndef WOLFSSH_NO_ED25519
+    unitResult = test_Ed25519KeyGen();
+    printf("Ed25519KeyGen: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));
     testResult = testResult || unitResult;
 #endif
 #endif

--- a/wolfssh/keygen.h
+++ b/wolfssh/keygen.h
@@ -41,11 +41,13 @@ extern "C" {
 #define WOLFSSH_ECDSAKEY_PRIME256 256
 #define WOLFSSH_ECDSAKEY_PRIME384 384
 #define WOLFSSH_ECDSAKEY_PRIME521 521
+#define WOLFSSH_ED25519KEY        256
 
 
 WOLFSSH_API int wolfSSH_MakeRsaKey(byte* out, word32 outSz,
         word32 size, word32 e);
 WOLFSSH_API int wolfSSH_MakeEcdsaKey(byte* out, word32 outSz, word32 size);
+WOLFSSH_API int wolfSSH_MakeEd25519Key(byte* out, word32 outSz, word32 size);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add new _wolfSSH_MakeEd25519Key()_ function for generating ED25519 keys.  This follows conventions used in existing _wolfSSH_MakeEcdsaKey()_ function.