### PR TITLE
sftp Client Windows Version

### DIFF
--- a/ide/winvs/wolfsftp-client/wolfsftp-client.vcxproj
+++ b/ide/winvs/wolfsftp-client/wolfsftp-client.vcxproj
@@ -79,7 +79,6 @@
     <ProjectGuid>{8DD810D6-159B-4C40-B682-FCA11F9B3680}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>wolfsftp-client</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
The project file for the wolfSFTP example client is specifying a too-specific Windows target platform version. It is the only project file specifying the version to four places. Removed it and using the default Windows version for the version of the build tools.