### PR TITLE
Fix SFTP_GetAttributes with fatfs for root

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -4861,9 +4861,6 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
     (void) noFollow;
     (void) heap;
 
-    ret = f_stat(fileName, &info);
-    if (ret != FR_OK)
-        return -1;
     WMEMSET(atr, 0, sizeof(WS_SFTP_FILEATRB));
     if (sz > 2 && fileName[sz - 2] == ':') {
         atr->flags |= WOLFSSH_FILEATRB_PERM;
@@ -4872,12 +4869,14 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
     }
 
     /* handle case of "/" */
+    /* Calling f_stat for "/" returns FR_INVALID_NAME. So we simulate the result. */
     if (sz < 3 && fileName[0] == WS_DELIM) {
         atr->flags |= WOLFSSH_FILEATRB_PERM;
         atr->per |= 0x4000;
         return WS_SUCCESS;
     }
 
+    ret = f_stat(fileName, &info);
     if (ret != FR_OK) {
         return WS_BAD_FILE_E;
     }


### PR DESCRIPTION
After updating Filezilla to 3.70.5 (from 3.69.1) we got an error message during reception of the directory content. Connecting to a home directory not being root works. (This took us a while to find out.)

We tracked it down to SFTP_GetAttributes where f_stat is called for "/". f_stat doesn't support this and returns FR_INVALID_NAME. Interestingly, the code handling this is mainly there. But the function returns too early.