### PR TITLE
Drop redundant mlkem.h include

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -57,8 +57,7 @@
 #endif
 
 #ifdef WOLFSSL_HAVE_MLKEM
-#include <wolfssl/wolfcrypt/mlkem.h>
-#include <wolfssl/wolfcrypt/wc_mlkem.h>
+    #include <wolfssl/wolfcrypt/wc_mlkem.h>
 #endif
 
 #ifdef NO_INLINE


### PR DESCRIPTION
Drop redundant mlkem.h include. wc_mlkem.h used to include it already. mlkem.h was merged with wc_mlkem.h as of today.