### PR TITLE
UTF-8 -> 7-bit ASCII cleanup

### DIFF
--- a/ide/Renesas/cs+/README.md
+++ b/ide/Renesas/cs+/README.md
@@ -45,7 +45,7 @@ This demo is tested with the following condition.
   - Add project properties of linking library in ap_rx71m_0a_usbfunc_sample_cs.mtpj  
     wolfssh\ide\Renesas\cs+\Projects\wolfssl_lib\DefaultBuild\wolfssl_lib.lib  
     wolfssh\ide\Renesas\cs+\Projects\wolfssh_lib\DefaultBuild\wolfssh_lib.lib  
-　  wolfssh\ide\Renesas\cs+\Projects\demo_server\DefaultBuild\demo_sever.lib 
+    wolfssh\ide\Renesas\cs+\Projects\demo_server\DefaultBuild\demo_sever.lib
     
   - Set CC-RX(Build Tool)->Library Geberation->Library Configuration to"C99" and enable ctype.h.
 

--- a/ide/winvs/README.md
+++ b/ide/winvs/README.md
@@ -97,9 +97,9 @@ If you build the wolfSSL FIPS code in the **Release x64** configuration,
 then you should build wolfSSH with the **ReleaseFIPS x64** configuration.
 
 Similarly:
-- wolfSSL **Debug x64** → wolfSSH **DebugFIPS x64**
-- wolfSSL **Release Win32** → wolfSSH **ReleaseFIPS Win32**
-- wolfSSL **DLL Release x64** → wolfSSH **DLL ReleaseFIPS x64**
+- wolfSSL **Debug x64** -> wolfSSH **DebugFIPS x64**
+- wolfSSL **Release Win32** -> wolfSSH **ReleaseFIPS Win32**
+- wolfSSL **DLL Release x64** -> wolfSSH **DLL ReleaseFIPS x64**
 
 **Notes:**
 * wolfSSH examples and applications might initially fail because the FIPS Integrity

