### PR TITLE
Require wolfssl to be built with --enable-wolfssh

### DIFF
--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -40,6 +40,9 @@
 #include <wolfssl/wolfcrypt/curve25519.h>
 #include <wolfssl/wolfcrypt/ed25519.h>
 
+#ifndef WOLFSSL_WOLFSSH
+    #error "wolfssh requires wolfSSL built with WOLFSSL_WOLFSSH"
+#endif
 #ifdef WOLFSSH_SCP
     #include <wolfssh/wolfscp.h>
 #endif


### PR DESCRIPTION
Check for `WOLFSSL_WOLFSSH` in the `configure` script. Limiting the check to builds with `--enable-certs` for now.