### PR TITLE
SFTP Paths

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -2001,7 +2001,7 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
 {
     WS_SFTP_FILEATRB atr;
     WFD    fd;
-    word32 sz, dirSz;
+    word32 sz;
     char   dir[WOLFSSH_MAX_FILENAME];
     word32 reason;
     word32 idx = 0;
@@ -2043,9 +2043,8 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
         return WS_BUFFER_E;
     }
 
-    dirSz = sizeof(dir);
-    if (wolfSSH_GetPath(ssh->sftpDefaultPath, data + idx, sz, dir, &dirSz)
-            != WS_SUCCESS) {
+    if (GetAndCleanPath(ssh->sftpDefaultPath,
+                data + idx, sz, dir, sizeof(dir)) != WS_SUCCESS) {
         WLOG(WS_LOG_SFTP, "Creating path for file to open failed");
         return WS_FATAL_ERROR;
     }
@@ -2202,7 +2201,7 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
 {
 /*    WS_SFTP_FILEATRB atr;*/
     HANDLE fileHandle;
-    word32 sz, dirSz;
+    word32 sz;
     char   dir[WOLFSSH_MAX_FILENAME];
     word32 reason;
     word32 idx = 0;
@@ -2239,8 +2238,7 @@ int wolfSSH_SFTP_RecvOpen(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
         return WS_BUFFER_E;
     }
 
-    dirSz = sizeof(dir);
-    if (wolfSSH_GetPath(ssh->sftpDefaultPath, data + idx, sz, dir, &dirSz)
+    if (GetAndCleanPath(ssh->sftpDefaultPath, data + idx, sz, dir, sizeof(dir))
             != WS_SUCCESS) {
         WLOG(WS_LOG_SFTP, "Creating path for file to open failed");
         return WS_FATAL_ERROR;


### PR DESCRIPTION
Modify the SFTP function RecvOpen() to use the same path cleanup function, GetAndCleanPath(), that all the other SFTP functions use.

(ZD#20981)