### PR TITLE
Misc Static Analysis Fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -156,13 +156,13 @@
 
 ## Vulnerabilities
 
-- [Critical] CVE-2025-14942. wolfSSH’s key exchange state machine can be
-  manipulated to leak the client’s password in the clear, trick the client to
+- [Critical] CVE-2025-14942. wolfSSH's key exchange state machine can be
+  manipulated to leak the client's password in the clear, trick the client to
   send a bogus signature, or trick the client into skipping user
   authentication. This affects client applications with wolfSSH version 1.4.21
-  and earlier. Users of wolfSSH must update or apply the fix patch and it’s
+  and earlier. Users of wolfSSH must update or apply the fix patch and it's
   recommended to update credentials used. This fix is also recommended for
-  wolfSSH server applications. While there aren’t any specific attacks, the
+  wolfSSH server applications. While there aren't any specific attacks, the
   same defect is present. Thanks to Aina Toky Rasoamanana of Valeo and Olivier
   Levillain of Telecom SudParis for the report. (PR 855)
 - [Medium] CVE-2025-15382. The function used to clean up a path string may read
@@ -223,7 +223,7 @@
   cross-implementation testing. SFTP fix for init to handle channel data which
   resolves a potential interoperability SFTP connection issue. (PR 846)
 - Fixed SCP receive handling to reject traversal filenames containing path
-  separators or “dot” components. (PR 845)
+  separators or "dot" components. (PR 845)
 - Fixed missing declaration of wc_SSH_KDF that caused build failures under
   strict compiler warnings. (PR 848)
 - Fixed SSH agent test setup so regression tests exercise the intended code
@@ -237,7 +237,7 @@
 
 ## Vulnerabilities
 
