### PR TITLE
Fix handling of WOLFSSH_USERAUTH_REJECTED result from userAuthCb

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6517,9 +6517,12 @@ static int DoUserAuthInfoResponse(WOLFSSH* ssh,
             else if (ret == WOLFSSH_USERAUTH_REJECTED) {
                 WLOG(WS_LOG_DEBUG, "DUARKB: keyboard rejected");
                 #ifndef NO_FAILURE_ON_REJECTED
-                    authFailure = 1;
-                #endif
+                ret = SendUserAuthFailure(ssh, 0);
+                if (ret == WS_SUCCESS)
+                    ret = WS_USER_AUTH_E;
+                #else
                 ret = WS_USER_AUTH_E;
+                #endif
             }
             else if (ret == WOLFSSH_USERAUTH_WOULD_BLOCK) {
                 WLOG(WS_LOG_DEBUG, "DUARKB: keyboard callback would block");
@@ -6624,9 +6627,12 @@ static int DoUserAuthRequestPassword(WOLFSSH* ssh, WS_UserAuthData* authData,
             else if (ret == WOLFSSH_USERAUTH_REJECTED) {
                 WLOG(WS_LOG_DEBUG, "DUARPW: password rejected");
                 #ifndef NO_FAILURE_ON_REJECTED
-                    authFailure = 1;
-                #endif
+                ret = SendUserAuthFailure(ssh, 0);
+                if (ret == WS_SUCCESS)
+                    ret = WS_USER_AUTH_E;
+                #else
                 ret = WS_USER_AUTH_E;
+                #endif
             }
             else if (ret == WOLFSSH_USERAUTH_WOULD_BLOCK) {
                 WLOG(WS_LOG_DEBUG, "DUARPW: userauth callback would block");
@@ -7587,9 +7593,12 @@ static int DoUserAuthRequestPublicKey(WOLFSSH* ssh, WS_UserAuthData* authData,
             }
             else if (ret == WOLFSSH_USERAUTH_REJECTED) {
                 #ifndef NO_FAILURE_ON_REJECTED
-                    authFailure = 1;
-                #endif
+                ret = SendUserAuthFailure(ssh, 0);
+                if (ret == WS_SUCCESS)
+                    ret = WS_USER_AUTH_E;
+                #else
                 ret = WS_USER_AUTH_E;
+                #endif
             }
             else {
                 if (ret == WOLFSSH_USERAUTH_PARTIAL_SUCCESS) {


### PR DESCRIPTION
I noticed that if compile option **NO_FAILURE_ON_RJECTED** is not used,
then _WOLFSSH_USERAUTH_REJECTED_ response from user authentication 
callback (userAuthCb) do not appear to be handled properly (?)  As this seems to prevent SSH server
(userAuthCb) from rejecting client connections.

If **NO_FAILURE_ON_REJECTED** is defined, then everything works ok, as "DoUserAuth" functions (DoUserAuthInforResponse(), DouserAuthRequestPassword(), DoUserAuthRequestPublicKey()) 
end up returning correct return value (**WS_USER_AUTH_E**).

But when _NO_FAILURE_ON_REJECT_ is **not** defined, that causes _authFailure_ getting set:
```
            else if (ret == WOLFSSH_USERAUTH_REJECTED) {
                WLOG(WS_LOG_DEBUG, "DUARKB: keyboard rejected");
                #ifndef NO_FAILURE_ON_REJECTED
                    authFailure = 1;
                #endif
                ret = WS_USER_AUTH_E;
            }
```

Which in turn results in the return value getting overridden little bit later by function call to _SendUserAuthFailure()_:

```
    if (authFailure || partialSuccess) {
        ret = SendUserAuthFailure(ssh, partialSuccess);
    }
```


I noticed that _DoUserAuthRequestNone()_ doesn't seem to have this problem as it handles this differently, so I updated the other "DoUserAuth..." functions to work same way, and now connections get rejected also when **NO_FAILURE_ON_REJECT** is not used.

This patch updates the other functions to follow same logic as  _DoUserAuthRequestNonte()_ already does. Not sure if this is necessary "correct" solution, but seems to solve my problem...