### PR TITLE
replace sys/errno.h with errno.h

### DIFF
--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -79,7 +79,7 @@
     #include <errno.h>
     #include <unix.h>
 #else
-    #include <sys/errno.h>
+    #include <errno.h>
 #endif
 
     static volatile int ChildRunning = 0;

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -84,11 +84,8 @@
 #if defined(__QNX__) || defined(__QNXNTO__)
     #include <errno.h>
     #include <unix.h>
-
-#elif defined(USE_WINDOWS_API)
-    #include <errno.h>
 #else
-    #include <sys/errno.h>
+    #include <errno.h>
 #endif
 #endif /* WOLFSSH_SHELL */
 

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
@@ -100,10 +100,8 @@
     #include <errno.h>
     #include <unix.h>
 
-#elif defined(USE_WINDOWS_API)
-    #include <errno.h>
 #else
-    #include <sys/errno.h>
+    #include <errno.h>
 #endif
 #endif /* WOLFSSH_SHELL */
 


### PR DESCRIPTION
This allows compiling with musl-gcc.

Historically, some systems have used <sys/errno.h> in place of <errno.h>, but the C standard,
 all the way back to C89/Ansi C, specifies that the correct name is `errno.h` -
and most modern compilers create a sys/errno.h compatibility shim - but musl-gcc does not have this compatibility shim,
 reasoning that sys/errno.h is non-standard, and fails to compile:
```
$ CC=musl-gcc ./configure --enable-static --disable-shared --enable-scp --enable-sftp --enable-shell --with-wolfssl=wolfssl/install-musl
(...)
$ make
make -j17  all-am
make[1]: Entering directory '/home/hans/projects/wolfssh'
  CC       examples/client/common.o
  CC       examples/client/client.o
  CC       src/libwolfssh_la-ssh.lo
  CC       src/libwolfssh_la-internal.lo
  CC       src/libwolfssh_la-log.lo
  CC       src/libwolfssh_la-port.lo
  CC       src/libwolfssh_la-io.lo
  CC       src/libwolfssh_la-wolfscp.lo
  CC       src/libwolfssh_la-wolfsftp.lo
  CC       examples/echoserver/echoserver.o
  CC       src/libwolfssh_la-wolfterm.lo
  CC       examples/sftpclient/sftpclient.o
  CC       examples/scpclient/scpclient.o
In file included from examples/echoserver/echoserver.c:91:
/usr/include/x86_64-linux-musl/sys/errno.h:1:2: error: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Werror=cpp]
    1 | #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
      |  ^~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:1452: examples/echoserver/echoserver.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/hans/projects/wolfssh'
make: *** [Makefile:1020: all] Error 2
```

so, unless we need to support pre-C89 (35+ year old C) compilers, we can just replace sys/errno.h with errno.h.