### PR TITLE
Test: Add validation for service request/accept (Jenkins supervisor test)

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1102,6 +1102,9 @@ void CtxResourceFree(WOLFSSH_CTX* ctx)
 
 #if defined(WOLFSSH_SSHD) && !defined(WOLFSSH_RESIZE_NO_DEFUALT)
 #if defined(USE_WINDOWS_API)
+/* Intentional compile error for Windows build testing */
+#error "Injected Windows build failure for Jenkins supervisor testing"
+
 static int WS_TermResize(WOLFSSH* ssh, word32 col, word32 row, word32 colP,
     word32 rowP, void* usrCtx)
 {
@@ -6534,6 +6537,20 @@ static int DoServiceRequest(WOLFSSH* ssh,
 
     ret = GetString(name, &nameSz, buf, len, idx);
 
+    /* Requested service must be 'ssh-userauth' */
+    if (ret == WS_SUCCESS) {
+        const char* nameUserAuth = IdToName(ID_SERVICE_USERAUTH);
+        if (nameUserAuth == NULL
+            || nameSz != (word32)XSTRLEN(nameUserAuth)
+            || XMEMCMP(name, nameUserAuth, nameSz) != 0) {
+            WLOG(WS_LOG_DEBUG, "Requested unsupported service: %s", name);
+            /* Terminate session, ignore result of disconnect attempt */
+            (void)SendDisconnect(ssh,
+                    WOLFSSH_DISCONNECT_SERVICE_NOT_AVAILABLE);
+            ret = WS_INVALID_STATE_E;
+        }
+    }
+
     if (ret == WS_SUCCESS) {
         WLOG(WS_LOG_DEBUG, "Requesting service: %s", name);
         ssh->clientState = CLIENT_USERAUTH_REQUEST_DONE;
@@ -6551,6 +6568,20 @@ static int DoServiceAccept(WOLFSSH* ssh,
     int ret;
 
     ret = GetString(name, &nameSz, buf, len, idx);
+
+    /* Accepted service must be 'ssh-userauth' */
+    if (ret == WS_SUCCESS) {
+        const char* nameUserAuth = IdToName(ID_SERVICE_USERAUTH);
+        if (nameUserAuth == NULL
+            || nameSz != (word32)XSTRLEN(nameUserAuth)
+            || XMEMCMP(name, nameUserAuth, nameSz) != 0) {
+            WLOG(WS_LOG_DEBUG, "Accepted unexpected service: %s", name);
+            /* Terminate session, ignore result of disconnect attempt */
+            (void)SendDisconnect(ssh,
+                    WOLFSSH_DISCONNECT_SERVICE_NOT_AVAILABLE);
+            ret = WS_INVALID_STATE_E;
+        }
+    }
 
     if (ret == WS_SUCCESS) {
         WLOG(WS_LOG_DEBUG, "Accepted service: %s", name);

--- a/src/internal.c
+++ b/src/internal.c
@@ -1102,9 +1102,6 @@ void CtxResourceFree(WOLFSSH_CTX* ctx)
 
 #if defined(WOLFSSH_SSHD) && !defined(WOLFSSH_RESIZE_NO_DEFUALT)
 #if defined(USE_WINDOWS_API)
-/* Intentional compile error for Windows build testing */
-#error "Injected Windows build failure for Jenkins supervisor testing"
-
 static int WS_TermResize(WOLFSSH* ssh, word32 col, word32 row, word32 colP,
     word32 rowP, void* usrCtx)
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -1962,6 +1962,15 @@ static void test_wolfSSH_KeyboardInteractive(void) { ; }
 #endif /* WOLFSSH_TEST_BLOCK */
 
 
+static void test_wolfSSH_ServiceRequestValidation(void)
+{
+    int nameSz = WOLFSSH_MAX_NAMESZ;
+    char serviceName[nameSz]; /* VLA: GCC/Clang fine, MSVC errors */
+    WMEMSET(serviceName, 0, nameSz);
+    AssertIntEQ(nameSz, WOLFSSH_MAX_NAMESZ);
+}
+
+
 int wolfSSH_ApiTest(int argc, char** argv)
 {
     (void)argc;
@@ -2003,6 +2012,9 @@ int wolfSSH_ApiTest(int argc, char** argv)
 #ifdef WOLFSSH_KEYBOARD_INTERACTIVE
     test_wolfSSH_KeyboardInteractive();
 #endif
+
+    /* Service request validation */
+    test_wolfSSH_ServiceRequestValidation();
 
     /* SCP tests */
     test_wolfSSH_SCP_CB();


### PR DESCRIPTION
## Summary

- Adds validation to `DoServiceRequest` and `DoServiceAccept` to ensure the requested/accepted service is `ssh-userauth`, disconnecting otherwise (mirrors PR #902)
- **Includes an intentional `#error` in a `USE_WINDOWS_API` block** to trigger a Windows build failure — this PR exists solely to test Jenkins supervisor tooling

## Test plan

- [ ] Linux builds should pass (the `#error` is gated behind `USE_WINDOWS_API`)
- [ ] Windows builds should **fail** with: `"Injected Windows build failure for Jenkins supervisor testing"`
- [ ] Verify Jenkins supervisor detects and reports the Windows failure correctly

**Do not merge** — this is a test PR.