### PR TITLE
Fix "rejected" authentication in DoUserAuthRequestPublicKey()

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7585,12 +7585,12 @@ static int DoUserAuthRequestPublicKey(WOLFSSH* ssh, WS_UserAuthData* authData,
             if (ret == WOLFSSH_USERAUTH_WOULD_BLOCK) {
                 ret = WS_AUTH_PENDING;
             }
-	    else if (ret == WOLFSSH_USERAUTH_REJECTED) {
+            else if (ret == WOLFSSH_USERAUTH_REJECTED) {
                 #ifndef NO_FAILURE_ON_REJECTED
-		    authFailure = 1;
+                    authFailure = 1;
                 #endif
-		ret = WS_USER_AUTH_E;
-	    }
+                ret = WS_USER_AUTH_E;
+            }
             else {
                 if (ret == WOLFSSH_USERAUTH_PARTIAL_SUCCESS) {
                     partialSuccess = 1;


### PR DESCRIPTION
Fix to WOLFSSH_USERAUTH_REJECTED result from user authentication
callback getting ignored for public key authentication.
This changes behavior to be similar how _DoUserAuthRequestPassword()_ works.


See #824