### PR TITLE
Small Test Reorganization

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -853,37 +853,6 @@ INLINE static int IsMessageAllowed(WOLFSSH *ssh, byte msg, byte state)
     return 0;
 }
 
-#ifdef WOLFSSH_TEST_INTERNAL
-int wolfSSH_TestIsMessageAllowed(WOLFSSH* ssh, byte msg, byte state)
-{
-    return IsMessageAllowed(ssh, msg, state);
-}
-
-static int DoKexInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx);
-static int DoKexDhInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx);
-#ifndef WOLFSSH_NO_DH_GEX_SHA256
-static int DoKexDhGexRequest(WOLFSSH* ssh, byte* buf, word32 len, word32* idx);
-#endif
-
-int wolfSSH_TestDoKexInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
-{
-    return DoKexInit(ssh, buf, len, idx);
-}
-
-int wolfSSH_TestDoKexDhInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
-{
-    return DoKexDhInit(ssh, buf, len, idx);
-}
-
-#ifndef WOLFSSH_NO_DH_GEX_SHA256
-int wolfSSH_TestDoKexDhGexRequest(WOLFSSH* ssh, byte* buf, word32 len,
-        word32* idx)
-{
-    return DoKexDhGexRequest(ssh, buf, len, idx);
-}
-#endif
-#endif
-
 
 static const char cannedKexAlgoNames[] =
 #if !defined(WOLFSSH_NO_CURVE25519_MLKEM768_SHA256)
@@ -6558,15 +6527,6 @@ static int DoKexDhGexGroup(WOLFSSH* ssh,
     return ret;
 }
 
-#ifdef WOLFSSH_TEST_INTERNAL
-int wolfSSH_TestValidateKexDhGexGroup(const byte* primeGroup,
-        word32 primeGroupSz, const byte* generator, word32 generatorSz,
-        word32 minBits, word32 maxBits, WC_RNG* rng)
-{
-    return ValidateKexDhGexGroup(primeGroup, primeGroupSz,
-            generator, generatorSz, minBits, maxBits, rng);
-}
-#endif
 #endif /* !WOLFSSH_NO_DH_GEX_SHA256 */
 
 
@@ -10750,31 +10710,6 @@ int DoReceive(WOLFSSH* ssh)
     return ret;
 }
 
-#ifdef WOLFSSH_TEST_INTERNAL
-int wolfSSH_TestDoReceive(WOLFSSH* ssh)
-{
-    return DoReceive(ssh);
-}
-
-int wolfSSH_TestDoUserAuthBanner(WOLFSSH* ssh, byte* buf, word32 len,
-        word32* idx)
-{
-    return DoUserAuthBanner(ssh, buf, len, idx);
-}
-
-int wolfSSH_TestDoChannelRequest(WOLFSSH* ssh, byte* buf, word32 len,
-        word32* idx)
-{
-    return DoChannelRequest(ssh, buf, len, idx);
-}
-
-int wolfSSH_TestChannelPutData(WOLFSSH_CHANNEL* channel, byte* data,
-        word32 dataSz)
-{
-    return ChannelPutData(channel, data, dataSz);
-}
-#endif
-
 
 int DoProtoId(WOLFSSH* ssh)
 {
@@ -11968,15 +11903,6 @@ int wolfSSH_RsaVerify(const byte *sig, word32 sigSz,
     return ret;
 }
 
-#ifdef WOLFSSH_TEST_INTERNAL
-int wolfSSH_TestRsaVerify(const byte* sig, word32 sigSz,
-        const byte* encDigest, word32 encDigestSz,
-        RsaKey* key, void* heap)
-{
-    return wolfSSH_RsaVerify(sig, sigSz, encDigest, encDigestSz,
-            key, heap, "wolfSSH_TestRsaVerify");
-}
-#endif /* WOLFSSH_TEST_INTERNAL */
 #endif /* WOLFSSH_NO_RSA */
 
 
@@ -17933,3 +17859,76 @@ void AddAssign64(word32* addend1, word32 addend2)
 }
 
 #endif /* WOLFSSH_SFTP */
+
+
+#ifdef WOLFSSH_TEST_INTERNAL
+
+int wolfSSH_TestIsMessageAllowed(WOLFSSH* ssh, byte msg, byte state)
+{
+    return IsMessageAllowed(ssh, msg, state);
+}
+
+int wolfSSH_TestDoReceive(WOLFSSH* ssh)
+{
+    return DoReceive(ssh);
+}
+
+int wolfSSH_TestDoUserAuthBanner(WOLFSSH* ssh, byte* buf, word32 len,
+        word32* idx)
+{
+    return DoUserAuthBanner(ssh, buf, len, idx);
+}
+
+int wolfSSH_TestDoChannelRequest(WOLFSSH* ssh, byte* buf, word32 len,
+        word32* idx)
+{
+    return DoChannelRequest(ssh, buf, len, idx);
+}
+
+int wolfSSH_TestDoKexInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
+{
+    return DoKexInit(ssh, buf, len, idx);
+}
+
+int wolfSSH_TestDoKexDhInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
+{
+    return DoKexDhInit(ssh, buf, len, idx);
+}
+
+int wolfSSH_TestChannelPutData(WOLFSSH_CHANNEL* channel, byte* data,
+        word32 dataSz)
+{
+    return ChannelPutData(channel, data, dataSz);
+}
+
+#ifndef WOLFSSH_NO_DH_GEX_SHA256
+
+int wolfSSH_TestDoKexDhGexRequest(WOLFSSH* ssh, byte* buf, word32 len,
+        word32* idx)
+{
+    return DoKexDhGexRequest(ssh, buf, len, idx);
+}
+
+int wolfSSH_TestValidateKexDhGexGroup(const byte* primeGroup,
+        word32 primeGroupSz, const byte* generator, word32 generatorSz,
+        word32 minBits, word32 maxBits, WC_RNG* rng)
+{
+    return ValidateKexDhGexGroup(primeGroup, primeGroupSz,
+            generator, generatorSz, minBits, maxBits, rng);
+}
+
+#endif /* !WOLFSSH_NO_DH_GEX_SHA256 */
+
+#ifndef WOLFSSH_NO_RSA
+
+int wolfSSH_TestRsaVerify(const byte* sig, word32 sigSz,
+        const byte* encDigest, word32 encDigestSz,
+        RsaKey* key, void* heap)
+{
+    return wolfSSH_RsaVerify(sig, sigSz, encDigest, encDigestSz,
+            key, heap, "wolfSSH_TestRsaVerify");
+}
+
+#endif /* !WOLFSSH_NO_RSA */
+
+#endif /* WOLFSSH_TEST_INTERNAL */