--- a/src/internal.c
+++ b/src/internal.c
@@ -9723,7 +9723,7 @@ static int DoChannelRequest(WOLFSSH* ssh,
         else if (WSTRNCMP(type, "window-change", typeSz) == 0) {
             word32 widthChar, heightRows, widthPixels, heightPixels;
 
-            wantReply = 0; /* RFC 4254 §6.7: no reply for window-change */
+            wantReply = 0; /* RFC 4254 sec 6.7: no reply for window-change */
             ret = GetUint32(&widthChar, buf, len, &begin);
             if (ret == WS_SUCCESS)
                 ret = GetUint32(&heightRows, buf, len, &begin);
@@ -9753,7 +9753,7 @@ static int DoChannelRequest(WOLFSSH* ssh,
         #endif /* WOLFSSH_SHELL && WOLFSSH_TERM */
         #if defined(WOLFSSH_TERM) || defined(WOLFSSH_SHELL)
         else if (WSTRNCMP(type, "exit-status", typeSz) == 0) {
-            wantReply = 0; /* RFC 4254 §6.10: no reply for exit-status */
+            wantReply = 0; /* RFC 4254 sec 6.10: no reply for exit-status */
             ret = GetUint32(&ssh->exitStatus, buf, len, &begin);
             WLOG(WS_LOG_AGENT, "Got exit status %u.", ssh->exitStatus);
         }
@@ -9762,7 +9762,7 @@ static int DoChannelRequest(WOLFSSH* ssh,
             word32 sigSz;
             byte coreDumped;
 
-            wantReply = 0; /* RFC 4254 §6.10: no reply for exit-signal */
+            wantReply = 0; /* RFC 4254 sec 6.10: no reply for exit-signal */
             WLOG(WS_LOG_AGENT, "Got exit signal, remote command terminated");
 
             sigSz = WOLFSSH_MAX_NAMESZ;

--- a/tests/auth.c
+++ b/tests/auth.c
@@ -829,7 +829,7 @@ static void test_pubkey_auth_wrong_key(void)
 
 /* -----------------------------------------------------------------------
  * Password auth: unknown callback return value must not grant auth (issue 2486)
- * This block intentionally has no NO_SHA256 guard — password auth does not
+ * This block intentionally has no NO_SHA256 guard -- password auth does not
  * use SHA256.  The surrounding utility functions (tcp_listen, load_key, etc.)
  * are available because they share the base server/client/threading guard.
  * ----------------------------------------------------------------------- */

--- a/tests/regress.c
+++ b/tests/regress.c
@@ -1491,8 +1491,8 @@ static void TestGlobalRequestFwdCancelWithCbSendsSuccess(void)
 }
 
 /* Verify DoRequestSuccess correctly consumes a uint32 port payload (RFC 4254
- * §4) without treating it as a length prefix, which would overrun the buffer
- * and produce WS_BUFFER_E. */
+ * sec 4) without treating it as a length prefix, which would overrun the
+ * buffer and produce WS_BUFFER_E. */
 static void TestRequestSuccessWithPortParsesCorrectly(void)
 {
     ChannelOpenHarness harness;
@@ -2207,7 +2207,7 @@ static void TestIndependentAlgoNegotiation(void)
     AssertIntEQ(ssh->handshake->macId,         ID_HMAC_SHA2_256);
     AssertIntEQ(ssh->handshake->peerAeadMode,  0);
     AssertIntEQ(ssh->handshake->aeadMode,      0);
-    /* Key sizes — server: C2S→peerKeys, S2C→keys. Validates the
+    /* Key sizes -- server: C2S->peerKeys, S2C->keys. Validates the
      * side-aware DoKexInit fix: wrong mapping would swap these sizes. */
     AssertIntEQ(ssh->handshake->peerKeys.encKeySz, AES_128_KEY_SIZE);
     AssertIntEQ(ssh->handshake->keys.encKeySz,     AES_256_KEY_SIZE);
@@ -2215,7 +2215,7 @@ static void TestIndependentAlgoNegotiation(void)
     AssertIntEQ(ssh->handshake->keys.ivSz,         AES_BLOCK_SIZE);
     AssertIntEQ(ssh->handshake->peerKeys.macKeySz, WC_SHA_DIGEST_SIZE);
     AssertIntEQ(ssh->handshake->keys.macKeySz,     WC_SHA256_DIGEST_SIZE);
-    /* Block/mac sizes — server: C2S→peer*, S2C→local. */
+    /* Block/mac sizes -- server: C2S->peer*, S2C->local. */
     AssertIntEQ(ssh->handshake->peerBlockSz, AES_BLOCK_SIZE);
     AssertIntEQ(ssh->handshake->blockSz,     AES_BLOCK_SIZE);
     AssertIntEQ(ssh->handshake->peerMacSz,   WC_SHA_DIGEST_SIZE);
@@ -2223,7 +2223,7 @@ static void TestIndependentAlgoNegotiation(void)
     wolfSSH_free(ssh);
 
 #ifndef WOLFSSH_NO_AES_GCM
-    /* Sub-test B: AEAD S2C, non-AEAD C2S — MAC only negotiated for C2S */
+    /* Sub-test B: AEAD S2C, non-AEAD C2S -- MAC only negotiated for C2S */
     ssh = wolfSSH_new(ctx);
     AssertNotNull(ssh);
     AssertIntEQ(wolfSSH_SetAlgoListKex(ssh, FPF_KEX_GOOD), WS_SUCCESS);
@@ -2280,8 +2280,8 @@ static void TestIndependentAlgoNegotiationClient(void)
     AssertNotNull(ctx);
 
     /* Sub-test A: different non-AEAD cipher and MAC per direction.
-     * Client mapping is the mirror of server: C2S→keys/encryptId,
-     * S2C→peerKeys/peerEncryptId.  A swap bug would make these asserts fail. */
+     * Client mapping is the mirror of server: C2S->keys/encryptId,
+     * S2C->peerKeys/peerEncryptId.  A swap bug would make these asserts fail. */
     ssh = wolfSSH_new(ctx);
     AssertNotNull(ssh);
     AssertIntEQ(wolfSSH_SetAlgoListKex(ssh, FPF_KEX_GOOD), WS_SUCCESS);
@@ -2302,7 +2302,7 @@ static void TestIndependentAlgoNegotiationClient(void)
      * callback is set up. We only care about the negotiated algorithm IDs. */
     (void)wolfSSH_TestDoKexInit(ssh, payload, payloadSz, &idx);
     AssertNotNull(ssh->handshake);
-    /* Client: C2S is local outgoing → encryptId/keys */
+    /* Client: C2S is local outgoing -> encryptId/keys */
     AssertIntEQ(ssh->handshake->encryptId,     ID_AES128_CBC);
     AssertIntEQ(ssh->handshake->peerEncryptId, ID_AES256_CTR);
     AssertIntEQ(ssh->handshake->macId,         ID_HMAC_SHA1);
@@ -2315,7 +2315,7 @@ static void TestIndependentAlgoNegotiationClient(void)
     AssertIntEQ(ssh->handshake->peerKeys.ivSz,     AES_BLOCK_SIZE);
     AssertIntEQ(ssh->handshake->keys.macKeySz,     WC_SHA_DIGEST_SIZE);
     AssertIntEQ(ssh->handshake->peerKeys.macKeySz, WC_SHA256_DIGEST_SIZE);
-    /* Block/mac sizes — client: C2S→local (block/macSz), S2C→peer (peerBlock/MacSz). */
+    /* Block/mac sizes -- client: C2S->local (block/macSz), S2C->peer (peerBlock/MacSz). */
     AssertIntEQ(ssh->handshake->blockSz,     AES_BLOCK_SIZE);
     AssertIntEQ(ssh->handshake->peerBlockSz, AES_BLOCK_SIZE);
     AssertIntEQ(ssh->handshake->macSz,       WC_SHA_DIGEST_SIZE);
@@ -2323,7 +2323,7 @@ static void TestIndependentAlgoNegotiationClient(void)
     wolfSSH_free(ssh);
 
 #ifndef WOLFSSH_NO_AES_GCM
-    /* Sub-test B: AEAD S2C, non-AEAD C2S — client perspective. */
+    /* Sub-test B: AEAD S2C, non-AEAD C2S -- client perspective. */
     ssh = wolfSSH_new(ctx);
     AssertNotNull(ssh);
     AssertIntEQ(wolfSSH_SetAlgoListKex(ssh, FPF_KEX_GOOD), WS_SUCCESS);
@@ -2344,7 +2344,7 @@ static void TestIndependentAlgoNegotiationClient(void)
      * callback is set up. We only care about the negotiated algorithm IDs. */
     (void)wolfSSH_TestDoKexInit(ssh, payload, payloadSz, &idx);
     AssertNotNull(ssh->handshake);
-    /* Client: C2S→encryptId/keys, S2C→peerEncryptId/peerKeys */
+    /* Client: C2S->encryptId/keys, S2C->peerEncryptId/peerKeys */
     AssertIntEQ(ssh->handshake->encryptId,     ID_AES128_CBC);
     AssertIntEQ(ssh->handshake->peerEncryptId, ID_AES256_GCM);
     AssertIntEQ(ssh->handshake->aeadMode,      0);
@@ -2369,7 +2369,7 @@ static void TestIndependentAlgoNegotiationClient(void)
 }
 
 /* Verify WS_MATCH_ENC_ALGO_E when exactly one direction's cipher list has no
- * match in the local algoListCipher — the new per-direction S2C matching path
+ * match in the local algoListCipher -- the new per-direction S2C matching path
  * introduced by the independent-algo-negotiation change. */
 static void TestEncMismatch(void)
 {
@@ -2433,7 +2433,7 @@ static void TestEncMismatch(void)
 }
 
 /* Verify WS_MATCH_MAC_ALGO_E when exactly one direction's MAC list has no
- * match in the local algoListMac — the new per-direction S2C MAC matching path.
+ * match in the local algoListMac -- the new per-direction S2C MAC matching path.
  * Both cipher directions must succeed so that MAC negotiation is reached. */
 static void TestMacMismatch(void)
 {
@@ -2541,7 +2541,7 @@ static void TestGenerateKeysSplit(void)
     (void)wolfSSH_TestDoKexInit(ssh, payload, payloadSz, &idx);
     AssertNotNull(ssh->handshake);
 
-    /* Synthetic K/H/sessionId — any non-zero values produce valid key material. */
+    /* Synthetic K/H/sessionId -- any non-zero values produce valid key material. */
     WMEMSET(ssh->k, 0xAA, WC_SHA256_DIGEST_SIZE);
     ssh->kSz = WC_SHA256_DIGEST_SIZE;
     WMEMSET(ssh->h, 0xBB, WC_SHA256_DIGEST_SIZE);
@@ -2551,7 +2551,7 @@ static void TestGenerateKeysSplit(void)
 
     AssertIntEQ(wolfSSH_TestGenerateKeys(ssh, ssh->handshake->kexHashId), WS_SUCCESS);
 
-    /* C2S direction (server: peerKeys) — aes128-cbc + hmac-sha1. */
+    /* C2S direction (server: peerKeys) -- aes128-cbc + hmac-sha1. */
     AssertIntEQ(ssh->handshake->peerKeys.encKeySz, AES_128_KEY_SIZE);
     AssertTrue(WMEMCMP(ssh->handshake->peerKeys.encKey, zeros,
                        AES_128_KEY_SIZE) != 0);
@@ -2559,7 +2559,7 @@ static void TestGenerateKeysSplit(void)
     AssertTrue(WMEMCMP(ssh->handshake->peerKeys.macKey, zeros,
                        WC_SHA_DIGEST_SIZE) != 0);
 
-    /* S2C direction (server: keys) — aes256-ctr + hmac-sha2-256. */
+    /* S2C direction (server: keys) -- aes256-ctr + hmac-sha2-256. */
     AssertIntEQ(ssh->handshake->keys.encKeySz, AES_256_KEY_SIZE);
     AssertTrue(WMEMCMP(ssh->handshake->keys.encKey, zeros,
                        AES_256_KEY_SIZE) != 0);
@@ -2620,7 +2620,7 @@ static void TestGenerateKeysSplit(void)
 #endif /* !WOLFSSH_NO_AES_GCM */
 
 #ifndef WOLFSSH_NO_AES_GCM
-    /* Sub-test C: aes256-gcm C2S (AEAD) / aes128-cbc S2C (non-AEAD) — mirror.
+    /* Sub-test C: aes256-gcm C2S (AEAD) / aes128-cbc S2C (non-AEAD) -- mirror.
      * Verifies that key 'E' is skipped (peerKeys.macKeySz==0) while key 'F'
      * is generated for the non-AEAD S2C direction. */
     ssh = wolfSSH_new(ctx);
@@ -2663,7 +2663,7 @@ static void TestGenerateKeysSplit(void)
 
     wolfSSH_free(ssh);
 
-    /* Sub-test D: aes256-gcm C2S (AEAD) / aes256-gcm S2C (AEAD) — symmetric.
+    /* Sub-test D: aes256-gcm C2S (AEAD) / aes256-gcm S2C (AEAD) -- symmetric.
      * Both macKeySz==0; both key 'E' and key 'F' generation skipped.
      * Directly validates the per-direction macKeySz>0 guards in GenerateKeys. */
     ssh = wolfSSH_new(ctx);
@@ -2723,8 +2723,8 @@ static void TestGenerateKeysSplitClient(void)
     ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_CLIENT, NULL);
     AssertNotNull(ctx);
 
-    /* Sub-test A: aes128-cbc C2S / aes256-ctr S2C — client mapping.
-     * Client: C2S→keys (local outgoing), S2C→peerKeys (peer outgoing). */
+    /* Sub-test A: aes128-cbc C2S / aes256-ctr S2C -- client mapping.
+     * Client: C2S->keys (local outgoing), S2C->peerKeys (peer outgoing). */
     ssh = wolfSSH_new(ctx);
     AssertNotNull(ssh);
     AssertIntEQ(wolfSSH_SetAlgoListKex(ssh, FPF_KEX_GOOD), WS_SUCCESS);
@@ -2755,7 +2755,7 @@ static void TestGenerateKeysSplitClient(void)
 
     AssertIntEQ(wolfSSH_TestGenerateKeys(ssh, ssh->handshake->kexHashId), WS_SUCCESS);
 
-    /* C2S direction (client: keys) — aes128-cbc + hmac-sha1. */
+    /* C2S direction (client: keys) -- aes128-cbc + hmac-sha1. */
     AssertIntEQ(ssh->handshake->keys.encKeySz, AES_128_KEY_SIZE);
     AssertTrue(WMEMCMP(ssh->handshake->keys.encKey, zeros,
                        AES_128_KEY_SIZE) != 0);
@@ -2763,7 +2763,7 @@ static void TestGenerateKeysSplitClient(void)
     AssertTrue(WMEMCMP(ssh->handshake->keys.macKey, zeros,
                        WC_SHA_DIGEST_SIZE) != 0);
 
-    /* S2C direction (client: peerKeys) — aes256-ctr + hmac-sha2-256. */
+    /* S2C direction (client: peerKeys) -- aes256-ctr + hmac-sha2-256. */
     AssertIntEQ(ssh->handshake->peerKeys.encKeySz, AES_256_KEY_SIZE);
     AssertTrue(WMEMCMP(ssh->handshake->peerKeys.encKey, zeros,
                        AES_256_KEY_SIZE) != 0);
@@ -2778,7 +2778,7 @@ static void TestGenerateKeysSplitClient(void)
     wolfSSH_free(ssh);
 
 #ifndef WOLFSSH_NO_AES_GCM
-    /* Sub-test B: aes128-cbc C2S (non-AEAD) / aes256-gcm S2C (AEAD) — client.
+    /* Sub-test B: aes128-cbc C2S (non-AEAD) / aes256-gcm S2C (AEAD) -- client.
      * keys.macKeySz must be set; peerKeys.macKeySz must be 0 (AEAD, no MAC). */
     ssh = wolfSSH_new(ctx);
     AssertNotNull(ssh);
@@ -2822,8 +2822,8 @@ static void TestGenerateKeysSplitClient(void)
 
     wolfSSH_free(ssh);
 
-    /* Sub-test C: aes256-gcm C2S (AEAD) / aes128-cbc S2C (non-AEAD) — mirror.
-     * Client: C2S→keys (local outgoing), S2C→peerKeys (peer outgoing).
+    /* Sub-test C: aes256-gcm C2S (AEAD) / aes128-cbc S2C (non-AEAD) -- mirror.
+     * Client: C2S->keys (local outgoing), S2C->peerKeys (peer outgoing).
      * Verifies key 'E' skipped (keys.macKeySz==0) and key 'F' generated. */
     ssh = wolfSSH_new(ctx);
     AssertNotNull(ssh);
@@ -2865,7 +2865,7 @@ static void TestGenerateKeysSplitClient(void)
 
     wolfSSH_free(ssh);
 
-    /* Sub-test D: aes256-gcm C2S (AEAD) / aes256-gcm S2C (AEAD) — symmetric.
+    /* Sub-test D: aes256-gcm C2S (AEAD) / aes256-gcm S2C (AEAD) -- symmetric.
      * Both macKeySz==0; both key 'E' and key 'F' generation skipped. */
     ssh = wolfSSH_new(ctx);
     AssertNotNull(ssh);
@@ -2921,7 +2921,7 @@ static void TestDoNewKeys(void)
     byte expectedPeerAeadMode;
     Keys savedPeerKeys;
 
-    /* Sub-test A: aes128-cbc C2S / aes256-ctr S2C — non-AEAD both dirs.
+    /* Sub-test A: aes128-cbc C2S / aes256-ctr S2C -- non-AEAD both dirs.
      * After DoNewKeys on the server, ssh->peer* must reflect the C2S (peer
      * outgoing) direction, not the S2C (local outgoing) direction. */
     ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
@@ -3031,8 +3031,8 @@ static void TestDoNewKeys(void)
     wolfSSH_CTX_free(ctx);
 #endif /* !WOLFSSH_NO_AES_GCM */
 
-    /* Sub-test C: client mirror of A — aes128-cbc C2S / aes256-ctr S2C.
-     * Client: C2S→keys (local), S2C→peerKeys (peer).  After DoNewKeys,
+    /* Sub-test C: client mirror of A -- aes128-cbc C2S / aes256-ctr S2C.
+     * Client: C2S->keys (local), S2C->peerKeys (peer).  After DoNewKeys,
      * ssh->peer* must reflect the S2C (server outgoing) direction. */
     ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_CLIENT, NULL);
     AssertNotNull(ctx);
@@ -3086,7 +3086,7 @@ static void TestDoNewKeys(void)
     wolfSSH_CTX_free(ctx);
 
 #ifndef WOLFSSH_NO_AES_GCM
-    /* Sub-test D: client mirror of B — aes128-cbc C2S (non-AEAD) /
+    /* Sub-test D: client mirror of B -- aes128-cbc C2S (non-AEAD) /
      * aes256-gcm S2C (AEAD).  Verifies peerAeadMode==1 (S2C AEAD) rather
      * than 0 (C2S non-AEAD), catching regression to handshake->aeadMode. */
     ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_CLIENT, NULL);

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -1347,21 +1347,21 @@ static int test_DoChannelSuccess(void)
         goto done;
     }
 
