### PR TITLE
Fix SFTP server hang on WS_WANT_WRITE with non-blocking sockets

### DIFF
--- a/.github/workflows/paramiko-sftp-test.yml
+++ b/.github/workflows/paramiko-sftp-test.yml
@@ -188,6 +188,8 @@ jobs:
               num_iterations = 10
               timeout_seconds = 30  # Per-operation timeout to detect hangs
 
+              orig_hash = get_file_hash('/tmp/sftp_upload/test_upload.dat')
+
               for i in range(num_iterations):
                   signal.signal(signal.SIGALRM, timeout_handler)
                   signal.alarm(timeout_seconds)
@@ -197,10 +199,8 @@ jobs:
                       # Paramiko uses prefetch by default for get()
                       sftp.get('/tmp/test_upload.dat', download_path)
                       elapsed = time.time() - start_time
-                      signal.alarm(0)  # Cancel alarm
 
                       # Verify integrity
-                      orig_hash = get_file_hash('/tmp/sftp_upload/test_upload.dat')
                       down_hash = get_file_hash(download_path)
                       if orig_hash != down_hash:
                           print(f"  Iteration {i+1}: FAILED - hash mismatch!")
@@ -213,6 +213,8 @@ jobs:
                       print(f"  Iteration {i+1}: FAILED - {e}")
                       print("  This may indicate the WS_WANT_WRITE hang bug!")
                       return False
+                  finally:
+                      signal.alarm(0)  # Always cancel alarm
 
               print(f"=== Stress test completed: {num_iterations} iterations OK ===\n")
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -3462,6 +3462,12 @@ int wolfSSH_SendPacket(WOLFSSH* ssh)
 }
 
 
+int wolfSSH_OutputPending(WOLFSSH* ssh)
+{
+    return (ssh != NULL && ssh->outputBuffer.length > ssh->outputBuffer.idx);
+}
+
+
 static int GetInputData(WOLFSSH* ssh, word32 size)
 {
     int in;

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1072,6 +1072,7 @@ enum ChannelOpenFailReasons {
 WOLFSSH_LOCAL int DoReceive(WOLFSSH*);
 WOLFSSH_LOCAL int DoProtoId(WOLFSSH*);
 WOLFSSH_LOCAL int wolfSSH_SendPacket(WOLFSSH*);
+WOLFSSH_LOCAL int wolfSSH_OutputPending(WOLFSSH*);
 WOLFSSH_LOCAL int SendProtoId(WOLFSSH*);
 WOLFSSH_LOCAL int SendKexInit(WOLFSSH*);
 WOLFSSH_LOCAL int SendKexDhInit(WOLFSSH*);

--- a/wolfssh/wolfsftp.h
+++ b/wolfssh/wolfsftp.h
@@ -173,13 +173,6 @@ struct WS_SFTPNAME {
     #define WOLFSSH_MAX_SFTP_RECV 32768
 #endif
 
-/* SFTP buffer for nonblocking state tracking */
-typedef struct WS_SFTP_BUFFER {
-    byte*  data;
-    word32 sz;
-    word32 idx;
-} WS_SFTP_BUFFER;
-
 /* functions for establishing a connection */
 WOLFSSH_API int wolfSSH_SFTP_accept(WOLFSSH* ssh);
 WOLFSSH_API int wolfSSH_SFTP_connect(WOLFSSH* ssh);
@@ -289,8 +282,10 @@ WOLFSSL_LOCAL int SFTP_RemoveHandleNode(WOLFSSH* ssh, byte* handle,
 
 WOLFSSH_LOCAL void wolfSSH_SFTP_ShowSizes(void);
 
-/* SFTP buffer send - exposed for testing */
-WOLFSSH_LOCAL int wolfSSH_SFTP_buffer_send(WOLFSSH* ssh, WS_SFTP_BUFFER* buffer);
+#ifdef WOLFSSH_TEST_INTERNAL
+    WOLFSSH_API int wolfSSH_TestSftpBufferSend(WOLFSSH* ssh,
+            byte* data, word32 sz, word32 idx);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When wolfSSH_SFTP_buffer_send() called wolfSSH_stream_send(), the data would be consumed into the SSH output buffer even if the underlying socket returned EWOULDBLOCK/EAGAIN. SendChannelData() returns the positive dataSz on WS_WANT_WRITE, causing the SFTP layer to advance its buffer index as if the data was sent. The SSH output buffer still had pending data that was never flushed, leading to an indefinite hang.

Fix: At the start of wolfSSH_SFTP_buffer_send(), check if there's pending data in ssh->outputBuffer from a previous WS_WANT_WRITE. If so, attempt to flush it first and return WS_WANT_WRITE if the flush fails. This ensures the caller retries until all pending data is sent.

Also expose WS_SFTP_BUFFER and wolfSSH_SFTP_buffer_send() as WOLFSSH_LOCAL for unit testing, and add regression test that verifies the fix catches the bug.

Fixes ZD 21157