-- [Critical] CVE-2025-11625 The client's host verification can be bypassed by a malicious server, and client credentials leaked. This affects client applications with wolfSSH version 1.4.20 and earlier. Users of wolfSSH on the client side must update or apply the fix patch and it’s recommended to update credentials used. Fixed in PR (https://github.com/wolfSSL/wolfssh/pull/840)
+- [Critical] CVE-2025-11625 The client's host verification can be bypassed by a malicious server, and client credentials leaked. This affects client applications with wolfSSH version 1.4.20 and earlier. Users of wolfSSH on the client side must update or apply the fix patch and it's recommended to update credentials used. Fixed in PR (https://github.com/wolfSSL/wolfssh/pull/840)
 
 - [Med] CVE-2025-11624 Potential for stack overflow write when reading the file handle provided by an SFTP client. After a SFTP connection was established there is the case where a SFTP client could craft a malicious read, write or set state SFTP packet which would cause the SFTP server code to write into stack. Thanks to Stanislav Fort of Aisle Research for the report. Fixed in PR (https://github.com/wolfSSL/wolfssh/pull/834)
 
@@ -330,7 +330,7 @@
 ## Fixes
 
 - Remove Inline for function HashForId() to resolve clash with WOLFSSH_LOCAL declaration (PR 738)
-- Fix for wolfSSHd’s handling of re-key and window full when processing a command with lots of stdout text (PR 719)
+- Fix for wolfSSHd's handling of re-key and window full when processing a command with lots of stdout text (PR 719)
 - Fix for wolfSSH client app to gracefully clean up on failure and added more WLOG debug messages (PR 732)
 - Minor static analysis report fixes (PR 740, 735)
 - Fix for handling SFTP transfer to non-existent folder (PR 743)
@@ -371,7 +371,7 @@
 - Add callback hooks for most channel messages including open, close, success,
   fail, and requests.
 - Reduce the number of memory allocations SCP makes.
-- Improve wolfSSHd’s behavior on closing a connection. It closes channels and
+- Improve wolfSSHd's behavior on closing a connection. It closes channels and
   waits for the peer to close the channels.
 
 ## Fixes
@@ -532,7 +532,7 @@
 - Internal refactor of client apps to simplify them and added X509 support to scpclient
 - wolfSSH_accept now returns WS_SCP_INIT and needs called again to complete the SCP operation
 - Update to document Cube Pack dependencies
-- Add carriage return for ‘enter’ key in the example client with shell connections to windows server
+- Add carriage return for 'enter' key in the example client with shell connections to windows server
 - Stack usage improvement to limit the scope of variables
 - Echoserver example SFTP non blocking improvement for want read cases
 - Increase SFTP performance with throughput
@@ -540,7 +540,7 @@
 ## Fixes
 
 - Fix for calling chdir after chroot with wolfSSHd when jailing connections on unix environments
-- Better handling on the server side for when the client’s window is filled up
+- Better handling on the server side for when the client's window is filled up
 - Fix for building the client project on windows when shell support is enabled
 - Sanity check improvements for handling memory management with non blocking connections
 - Fix for support with secondary groups with wolfSSHd
@@ -716,7 +716,7 @@
 - Fix for potential memory leak with agent and a case with wolfSHS_SFTP_GetHandle
 - Fuzzing fix for potential out of bounds read in the public key user auth messages
 - MQX build fixes
-- Sanity check that agent was set before setting the agent’s channel
+- Sanity check that agent was set before setting the agent's channel
 - Fuzzing fix for bounds checking with DoKexDhReply internal function
 - Fuzzing fix for clean up of base path with SCP use
 - Fuzzing fix for sanity checks on setting the prime group and generator
@@ -817,7 +817,7 @@
 - Fix for warning with enums used with SFTP and set socket type
 - Added example server with Renesas CS+ port
 - Fix for initializing UserAuthData to all zeros before use
-- Fix for SFTP “LS” operation when setting the default window size to 2048
+- Fix for SFTP "LS" operation when setting the default window size to 2048
 - Add structure size print out option -z to example client when the macro
   WOLFSSH_SHOW_SIZES is defined
 - Additional automated tests of wolfSSH_CTX_UsePrivateKey_buffer and fix for
@@ -853,12 +853,12 @@
 - Change name of internal function SendBuffered() to avoid clash with wolfSSL
 - Add support for SFTP on Windows
 - Use int types for arguments in examples to fix Raspberry Pi build
-- Fix for fail case with leading 0’s on MPINT
+- Fix for fail case with leading 0's on MPINT
 - Default window size (DEFAULT_WINDOW_SZ) lowered from ~ 1 MB to ~ 16 KB
 - Disable examples option added to configure (--disable-examples)
 - Callback function and example use added for checking public key sent
 - AES CTR cipher support added
-- Fix for free’ing ECC caches with examples
+- Fix for free'ing ECC caches with examples
 - Renamed example SFTP to be examples/sftpclient/wolfsftp
 
 

--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -378,7 +378,7 @@ static int test_ConfigCopy(void)
     return ret;
 }
 
-/* Verifies ConfigFree releases all string fields — most useful under ASan. */
+/* Verifies ConfigFree releases all string fields - most useful under ASan. */
 static int test_ConfigFree(void)
 {
     int ret = WS_SUCCESS;
@@ -403,10 +403,10 @@ static int test_ConfigFree(void)
     if (ret == WS_SUCCESS)
         ret = wolfSSHD_ConfigSetAuthKeysFile(head, ".ssh/authorized_keys");
 
-    /* Match User — allocates usrAppliesTo on the copied node */
+    /* Match User - allocates usrAppliesTo on the copied node */
     if (ret == WS_SUCCESS) ret = PCL("Match User alice");
 
-    /* Match Group — allocates groupAppliesTo on the next copied node */
+    /* Match Group - allocates groupAppliesTo on the next copied node */
     if (ret == WS_SUCCESS) ret = PCL("Match Group staff");
 #undef PCL
 

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1424,7 +1424,7 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
         else { /* open interactive shell */
             ret = execv(cmd, (char**)args);
         }
-        if (ret && errno) {
+        if (ret) {
             wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Issue opening shell");
             exit(1);
         }

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -164,12 +164,12 @@ static void myStatusCb(WOLFSSH* sshIn, word32* bytes, char* name)
     currentTime = current_time(0);
     if (currentTime == lastOutputTime) {
         if (bytes[0] != lastPrintedBytes[0] || bytes[1] != lastPrintedBytes[1]) {
-            /* Progress made in the same second — throttle but track latest */
+            /* Progress made in the same second - throttle but track latest */
             lastPrintedBytes[0] = bytes[0];
             lastPrintedBytes[1] = bytes[1];
             return;
         }
-        /* bytes unchanged: EOF final call — fall through to print */
+        /* bytes unchanged: EOF final call - fall through to print */
     }
     else {
         lastOutputTime = currentTime;

--- a/scripts/fwd.test.expect
+++ b/scripts/fwd.test.expect
@@ -75,14 +75,14 @@ puts "\n\[1\] Starting nc server: nc -l 11111"
 spawn nc -l 11111
 set nc_server_id  $spawn_id
 set nc_server_pid [exp_pid]
-puts "    PID $nc_server_pid — waiting for a connection..."
+puts "    PID $nc_server_pid - waiting for a connection..."
 
 # --- [2] Start wolfssh server ------------------------------------------------
 puts "\n\[2\] Starting wolfssh server..."
 spawn ./examples/echoserver/echoserver -1 -f
 set wolfssh_srv_id  $spawn_id
 set wolfssh_srv_pid [exp_pid]
-puts "    PID $wolfssh_srv_pid — waiting for a connection..."
+puts "    PID $wolfssh_srv_pid - waiting for a connection..."
 
 # --- [3] Start wolfssh client ------------------------------------------------
 puts "\n\[3\] Starting wolfssh client (plain:12345 -> 11111)..."

--- a/tests/api.c
+++ b/tests/api.c
@@ -522,7 +522,12 @@ static int load_file(const char* filename, byte** buf, word32* bufSz)
     }
 
     if (ret == 0) {
-        rewind(f);
+        ret = fseek(f, 0, XSEEK_SET);
+        if (ret < 0)
+            ret = -8;
+    }
+
+    if (ret == 0) {
         *buf = (byte*)malloc(*bufSz);
         if (*buf == NULL)
             ret = -5;

--- a/tests/api.c
+++ b/tests/api.c
@@ -579,6 +579,7 @@ static void test_wolfSSH_CTX_UseCert_buffer(void)
             wolfSSH_CTX_UseCert_buffer(ctx, cert, certSz, 99));
 
     free(cert);
+    cert = NULL;
 
     AssertIntEQ(0, load_file("./keys/server-cert.der", &cert, &certSz));
     AssertNotNull(cert);

--- a/tests/auth.c
+++ b/tests/auth.c
@@ -559,9 +559,9 @@ static int AcceptAnyServerHostKey(const byte* pubKey, word32 pubKeySz,
 }
 
 /* Run one pubkey auth attempt.
- * sCtx   – server context (authorised key hash)
- * cCtx   – client context (key material to present)
- * expect – expected return value from both wolfSSH_connect() and
+ * sCtx   - server context (authorised key hash)
+ * cCtx   - client context (key material to present)
+ * expect - expected return value from both wolfSSH_connect() and
  *           wolfSSH_accept(): WS_SUCCESS for a valid-key test,
  *           WS_FATAL_ERROR for a reject test */
 static int run_pubkey_test(PubkeyServerCtx* sCtx, PubkeyClientCtx* cCtx,

--- a/tests/regress.c
+++ b/tests/regress.c
@@ -1648,6 +1648,7 @@ static void TestPasswordEofNoCrash(void)
     WMEMSET(&auth, 0, sizeof(auth));
 
     savedStdin = dup(STDIN_FILENO);
+    AssertTrue(savedStdin >= 0);
     devNull = open("/dev/null", O_RDONLY);
     AssertTrue(devNull >= 0);
     AssertTrue(dup2(devNull, STDIN_FILENO) >= 0);

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -449,7 +449,8 @@ extern "C" {
     #define WFSEEK(fs,s,o,w)    fseek((s),(o),(w))
     #define WFTELL(fs,s)        ftell((s))
     #define WFSTAT(fs,fd,b)     fstat((fd),(b))
-    #define WREWIND(fs,s)       rewind((s))
+    #define WREWIND(fs,s)       do { fseek((s),0,SEEK_SET); \
+                                     clearerr((s)); } while (0)
     #define WSEEK_END           SEEK_END
     #define WBADFILE            NULL
     #define WSETTIME(fs,f,a,m) (0)


### PR DESCRIPTION
- Fix potential double-free: Null out a pointer after freeing in wolfSSH_CTX_UseCert_buffer() test to prevent a double-free if the second cert load fails.
- Fix scan-build errno warnings: Replace rewind() with fseek() in both the WREWIND macro and api.c test helper to avoid scan-build flagging the implicit errno clear, and remove a redundant errno check after execv().
- Fix unchecked return value warning: Handle the return value of dup() in regress.c to silence the static analysis warning.
- 7-bit clean ASCII: Scrub non-ASCII characters (curly quotes, n-dashes) from the main source files to ensure all text is 7-bit clean.