### PR TITLE
Coverity: Untrusted divisor

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4751,7 +4751,7 @@ static int DoKexDhInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
      * in the message isn't of the DH e value. Treat the Q as e. */
     /* DYNTYPE_DH */
 
-    byte* e;
+    const byte* e;
     word32 eSz;
     word32 begin;
     int ret = WS_SUCCESS;
@@ -4770,28 +4770,20 @@ static int DoKexDhInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
             *idx += len;
             return WS_SUCCESS;
         }
-    }
 
-    if (ret == WS_SUCCESS) {
         begin = *idx;
-        ret = GetUint32(&eSz, buf, len, &begin);
+        ret = GetStringRef(&eSz, &e, buf, len, &begin);
     }
 
     if (ret == WS_SUCCESS) {
         /* Validate eSz */
-        if ((len < begin) || (eSz > len - begin)) {
-            ret = WS_RECV_OVERFLOW_E;
-        }
+        if (eSz > (word32)sizeof(ssh->handshake->e) || eSz == 0)
+            ret = WS_PUBKEY_REJECTED_E;
     }
 
     if (ret == WS_SUCCESS) {
-        e = buf + begin;
-        begin += eSz;
-
-        if (eSz <= (word32)sizeof(ssh->handshake->e)) {
-            WMEMCPY(ssh->handshake->e, e, eSz);
-            ssh->handshake->eSz = eSz;
-        }
+        WMEMCPY(ssh->handshake->e, e, eSz);
+        ssh->handshake->eSz = eSz;
 
         ssh->clientState = CLIENT_KEXDH_INIT_DONE;
         *idx = begin;

--- a/src/misc.c
+++ b/src/misc.c
@@ -74,7 +74,17 @@ STATIC INLINE word32 min(word32 a, word32 b)
 /* convert opaque to 32 bit integer */
 STATIC INLINE void ato32(const byte* c, word32* u32)
 {
-    *u32 = (c[0] << 24) | (c[1] << 16) | (c[2] << 8) | c[3];
+    word32 v = 0;
+
+    v |= (word32)(c[0] & 0xFF);
+    v <<= 8;
+    v |= (word32)(c[1] & 0xFF);
+    v <<= 8;
+    v |= (word32)(c[2] & 0xFF);
+    v <<= 8;
+    v |= (word32)(c[3] & 0xFF);
+
+    *u32 = v;
 }
 
 


### PR DESCRIPTION
Coverity report of an untrusted divisor. It goes back to the function ato32(), assuming that the value read is a size (which it is) and that it isn't appropriately checked. It is checked when used, but it is already tainted at that point, and the taint spread to other things. Changed ato32() to mask more and shift in a different manner.

Fixes CID: 572837