-    /* Short buffer → WS_BUFFER_E */
+    /* Short buffer -> WS_BUFFER_E */
     idx = 0;
     ret = wolfSSH_TestDoChannelSuccess(ssh, (byte*)payShort,
                                        (word32)sizeof(payShort), &idx);
     if (ret != WS_BUFFER_E) { result = -510; goto done; }
     if (idx != 0) { result = -514; goto done; }
 
-    /* Unknown channel → WS_INVALID_CHANID */
+    /* Unknown channel -> WS_INVALID_CHANID */
     idx = 0;
     ret = wolfSSH_TestDoChannelSuccess(ssh, (byte*)payUnknown,
                                        (word32)sizeof(payUnknown), &idx);
     if (ret != WS_INVALID_CHANID) { result = -511; goto done; }
     if (idx != 4) { result = -515; goto done; }
 
-    /* Happy path → WS_SUCCESS, serverState == SERVER_DONE */
+    /* Happy path -> WS_SUCCESS, serverState == SERVER_DONE */
     idx = 0;
     ret = wolfSSH_TestDoChannelSuccess(ssh, (byte*)payOk,
                                        (word32)sizeof(payOk), &idx);
@@ -1404,21 +1404,21 @@ static int test_DoChannelFailure(void)
         goto done;
     }
 
