### PR TITLE
Add warning to make non-registered channelOpenCb visible

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8960,6 +8960,12 @@ static int DoChannelOpen(WOLFSSH* ssh,
             if (ssh->ctx->channelOpenCb) {
                 ret = ssh->ctx->channelOpenCb(newChannel, ssh->channelOpenCtx);
             }
+            else {
+                WLOG(WS_LOG_WARN, "No channel open callback set "
+                        "(call wolfSSH_CTX_SetChannelOpenCb()), accepting "
+                        "channel open by default; typeId=%u, peerChannelId=%u",
+                        (word32)typeId, peerChannelId);
+            }
             if (ssh->channelListSz == 0)
                 ssh->defaultPeerChannelId = peerChannelId;
         #ifdef WOLFSSH_FWD


### PR DESCRIPTION
This PR adds the waring log for non-registered channelOpenCb usage.
This doesn't break current program flow but make users aware of it.