### PR TITLE
Static-analysis fixes

### DIFF
--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -920,7 +920,7 @@ static int config_print(struct config* config)
         printf("port %u\n", config->port);
         printf("keyFile %s\n", config->keyFile ? config->keyFile : "none");
         printf("pubKeyFile %s\n",
-                config->keyFile ? config->keyFile : "none");
+                config->pubKeyFile ? config->pubKeyFile : "none");
         printf("noCommand %s\n", config->noCommand ? "true" : "false");
         printf("logfile %s\n", config->logFile ? config->logFile : "default");
         printf("command %s\n", config->command ? config->command : "none");

--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -437,6 +437,7 @@ static int CheckPasswordUnix(const char* usr, const byte* pw, word32 pwSz, WOLFS
         WFREE(pwStr, NULL, DYNTYPE_STRING);
     }
     if (storedHashCpy != NULL) {
+        ForceZero(storedHashCpy, (word32)WSTRLEN(storedHashCpy) + 1);
         WFREE(storedHashCpy, NULL, DYNTYPE_STRING);
     }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -6667,18 +6667,17 @@ static int DoUnimplemented(WOLFSSH* ssh,
 {
     word32 seq;
     word32 begin = *idx;
+    int ret;
 
     WOLFSSH_UNUSED(ssh);
-    WOLFSSH_UNUSED(len);
 
-    ato32(buf + begin, &seq);
-    begin += UINT32_SZ;
+    ret = GetUint32(&seq, buf, len, &begin);
+    if (ret == WS_SUCCESS) {
+        *idx = begin;
+        WLOG(WS_LOG_DEBUG, "UNIMPLEMENTED: seq %u", seq);
+    }
 
-    WLOG(WS_LOG_DEBUG, "UNIMPLEMENTED: seq %u", seq);
-
-    *idx = begin;
-
-    return WS_SUCCESS;
+    return ret;
 }
 
 
@@ -6687,57 +6686,67 @@ static int DoDisconnect(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
     word32 reason;
     const char* reasonStr = NULL;
     word32 begin = *idx;
+    int ret;
 
-    WOLFSSH_UNUSED(len);
     WOLFSSH_UNUSED(reasonStr);
 
-    ato32(buf + begin, &reason);
-    begin += UINT32_SZ;
+    ret = GetUint32(&reason, buf, len, &begin);
+    if (ret == WS_SUCCESS) {
+        /* Skip the description text. */
+        ret = GetSkip(buf, len, &begin);
+    }
+    if (ret == WS_SUCCESS) {
+        /* Skip the language identifier. */
+        ret = GetSkip(buf, len, &begin);
+    }
+
+    if (ret == WS_SUCCESS) {
+        *idx = begin;
+        ssh->error = WS_DISCONNECT;
+        ret = WS_DISCONNECT;
 
 #ifdef NO_WOLFSSH_STRINGS
-    WLOG(WS_LOG_DEBUG, "DISCONNECT: (%u)", reason);
+        WLOG(WS_LOG_DEBUG, "DISCONNECT: (%u)", reason);
 #elif defined(DEBUG_WOLFSSH)
-    switch (reason) {
-        case WOLFSSH_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT:
-            reasonStr = "host not allowed to connect"; break;
-        case WOLFSSH_DISCONNECT_PROTOCOL_ERROR:
-            reasonStr = "protocol error"; break;
-        case WOLFSSH_DISCONNECT_KEY_EXCHANGE_FAILED:
-            reasonStr = "key exchange failed"; break;
-        case WOLFSSH_DISCONNECT_RESERVED:
-            reasonStr = "reserved"; break;
-        case WOLFSSH_DISCONNECT_MAC_ERROR:
-            reasonStr = "mac error"; break;
-        case WOLFSSH_DISCONNECT_COMPRESSION_ERROR:
-            reasonStr = "compression error"; break;
-        case WOLFSSH_DISCONNECT_SERVICE_NOT_AVAILABLE:
-            reasonStr = "service not available"; break;
-        case WOLFSSH_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED:
-            reasonStr = "protocol version not supported"; break;
-        case WOLFSSH_DISCONNECT_HOST_KEY_NOT_VERIFIABLE:
-            reasonStr = "host key not verifiable"; break;
-        case WOLFSSH_DISCONNECT_CONNECTION_LOST:
-            reasonStr = "connection lost"; break;
-        case WOLFSSH_DISCONNECT_BY_APPLICATION:
-            reasonStr = "disconnect by application"; break;
-        case WOLFSSH_DISCONNECT_TOO_MANY_CONNECTIONS:
-            reasonStr = "too many connections"; break;
-        case WOLFSSH_DISCONNECT_AUTH_CANCELLED_BY_USER:
-            reasonStr = "auth cancelled by user"; break;
-        case WOLFSSH_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE:
-            reasonStr = "no more auth methods available"; break;
-        case WOLFSSH_DISCONNECT_ILLEGAL_USER_NAME:
-            reasonStr = "illegal user name"; break;
-        default:
-            reasonStr = "unknown reason";
-    }
-    WLOG(WS_LOG_DEBUG, "DISCONNECT: (%u) %s", reason, reasonStr);
+        switch (reason) {
+            case WOLFSSH_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT:
+                reasonStr = "host not allowed to connect"; break;
+            case WOLFSSH_DISCONNECT_PROTOCOL_ERROR:
+                reasonStr = "protocol error"; break;
+            case WOLFSSH_DISCONNECT_KEY_EXCHANGE_FAILED:
+                reasonStr = "key exchange failed"; break;
+            case WOLFSSH_DISCONNECT_RESERVED:
+                reasonStr = "reserved"; break;
+            case WOLFSSH_DISCONNECT_MAC_ERROR:
+                reasonStr = "mac error"; break;
+            case WOLFSSH_DISCONNECT_COMPRESSION_ERROR:
+                reasonStr = "compression error"; break;
+            case WOLFSSH_DISCONNECT_SERVICE_NOT_AVAILABLE:
+                reasonStr = "service not available"; break;
+            case WOLFSSH_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED:
+                reasonStr = "protocol version not supported"; break;
+            case WOLFSSH_DISCONNECT_HOST_KEY_NOT_VERIFIABLE:
+                reasonStr = "host key not verifiable"; break;
+            case WOLFSSH_DISCONNECT_CONNECTION_LOST:
+                reasonStr = "connection lost"; break;
+            case WOLFSSH_DISCONNECT_BY_APPLICATION:
+                reasonStr = "disconnect by application"; break;
+            case WOLFSSH_DISCONNECT_TOO_MANY_CONNECTIONS:
+                reasonStr = "too many connections"; break;
+            case WOLFSSH_DISCONNECT_AUTH_CANCELLED_BY_USER:
+                reasonStr = "auth cancelled by user"; break;
+            case WOLFSSH_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE:
+                reasonStr = "no more auth methods available"; break;
+            case WOLFSSH_DISCONNECT_ILLEGAL_USER_NAME:
+                reasonStr = "illegal user name"; break;
+            default:
+                reasonStr = "unknown reason";
+        }
+        WLOG(WS_LOG_DEBUG, "DISCONNECT: (%u) %s", reason, reasonStr);
 #endif
+    }
 
-    *idx = begin;
-
-    ssh->error = WS_DISCONNECT;
-    return WS_DISCONNECT;
+    return ret;
 }
 
 

--- a/src/port.c
+++ b/src/port.c
@@ -456,13 +456,19 @@ int WS_MoveFileA(const char* oldName, const char* newName, void* heap)
 
     error = mbstowcs_s(&returnSz, unicodeOldName, unicodeOldNameSz,
         oldName, oldNameSz);
+    if (error != 0) {
+        WFREE(unicodeOldName, heap, PORT_DYNTYPE_STRING);
+        return 0;
+    }
 
     newNameSz = WSTRLEN(newName);
     newName = TrimFileName(newName, &newNameSz);
 
     error = mbstowcs_s(&unicodeNewNameSz, NULL, 0, newName, 0);
-    if (error != 0)
+    if (error != 0) {
+        WFREE(unicodeOldName, heap, PORT_DYNTYPE_STRING);
         return 0;
+    }
 
     unicodeNewName = (wchar_t*)WMALLOC((unicodeNewNameSz+1)*sizeof(wchar_t),
             heap, PORT_DYNTYPE_STRING);


### PR DESCRIPTION
- src/internal.c (F-413): DoDisconnect/DoUnimplemented now use GetUint32() instead of raw ato32() so short payloads return WS_BUFFER_E instead of reading past the buffer. DoDisconnect also parses the description and language-identifier strings with GetSkip(), so a record truncated after the reason code returns WS_BUFFER_E instead of being treated as success.
- apps/wolfssh/wolfssh.c (F-214): config_print was printing keyFile twice; fixed to print pubKeyFile.
- src/port.c (F-50): WS_MoveFileA leaked unicodeOldName on two error paths; now freed before returning.
- apps/wolfsshd/auth.c (F-57): CheckPasswordUnix now ForceZeros storedHashCpy before freeing.

Issues: F-50, F-57, F-214, F-413