### PR TITLE
define WLOG to a no-op when not used with debugging

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11343,6 +11343,7 @@ int wolfSSH_RsaVerify(const byte *sig, word32 sigSz,
 #endif
     if (checkSig)
         WFREE(checkSig, heap, DYNTYPE_TEMP);
+    WOLFSSH_UNUSED(loc); /* Unused when WLOG is not defined */
     return ret;
 }
 #endif /* WOLFSSH_NO_RSA */

--- a/wolfssh/log.h
+++ b/wolfssh/log.h
@@ -72,11 +72,14 @@ WOLFSSH_API int wolfSSH_LogEnabled(void);
 WOLFSSH_API void wolfSSH_Log(enum wolfSSH_LogLevel,
                              const char *const, ...) FMTCHECK;
 
-#define WLOG(...) do { \
+#if defined(DEBUG_WOLFSSH) || defined(WOLFSSH_SSHD)
+    #define WLOG(...) do { \
                       if (wolfSSH_LogEnabled()) \
                           wolfSSH_Log(__VA_ARGS__); \
                   } while (0)
-
+#else
+    #define WLOG(...) WC_DO_NOTHING
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Thanks @AxlLind for the enhancement report https://github.com/wolfSSL/wolfssh/pull/836

Defining WLOG to no-op for code library size reduction when wolfSSH is not compiled with debugging enabled.