### PR TITLE
Fix server NEWKEYS message expectation

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12914,8 +12914,11 @@ int SendKexDhReply(WOLFSSH* ssh)
         ret = BundlePacket(ssh);
     }
 
-    if (ret == WS_SUCCESS)
+    if (ret == WS_SUCCESS) {
+        ssh->handshake->expectMsgId = MSGID_NEWKEYS;
+        WLOG_EXPECT_MSGID(ssh->handshake->expectMsgId);
         ret = SendNewKeys(ssh);
+    }
 
     if (ret == WS_SUCCESS && ssh->sendExtInfo) {
         ret = SendExtInfo(ssh);


### PR DESCRIPTION
In the server code, the server is not setting the expectedMsgId to MSGID_NEWKEYS before sending its new keys message. Update DoKexDhReply() to set expectMsgId to MSGID_NEWKEYS.

Affected function: DoKeyDhReply.
Issue: F-1275