-    /* Short buffer → WS_BUFFER_E */
+    /* Short buffer -> WS_BUFFER_E */
     idx = 0;
     ret = wolfSSH_TestDoChannelFailure(ssh, (byte*)payShort,
                                        (word32)sizeof(payShort), &idx);
     if (ret != WS_BUFFER_E) { result = -530; goto done; }
     if (idx != 0) { result = -533; goto done; }
 
-    /* Unknown channel → WS_INVALID_CHANID */
+    /* Unknown channel -> WS_INVALID_CHANID */
     idx = 0;
     ret = wolfSSH_TestDoChannelFailure(ssh, (byte*)payUnknown,
                                        (word32)sizeof(payUnknown), &idx);
     if (ret != WS_INVALID_CHANID) { result = -531; goto done; }
     if (idx != 4) { result = -534; goto done; }
 
-    /* Happy path → WS_CHANOPEN_FAILED */
+    /* Happy path -> WS_CHANOPEN_FAILED */
     idx = 0;
     ret = wolfSSH_TestDoChannelFailure(ssh, (byte*)payOk,
                                        (word32)sizeof(payOk), &idx);
@@ -1485,13 +1485,13 @@ static int test_DoChannelData_overflow(void)
         goto done;
     }
 
-    /* dataSz=65 > maxPacketSz=64 → WS_RECV_OVERFLOW_E */
+    /* dataSz=65 > maxPacketSz=64 -> WS_RECV_OVERFLOW_E */
     idx = 0;
     ret = wolfSSH_TestDoChannelData(ssh, (byte*)payOver,
                                     (word32)sizeof(payOver), &idx);
     if (ret != WS_RECV_OVERFLOW_E) { result = -550; goto done; }
 
