### PR TITLE
fix for warning with snprintf use in test case

### DIFF
--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -31,7 +31,11 @@ static void CleanupWildcardTest(void)
     WDIR dir;
     struct dirent* d;
     char filepath[MAX_PATH*2]; /* d_name is max_path long */
+    size_t prefixLen;
+    size_t maxNameLen;
 
+    prefixLen  = WSTRLEN("./sshd_config.d/");
+    maxNameLen = sizeof(filepath) - prefixLen - 1; /* -1 for null terminator */
     if (!WOPENDIR(NULL, NULL, &dir, "./sshd_config.d/")) {
         while ((d = WREADDIR(NULL, &dir)) != NULL) {
         #if defined(__QNX__) || defined(__QNXNTO__)
@@ -43,8 +47,9 @@ static void CleanupWildcardTest(void)
             if (d->d_type != DT_DIR)
         #endif
             {
-                WSNPRINTF(filepath, sizeof filepath, "%s%s",
-                        "./sshd_config.d/", d->d_name);
+                WSNPRINTF(filepath, sizeof filepath, "%.*s%.*s",
+                        (int)prefixLen, "./sshd_config.d/",
+                        (int)maxNameLen, d->d_name);
                 WREMOVE(0, filepath);
             }
         }


### PR DESCRIPTION
gcc version 15.2.0 (GCC) 

Fixes the following warning with `--enable-all` build:

```
apps/wolfsshd/test/test_configuration.c: In function 'CleanupWildcardTest':
./wolfssh/port.h:582:55: error: '%s' directive output may be truncated writing up to 1023 bytes into a region of size 506 [-Werror=format-truncation=]
  582 |         #define WSNPRINTF(s,n,f,...) snprintf((s),(n),(f),##__VA_ARGS__)
      |                                                       ^~~
apps/wolfsshd/test/test_configuration.c:46:17: note: in expansion of macro 'WSNPRINTF'
   46 |                 WSNPRINTF(filepath, sizeof filepath, "%s%s",
      |                 ^~~~~~~~~
./wolfssh/port.h:582:38: note: '__builtin_snprintf' output between 17 and 1040 bytes into a destination of size 522
  582 |         #define WSNPRINTF(s,n,f,...) snprintf((s),(n),(f),##__VA_ARGS__)
      |                                      ^~~~~~~~
apps/wolfsshd/test/test_configuration.c:46:17: note: in expansion of macro 'WSNPRINTF'
   46 |                 WSNPRINTF(filepath, sizeof filepath, "%s%s",
      |                 ^~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [apps/wolfsshd/test/test_configuration-test_configuration.o] Error 1
```