### PR TITLE
Fix wolfSSH_SFTPNAME_readdir with FATFS

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -3152,12 +3152,14 @@ static int wolfSSH_SFTPNAME_readdir(WOLFSSH* ssh, WDIR* dir, WS_SFTPNAME* out,
                 >= (int)sizeof(r)) {
             WLOG(WS_LOG_SFTP, "Path length too large");
             WFREE(out->fName, out->heap, DYNTYPE_SFTP);
+            out->fName = NULL;
             return WS_FATAL_ERROR;
         }
 
         if (wolfSSH_RealPath(ssh->sftpDefaultPath, r, s, sizeof(s)) < 0) {
             WLOG(WS_LOG_SFTP, "Error cleaning path to get attributes");
             WFREE(out->fName, out->heap, DYNTYPE_SFTP);
+            out->fName = NULL;
             return WS_FATAL_ERROR;
         }
         if (SFTP_GetAttributes(ssh->fs, s, &out->atrb, 0, ssh->ctx->heap)
@@ -3165,6 +3167,7 @@ static int wolfSSH_SFTPNAME_readdir(WOLFSSH* ssh, WDIR* dir, WS_SFTPNAME* out,
             WLOG(WS_LOG_SFTP, "Unable to get attribute values for %s",
                     out->fName);
             WFREE(out->fName, out->heap, DYNTYPE_SFTP);
+            out->fName = NULL;
             return WS_FATAL_ERROR;
         }
     }
@@ -3173,6 +3176,7 @@ static int wolfSSH_SFTPNAME_readdir(WOLFSSH* ssh, WDIR* dir, WS_SFTPNAME* out,
     if (SFTP_CreateLongName(out) != WS_SUCCESS) {
         WLOG(WS_LOG_DEBUG, "Error creating long name for %s", out->fName);
         WFREE(out->fName, out->heap, DYNTYPE_SFTP);
+        out->fName = NULL;
         return WS_FATAL_ERROR;
     }
     return WS_SUCCESS;

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -3130,7 +3130,7 @@ static int wolfSSH_SFTPNAME_readdir(WOLFSSH* ssh, WDIR* dir, WS_SFTPNAME* out,
     }
     dp = &f;
 
-    if (f_readdir(dir, dp) != FR_OK) {
+    if (f_readdir(dir, dp) != FR_OK || dp->fname[0] == 0) {
         return WS_FATAL_ERROR;
     }
     sz = (int)WSTRLEN(dp->fname);


### PR DESCRIPTION
This PR fixes the following issues for wolfSSH_SFTPNAME_readdir with FATFS:

- f_readdir returns FR_OK with empty string in fname when there is no directory entry left
- wolfSSH_SFTPNAME_free would crash because of a double free in case wolfSSH_SFTPNAME_readdir returns an error and frees fName without setting it to NULL

