### PR TITLE
Fix  issues addressed by static analysis

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1904,7 +1904,6 @@ static int GetOpenSshKey(WS_KeySignature *key,
             word32 subStrSz = 0, subIdx = 0, check1 = 0, check2 = ~0;
             byte keyId;
 
-            idx = 0;
             ret = GetUint32(&check1, str, strSz, &subIdx); /* checkint 1 */
             if (ret == WS_SUCCESS)
                 ret = GetUint32(&check2, str, strSz, &subIdx); /* checkint 2 */

--- a/src/internal.c
+++ b/src/internal.c
@@ -10447,7 +10447,7 @@ static INLINE int VerifyMac(WOLFSSH* ssh, const byte* in, word32 inSz,
                     ret = wc_HmacUpdate(&hmac, in, inSz);
                 if (ret == WS_SUCCESS)
                     ret = wc_HmacFinal(&hmac, checkMac);
-                if (ConstantCompare(checkMac, mac, ssh->peerMacSz) != 0)
+                if (ret == WS_SUCCESS && ConstantCompare(checkMac, mac, ssh->peerMacSz) != 0)
                     ret = WS_VERIFY_MAC_E;
                 break;
 
@@ -10460,7 +10460,7 @@ static INLINE int VerifyMac(WOLFSSH* ssh, const byte* in, word32 inSz,
                     ret = wc_HmacUpdate(&hmac, in, inSz);
                 if (ret == WS_SUCCESS)
                     ret = wc_HmacFinal(&hmac, checkMac);
-                if (ConstantCompare(checkMac, mac, ssh->peerMacSz) != 0)
+                if (ret == WS_SUCCESS && ConstantCompare(checkMac, mac, ssh->peerMacSz) != 0)
                     ret = WS_VERIFY_MAC_E;
                 break;
 
@@ -10473,7 +10473,7 @@ static INLINE int VerifyMac(WOLFSSH* ssh, const byte* in, word32 inSz,
                     ret = wc_HmacUpdate(&hmac, in, inSz);
                 if (ret == WS_SUCCESS)
                     ret = wc_HmacFinal(&hmac, checkMac);
-                if (ConstantCompare(checkMac, mac, ssh->peerMacSz) != 0)
+                if (ret == WS_SUCCESS && ConstantCompare(checkMac, mac, ssh->peerMacSz) != 0)
                     ret = WS_VERIFY_MAC_E;
                 break;
 

--- a/src/wolfterm.c
+++ b/src/wolfterm.c
@@ -467,8 +467,12 @@ static int wolfSSH_DoControlSeq(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf, 
     switch (c) {
         case 'H': /* move cursor to indicated row and column  -1 to account
                    * for 1,1 on linux vs 0,0 on windows */
-            wolfSSH_CursorMove(handle, args[1] - OFST, args[0] - OFST, 1);
+        {
+            word32 row = (args[0] > 0) ? args[0] : 1;
+            word32 col = (args[1] > 0) ? args[1] : 1;
+            wolfSSH_CursorMove(handle, col - OFST, row - OFST, 1);
             break;
+        }
 
         case 'C': /* move cursor right */
             wolfSSH_CursorMove(handle, args[0], 0, 0);


### PR DESCRIPTION
This PR fixes the following minor issues:

- Fix Mac comparison in VerifyMac for HMAC failure case
- Delete the incorrect statement in GetOpenSshKey
- Fix cursor mode handling in wolfSSH_DoControlSeq

Addressed by f_520, f_521 and f_522