--- a/tests/api.c
+++ b/tests/api.c
@@ -1855,6 +1855,30 @@ static void test_wolfSSH_QueryAlgoList(void)
     AssertNull(name);
 
     k = wolfSSH_CheckAlgoName("ssh-rsa");
+#ifndef WOLFSSH_NO_SSH_RSA_SHA1
+    AssertIntEQ(WS_SUCCESS, k);
+#else
+    AssertIntEQ(WS_INVALID_ALGO_ID, k);
+#endif /* WOLFSSH_NO_SSH_RSA_SHA1 */
+
+    k = wolfSSH_CheckAlgoName("ecdsa-sha2-nistp256");
+#ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP256
+    AssertIntEQ(WS_SUCCESS, k);
+#else
+    AssertIntEQ(WS_INVALID_ALGO_ID, k);
+#endif /* WOLFSSH_NO_ECDSA_SHA2_NISTP256 */
+
+    k = wolfSSH_CheckAlgoName("diffie-hellman-group14-sha256");
+#ifndef WOLFSSH_NO_DH_GROUP14_SHA256
+    AssertIntEQ(WS_SUCCESS, k);
+#else
+    AssertIntEQ(WS_INVALID_ALGO_ID, k);
+#endif /* WOLFSSH_NO_DH_GROUP14_SHA256 */
+
+    k = wolfSSH_CheckAlgoName("server-sig-algs");
+    AssertIntEQ(WS_SUCCESS, k);
+
+    k = wolfSSH_CheckAlgoName("nistp256");
     AssertIntEQ(WS_SUCCESS, k);
 
     k = wolfSSH_CheckAlgoName("not-an-algo@wolfssl.com");

--- a/tests/regress.c
+++ b/tests/regress.c
@@ -1644,20 +1644,41 @@ static void TestSftpRemoveHandleHeadUpdate(void)
 #endif
 #endif
 
+#if !(defined(WOLFSSH_NO_RSA) && defined(WOLFSSH_NO_ECDSA_SHA2_NISTP256))
 /* Ensure client buffer cleanup tolerates multiple invocations after allocs. */
 static void TestClientBuffersIdempotent(void)
 {
-    int ret;
+#ifndef WOLFSSH_NO_RSA
+    {
+        int ret;
 
-    ret = ClientUsePubKey("keys/gretel-key-rsa.pub");
-    AssertIntEQ(ret, 0);
-    ret = ClientSetPrivateKey("keys/gretel-key-rsa.pem");
-    AssertIntEQ(ret, 0);
+        ret = ClientUsePubKey("keys/gretel-key-rsa.pub");
+        AssertIntEQ(ret, 0);
+        ret = ClientSetPrivateKey("keys/gretel-key-rsa.pem");
+        AssertIntEQ(ret, 0);
 
-    ClientFreeBuffers();
-    /* Should be safe to call again without double free. */
-    ClientFreeBuffers();
+        ClientFreeBuffers();
+        /* Should be safe to call again without double free. */
+        ClientFreeBuffers();
+    }
+#endif
+
+#ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP256
+    {
+        int ret;
+
+        ret = ClientUsePubKey("keys/gretel-key-ecc.pub");
+        AssertIntEQ(ret, 0);
+        ret = ClientSetPrivateKey("keys/gretel-key-ecc.pem");
+        AssertIntEQ(ret, 0);
+
+        ClientFreeBuffers();
+        /* Should be safe to call again without double free. */
+        ClientFreeBuffers();
+    }
+#endif
 }
+#endif
 
 /* Simulate Ctrl+D (stdin EOF) during password prompt; expect failure but no crash. */
 static void TestPasswordEofNoCrash(void)
@@ -2157,7 +2178,9 @@ int main(int argc, char** argv)
     TestFirstPacketFollows();
 #endif
     TestDisconnectSetsDisconnectError();
+#if !(defined(WOLFSSH_NO_RSA) && defined(WOLFSSH_NO_ECDSA_SHA2_NISTP256))
     TestClientBuffersIdempotent();
+#endif
     TestPasswordEofNoCrash();
 #ifndef WOLFSSH_TEST_BLOCK
     TestWorkerReadsWhenSendWouldBlock();


### PR DESCRIPTION
1. Collect all the test function wrappers in internal.c to one location at the end of the file.
2. Update API test to check other algos if RSA or ECDSA are disabled.
3. Update regression test to test RSA or ECDSA, and will print a message if both are disabled.