### PR TITLE
Fix minor issues and Add test vectors

### DIFF
--- a/apps/wolfsshd/configuration.c
+++ b/apps/wolfsshd/configuration.c
@@ -103,13 +103,17 @@ static long GetConfigInt(const char* in, int inSz, int isTime, void* heap)
     int mult = 1; /* multiplier */
     int sz   = inSz;
 
+    if (in == NULL || inSz <= 0) {
+        ret = WS_BAD_ARGUMENT;
+    }
+
     /* check for multipliers */
-    if (isTime) {
+    if (ret == 0 && isTime) {
         if (in[sz - 1] == 'm') {
             sz--;
             mult = 60;
         }
-        if (in[sz - 1] == 'h') {
+        else if (in[sz - 1] == 'h') {
             sz--;
             mult = 60*60;
         }

--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -229,6 +229,8 @@ static int test_ParseConfigLine(void)
         {"Valid login grace time minutes", "LoginGraceTime 1m", 0},
         {"Valid login grace time hours", "LoginGraceTime 1h", 0},
         {"Invalid login grace time", "LoginGraceTime wolfsshd", 1},
+        {"Bare multiplier m (no digit)", "LoginGraceTime m", 1},
+        {"Bare multiplier h (no digit)", "LoginGraceTime h", 1},
 
         /* Permit empty password tests. */
         {"Permit empty password no", "PermitEmptyPasswords no", 0},

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -296,9 +296,6 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
     if (ret != WS_SUCCESS)
         err_sys("Couldn't set the session's socket.");
 
-    if (ret != WS_SUCCESS)
-        err_sys("Couldn't set the channel type.");
-
     do {
         if (dir == copyFromSrv)
             ret = wolfSSH_SCP_from(ssh, path1, path2);

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -1835,12 +1835,11 @@ int wolfSSH_SFTP_RecvRMDIR(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
  */
 int wolfSSH_SFTP_RecvMKDIR(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
 {
-    word32 attrFlags;
+    WS_SFTP_FILEATRB atr;
     word32 strSz;
     const byte* str;
     int    ret;
     char   dir[WOLFSSH_MAX_FILENAME];
-    word32 mode = 0;
     word32 idx  = 0;
     byte*  out;
     word32 outSz = 0;
@@ -1866,22 +1865,26 @@ int wolfSSH_SFTP_RecvMKDIR(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
         return ret;
     }
 
-    if (GetUint32(&attrFlags, data, maxSz, &idx) != WS_SUCCESS) {
+    if (SFTP_ParseAttributes_buffer(ssh, &atr, data, &idx, maxSz)
+            != WS_SUCCESS) {
         return WS_BUFFER_E;
     }
-    if (attrFlags != WOLFSSH_FILEATRB_PERM) {
-        WLOG(WS_LOG_SFTP, "Only permission attribute supported");
-        WLOG(WS_LOG_SFTP, "Skipping over attribute and using default");
-        mode = 040755;
-    }
-    else {
-        if (GetUint32(&mode, data, maxSz, &idx) != WS_SUCCESS) {
-            return WS_BUFFER_E;
-        }
-    }
-
 #ifndef USE_WINDOWS_API
-    ret = WMKDIR(ssh->fs, dir, mode);
+#ifndef WOLFSSH_FATFS
+    {
+        word32 mode = 040755;
+        if (atr.flags & WOLFSSH_FILEATRB_PERM) {
+            mode = atr.per;
+        }
+        else {
+            WLOG(WS_LOG_SFTP, "No permission attribute, using default");
+        }
+        ret = WMKDIR(ssh->fs, dir, mode);
+    }
+#else /* WOLFSSH_FATFS */
+    /* WMKDIR for FatFS drops mode argument */
+    ret = WMKDIR(ssh->fs, dir, 0);
+#endif /* WOLFSSH_FATFS */
 #else /* USE_WINDOWS_API */
     ret = WS_CreateDirectoryA(dir, ssh->ctx->heap) == 0;
 #endif /* USE_WINDOWS_API */


### PR DESCRIPTION
This PR fixes the following things:

- Remove dead check in scp_client()
- Fix input validation in GetConfigInt()
- Fix attributes validation in wolfSSH_SFTP_RecvMKDIR()

Also, this adds the test vector for GetConfigInt().

Addressed by f_3443, f_3670 and f_3875.