### PR TITLE
Fix DoChannelOpenConf

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8816,6 +8816,8 @@ static int DoChannelOpenConf(WOLFSSH* ssh,
         ret = GetUint32(&peerMaxPacketSz, buf, len, &begin);
 
     if (ret == WS_SUCCESS) {
+        *idx = begin;
+
         WLOG(WS_LOG_INFO, "  channelId = %u", channelId);
         WLOG(WS_LOG_INFO, "  peerChannelId = %u", peerChannelId);
         WLOG(WS_LOG_INFO, "  peerInitialWindowSz = %u", peerInitialWindowSz);


### PR DESCRIPTION
This PR fixes DoChannelOpenConf() so that this updates idx with the consumed length.
This issue didn't cause any real problem in current code because the buffer would be unconditionally released later.
But this shall be fixed for consistency and correctness.