### PR TITLE
Static analysis fixes

### DIFF
--- a/apps/wolfssh/common.c
+++ b/apps/wolfssh/common.c
@@ -144,6 +144,9 @@ static int ParseRFC6187(const byte* in, word32 inSz, byte** leafOut,
 
     /* Skip the name */
     ato32(in, &l);
+    if (l > inSz - sizeof(word32))
+        return WS_BUFFER_E;
+
     m += l + sizeof(word32);
 
     /* Get the cert count */

--- a/src/internal.c
+++ b/src/internal.c
@@ -2584,6 +2584,7 @@ int GenerateKey(byte hashId, byte keyId,
                 ret = wc_HashFinal(&hash, enmhashId, lastBlock);
                 if (ret == WS_SUCCESS)
                     WMEMCPY(key, lastBlock, remainder);
+                ForceZero(lastBlock, sizeof(lastBlock));
             }
         }
         else {
@@ -2629,6 +2630,7 @@ int GenerateKey(byte hashId, byte keyId,
                     ret = wc_HashFinal(&hash, enmhashId, lastBlock);
                 if (ret == WS_SUCCESS)
                     WMEMCPY(key + runningKeySz, lastBlock, remainder);
+                ForceZero(lastBlock, sizeof(lastBlock));
             }
         }
     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -13476,7 +13476,7 @@ int SendKexDhGexGroup(WOLFSSH* ssh)
     int ret = WS_SUCCESS;
 
     WLOG(WS_LOG_DEBUG, "Entering SendKexDhGexGroup()");
-    if (ssh == NULL)
+    if (ssh == NULL || ssh->handshake == NULL)
         ret = WS_BAD_ARGUMENT;
 
     if (ret == WS_SUCCESS) {
@@ -13523,8 +13523,11 @@ int SendKexDhGexGroup(WOLFSSH* ssh)
         ret = BundlePacket(ssh);
     }
 
-    if (ret == WS_SUCCESS)
+    if (ret == WS_SUCCESS) {
+        WLOG_EXPECT_MSGID(MSGID_KEXDH_GEX_INIT);
+        ssh->handshake->expectMsgId = MSGID_KEXDH_GEX_INIT;
         ret = wolfSSH_SendPacket(ssh);
+    }
 
     WLOG(WS_LOG_DEBUG, "Leaving SendKexDhGexGroup(), ret = %d", ret);
     return ret;

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1868,7 +1868,7 @@ static int DoPemKey(const byte* in, word32 inSz, byte** out,
     WOLFSSH_UNUSED(heap);
 
     if (*out == NULL) {
-        newKey = (byte*)WMALLOC(inSz, heap, DYNTYPE_PRIVKEY);
+        newKey = (byte*)WMALLOC(newKeySz, heap, DYNTYPE_PRIVKEY);
         if (newKey == NULL) {
             return WS_MEMORY_E;
         }
@@ -1879,6 +1879,7 @@ static int DoPemKey(const byte* in, word32 inSz, byte** out,
             return WS_BUFFER_E;
         }
         newKey = *out;
+        newKeySz = *outSz;
     }
 
     /* If it is PEM, convert to ASN1 then process. */
@@ -1914,6 +1915,7 @@ static int DoPemKey(const byte* in, word32 inSz, byte** out,
     }
     else {
         WLOG(WS_LOG_DEBUG, "Unable to identify PEM key");
+        ForceZero(newKey, newKeySz);
         if (*out == NULL) {
             WFREE(newKey, heap, DYNTYPE_PRIVKEY);
         }
@@ -1943,6 +1945,7 @@ static int DoOpenSshKey(const byte* in, word32 inSz, byte** out,
             return WS_BUFFER_E;
         }
         newKey = *out;
+        newKeySz = *outSz;
     }
 
     in += WSTRLEN(PrivBeginOpenSSH);
@@ -1970,6 +1973,7 @@ static int DoOpenSshKey(const byte* in, word32 inSz, byte** out,
     }
     else {
         WLOG(WS_LOG_DEBUG, "Unable to identify key");
+        ForceZero(newKey, newKeySz);
         if (*out == NULL) {
             WFREE(newKey, heap, DYNTYPE_PRIVKEY);
         }
@@ -2122,6 +2126,7 @@ int wolfSSH_ReadKey_file(const char* name,
     }
 
     WFCLOSE(NULL, file);
+    ForceZero(in, inSz);
     WFREE(in, heap, DYNTYPE_FILE);
 
     return ret;


### PR DESCRIPTION
- Pin expectMsgId to MSGID_KEXDH_GEX_INIT after KEXDH_GEX_GROUP; null-check ssh->handshake (F-3668).
- Reject ParseRFC6187 name lengths that would overflow when added to sizeof(word32), preventing OOB reads (F-1277).
- ForceZero the lastBlock stack buffers on both remainder paths in GenerateKey (F-2494).
- ForceZero newKey before free in DoPemKey/DoOpenSshKey and the PEM read buffer in wolfSSH_ReadKey_file (F-2885, F-3211, F-3212).