-    /* dataSz=32 ≤ maxPacketSz=64 → WS_CHAN_RXD */
+    /* dataSz=32 <= maxPacketSz=64 -> WS_CHAN_RXD */
     idx = 0;
     ret = wolfSSH_TestDoChannelData(ssh, (byte*)payOk,
                                     (word32)sizeof(payOk), &idx);
@@ -1566,13 +1566,13 @@ static int test_DoChannelExtendedData_overflow(void)
         goto done;
     }
 
-    /* dataSz=65 > maxPacketSz=64 → WS_RECV_OVERFLOW_E */
+    /* dataSz=65 > maxPacketSz=64 -> WS_RECV_OVERFLOW_E */
     idx = 0;
     ret = wolfSSH_TestDoChannelExtendedData(ssh, (byte*)payOver,
                                             (word32)sizeof(payOver), &idx);
     if (ret != WS_RECV_OVERFLOW_E) { result = -590; goto done; }
 
-    /* dataSz=32 ≤ maxPacketSz=64 → WS_EXTDATA */
+    /* dataSz=32 <= maxPacketSz=64 -> WS_EXTDATA */
     idx = 0;
     ret = wolfSSH_TestDoChannelExtendedData(ssh, (byte*)payOk,
                                             (word32)sizeof(payOk), &idx);
