### PR TITLE
fix error: implicit declaration of function 'wc_SSH_KDF'

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -48,7 +48,8 @@
 #include <wolfssl/wolfcrypt/hmac.h>
 #include <wolfssl/wolfcrypt/signature.h>
 
-#if (LIBWOLFSSL_VERSION_HEX >= WOLFSSL_V5_0_0) \
+#if defined(WOLFSSL_WOLFSSH) \
+    && (LIBWOLFSSL_VERSION_HEX >= WOLFSSL_V5_0_0) \
     && ((defined(HAVE_FIPS) && FIPS_VERSION_GE(5,2)) \
         || defined(WOLFSSH_NO_NISTP256_MLKEM768_SHA256))
     #include <wolfssl/wolfcrypt/kdf.h>
@@ -2330,7 +2331,8 @@ int GenerateKey(byte hashId, byte keyId,
                 const byte* h, word32 hSz,
                 const byte* sessionId, word32 sessionIdSz,
                 byte doKeyPad)
-#if (LIBWOLFSSL_VERSION_HEX >= WOLFSSL_V5_0_0) \
+#if defined(WOLFSSL_WOLFSSH) \
+    && (LIBWOLFSSL_VERSION_HEX >= WOLFSSL_V5_0_0) \
     && ((defined(HAVE_FIPS) && FIPS_VERSION_GE(5,2)) \
         || defined(WOLFSSH_NO_NISTP256_MLKEM768_SHA256))
 /* Cannot use the SSH KDF with ML-KEM. With ML-KEM, doKeyPad must be false,


### PR DESCRIPTION
hopefully resolves https://github.com/wolfSSL/wolfssh/issues/781


when compiling from git master ( 967d6c59ffeade98f30763b14737070045c4725e dated Fri Oct 24 09:44:15 2025 -0700) with
```
./configure --enable-static --disable-shared --enable-scp --enable-sftp --enable-shell --enable-cryptonly --with-wolfssl=wolfssl/install/
```
I got:
```
$ make -j17
(...)
make -j17  all-am
make[1]: warning: -j17 forced in submake: resetting jobserver mode. make[1]: Entering directory '/home/hans/projects/wolfssh'
  CC       src/libwolfssh_la-internal.lo
src/internal.c: In function 'GenerateKey':
src/internal.c:2348:15: error: implicit declaration of function 'wc_SSH_KDF'; did you mean 'wc_HKDF'? [-Werror=implicit-function-declaration]
 2348 |         ret = wc_SSH_KDF(hashId, keyId, key, keySz,
      |               ^~~~~~~~~~
      |               wc_HKDF
src/internal.c:2348:15: error: nested extern declaration of 'wc_SSH_KDF' [-Werror=nested-externs]
cc1: all warnings being treated as errors
make[1]: *** [Makefile:1483: src/libwolfssh_la-internal.lo] Error 1
make[1]: Leaving directory '/home/hans/projects/wolfssh'
make: *** [Makefile:1020: all] Error 2
```
