### PR TITLE
Fix DoRequestSuccess and DoRequestFailure, Add regress test

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6578,16 +6578,11 @@ static int DoIgnore(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
 
 static int DoRequestSuccess(WOLFSSH *ssh, byte *buf, word32 len, word32 *idx)
 {
-    word32 dataSz;
     word32 begin = *idx;
     int    ret=WS_SUCCESS;
 
-    WOLFSSH_UNUSED(ssh);
-    WOLFSSH_UNUSED(len);
-
     WLOG(WS_LOG_DEBUG, "DoRequestSuccess, *idx=%d, len=%d", *idx, len);
-    ato32(buf + begin, &dataSz);
-    begin += LENGTH_SZ + dataSz;
+    begin += len;
 
     if (ssh->ctx->reqSuccessCb != NULL)
         ret = ssh->ctx->reqSuccessCb(ssh, &(buf[*idx]), len, ssh->reqSuccessCtx);
@@ -6599,16 +6594,11 @@ static int DoRequestSuccess(WOLFSSH *ssh, byte *buf, word32 len, word32 *idx)
 
 static int DoRequestFailure(WOLFSSH *ssh, byte *buf, word32 len, word32 *idx)
 {
-    word32 dataSz;
     word32 begin = *idx;
     int ret = WS_SUCCESS;
 
-    WOLFSSH_UNUSED(ssh);
-    WOLFSSH_UNUSED(len);
-
-    WLOG(WS_LOG_DEBUG, "DoRequestFalure, *idx=%d, len=%d", *idx, len);
-    ato32(buf + begin, &dataSz);
-    begin += LENGTH_SZ + dataSz;
+    WLOG(WS_LOG_DEBUG, "DoRequestFailure, *idx=%d, len=%d", *idx, len);
+    begin += len;
 
     if (ssh->ctx->reqFailureCb != NULL)
         ret = ssh->ctx->reqFailureCb(ssh, &(buf[*idx]), len, ssh->reqFailureCtx);

--- a/tests/regress.c
+++ b/tests/regress.c
@@ -1489,6 +1489,30 @@ static void TestGlobalRequestFwdCancelWithCbSendsSuccess(void)
 
     FreeChannelOpenHarness(&harness);
 }
+
+/* Verify DoRequestSuccess correctly consumes a uint32 port payload (RFC 4254
+ * §4) without treating it as a length prefix, which would overrun the buffer
+ * and produce WS_BUFFER_E. */
+static void TestRequestSuccessWithPortParsesCorrectly(void)
+{
+    ChannelOpenHarness harness;
+    byte payload[UINT32_SZ];
+    byte in[64];
+    word32 inSz;
+    word32 idx = 0;
+    int ret;
+
+    idx = AppendUint32(payload, sizeof(payload), idx, 2222);
+    inSz = WrapPacket(MSGID_REQUEST_SUCCESS, payload, idx, in, sizeof(in));
+
+    InitChannelOpenHarness(&harness, in, inSz);
+
+    ret = DoReceive(harness.ssh);
+
+    AssertIntEQ(ret, WS_SUCCESS);
+
+    FreeChannelOpenHarness(&harness);
+}
 #endif
 
 #ifdef WOLFSSH_AGENT
@@ -2121,6 +2145,7 @@ int main(int argc, char** argv)
     TestGlobalRequestFwdWithCbSendsSuccess();
     TestGlobalRequestFwdCancelNoCbSendsFailure();
     TestGlobalRequestFwdCancelWithCbSendsSuccess();
+    TestRequestSuccessWithPortParsesCorrectly();
 #endif
 #ifdef WOLFSSH_AGENT
     TestAgentChannelNullAgentSendsOpenFail();


### PR DESCRIPTION
RFC 4254 §4 defines SSH_MSG_REQUEST_SUCCESS as byte SSH_MSG_REQUEST_SUCCESS followed directly by response-specific data (with no length prefix).
This PR fixes DoRequestSuccess and DoRequestFailure so that these don't consume the data with length prefix.
Also, this adds the regress test.