@@ -1611,11 +1611,11 @@ static int test_SendChannelData_eofTxd(void)
 
     ch->eofTxd = 1;
 
-    /* SendChannelData after EOF → WS_EOF */
+    /* SendChannelData after EOF -> WS_EOF */
     ret = SendChannelData(ssh, ch->channel, buf, (word32)sizeof(buf));
     if (ret != WS_EOF) { result = -570; goto done; }
 
-    /* SendChannelExtendedData after EOF → WS_EOF */
+    /* SendChannelExtendedData after EOF -> WS_EOF */
     ret = SendChannelExtendedData(ssh, ch->channel, buf, (word32)sizeof(buf));
     if (ret != WS_EOF) { result = -571; goto done; }
 
@@ -1765,7 +1765,7 @@ static int test_DoChannelRequest(void)
         }
     }
 
-    /* RFC 4254 §6.10: exit-status and exit-signal must not send a reply
+    /* RFC 4254 sec 6.10: exit-status and exit-signal must not send a reply
      * even if the wire wantReply byte is 1. DoChannelRequest overrides
      * wantReply=0 for these types, so no CHANNEL_SUCCESS/FAILURE packet
      * should be emitted. */
@@ -1827,7 +1827,7 @@ static int test_DoChannelRequest(void)
     }
 #endif /* WOLFSSH_TERM || WOLFSSH_SHELL */
 
-    /* RFC 4254 §6.7: window-change must not send a reply even if the
+    /* RFC 4254 sec 6.7: window-change must not send a reply even if the
      * wire wantReply byte is 1. */
 #if defined(WOLFSSH_SHELL) && defined(WOLFSSH_TERM)
     {


### PR DESCRIPTION
1. replace '§' symbol with 'sec'
2. replace '→' with '->'
3. replace '—' with '--'
4. replace '≤' with '<='