### PR TITLE
Fix Shadowed Index

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2698,23 +2698,23 @@ const char* IdToName(byte id)
 }
 
 
-const char* NameByIndexType(byte type, word32* index)
+const char* NameByIndexType(byte type, word32* idx)
 {
     const char* name = NULL;
 
-    if (index != NULL) {
+    if (idx != NULL) {
         word32 i, mapSz;
 
         mapSz = (word32)(sizeof(NameIdMap)/sizeof(NameIdPair));
 
-        for (i = *index; i < mapSz; i++) {
+        for (i = *idx; i < mapSz; i++) {
             if (NameIdMap[i].type == type) {
                 name = NameIdMap[i].name;
                 break;
             }
         }
 
-        *index = i + 1;
+        *idx = i + 1;
     }
 
     return name;

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -2359,27 +2359,27 @@ int wolfSSH_CheckAlgoName(const char* name)
 }
 
 
-const char* wolfSSH_QueryKex(word32* index)
+const char* wolfSSH_QueryKex(word32* idx)
 {
-    return NameByIndexType(TYPE_KEX, index);
+    return NameByIndexType(TYPE_KEX, idx);
 }
 
 
-const char* wolfSSH_QueryKey(word32* index)
+const char* wolfSSH_QueryKey(word32* idx)
 {
-    return NameByIndexType(TYPE_KEY, index);
+    return NameByIndexType(TYPE_KEY, idx);
 }
 
 
-const char* wolfSSH_QueryCipher(word32* index)
+const char* wolfSSH_QueryCipher(word32* idx)
 {
-    return NameByIndexType(TYPE_CIPHER, index);
+    return NameByIndexType(TYPE_CIPHER, idx);
 }
 
 
-const char* wolfSSH_QueryMac(word32* index)
+const char* wolfSSH_QueryMac(word32* idx)
 {
-    return NameByIndexType(TYPE_MAC, index);
+    return NameByIndexType(TYPE_MAC, idx);
 }
 
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -476,7 +476,7 @@ enum NameIdType {
 
 WOLFSSH_LOCAL byte NameToId(const char* name, word32 nameSz);
 WOLFSSH_LOCAL const char* IdToName(byte id);
-WOLFSSH_LOCAL const char* NameByIndexType(byte type, word32* index);
+WOLFSSH_LOCAL const char* NameByIndexType(byte type, word32* idx);
 
 
 /* For cases when openssl coexist is used */

--- a/wolfssh/ssh.h
+++ b/wolfssh/ssh.h
@@ -130,20 +130,20 @@ WOLFSSH_API const char* wolfSSH_GetAlgoListKeyAccepted(WOLFSSH* ssh);
 
 WOLFSSH_API int wolfSSH_CheckAlgoName(const char* name);
 
-WOLFSSH_API const char* wolfSSH_QueryKex(word32* index);
-WOLFSSH_API const char* wolfSSH_QueryKey(word32* index);
-WOLFSSH_API const char* wolfSSH_QueryCipher(word32* index);
-WOLFSSH_API const char* wolfSSH_QueryMac(word32* index);
+WOLFSSH_API const char* wolfSSH_QueryKex(word32* idx);
+WOLFSSH_API const char* wolfSSH_QueryKey(word32* idx);
+WOLFSSH_API const char* wolfSSH_QueryCipher(word32* idx);
+WOLFSSH_API const char* wolfSSH_QueryMac(word32* idx);
 
 typedef enum WS_Text {
-	WOLFSSH_TEXT_KEX_ALGO,
-	WOLFSSH_TEXT_KEX_CURVE,
-	WOLFSSH_TEXT_KEX_HASH,
+    WOLFSSH_TEXT_KEX_ALGO,
+    WOLFSSH_TEXT_KEX_CURVE,
+    WOLFSSH_TEXT_KEX_HASH,
 
-	WOLFSSH_TEXT_CRYPTO_IN_CIPHER,
-	WOLFSSH_TEXT_CRYPTO_IN_MAC,
-	WOLFSSH_TEXT_CRYPTO_OUT_CIPHER,
-	WOLFSSH_TEXT_CRYPTO_OUT_MAC,
+    WOLFSSH_TEXT_CRYPTO_IN_CIPHER,
+    WOLFSSH_TEXT_CRYPTO_IN_MAC,
+    WOLFSSH_TEXT_CRYPTO_OUT_CIPHER,
+    WOLFSSH_TEXT_CRYPTO_OUT_MAC,
 } WS_Text;
 
 /*


### PR DESCRIPTION
1. For the Query name by index functions, rename `index` as `idx`. Some versions of the C library have a global named `index` that can get shadowed.
2. Fix some whitespace.
(ZD#20321)