### PR TITLE
Add unit tests for wolfSSHD_AuthReducePermissionsUser

### DIFF
--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -79,6 +79,11 @@
 #define HAVE_SHADOW
 #endif
 
+#if defined(WOLFSSHD_UNIT_TEST) && !defined(_WIN32)
+int (*wsshd_setregid_cb)(WGID_T, WGID_T) = setregid;
+int (*wsshd_setreuid_cb)(WUID_T, WUID_T) = setreuid;
+#endif
+
 struct WOLFSSHD_AUTH {
     CallbackCheckUser      checkUserCb;
     CallbackCheckPassword  checkPasswordCb;
@@ -1543,12 +1548,20 @@ int wolfSSHD_AuthReducePermissionsUser(WOLFSSHD_AUTH* auth, WUID_T uid,
     WGID_T gid)
 {
 #ifndef WIN32
+#ifdef WOLFSSHD_UNIT_TEST
+    if (wsshd_setregid_cb(gid, gid) != 0) {
+#else
     if (setregid(gid, gid) != 0) {
+#endif
         wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Error setting user gid");
         return WS_FATAL_ERROR;
     }
 
+#ifdef WOLFSSHD_UNIT_TEST
+    if (wsshd_setreuid_cb(uid, uid) != 0) {
+#else
     if (setreuid(uid, uid) != 0) {
+#endif
         wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Error setting user uid");
         return WS_FATAL_ERROR;
     }

--- a/apps/wolfsshd/auth.h
+++ b/apps/wolfsshd/auth.h
@@ -80,6 +80,10 @@ int wolfSSHD_GetHomeDirectory(WOLFSSHD_AUTH* auth, WOLFSSH* ssh, WCHAR* out, int
 #endif
 
 #ifdef WOLFSSHD_UNIT_TEST
+#ifndef _WIN32
+extern int (*wsshd_setregid_cb)(WGID_T, WGID_T);
+extern int (*wsshd_setreuid_cb)(WUID_T, WUID_T);
+#endif
 #if defined(WOLFSSH_HAVE_LIBCRYPT) || defined(WOLFSSH_HAVE_LIBLOGIN)
 int CheckPasswordHashUnix(const char* input, char* stored);
 #endif

--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -593,6 +593,116 @@ static int test_CheckAuthKeysLine(void)
 }
 #endif /* WOLFSSL_BASE64_ENCODE */
 
+#ifndef _WIN32
+static WGID_T s_setregid_arg0, s_setregid_arg1;
+static WUID_T s_setreuid_arg0, s_setreuid_arg1;
+static int    s_setregid_ret;
+static int    s_setreuid_ret;
+static int    s_setregid_called;
+static int    s_setreuid_called;
+
+static int stub_setregid(WGID_T rgid, WGID_T egid)
+{
+    s_setregid_called = 1;
+    s_setregid_arg0   = rgid;
+    s_setregid_arg1   = egid;
+    return s_setregid_ret;
+}
+
+static int stub_setreuid(WUID_T ruid, WUID_T euid)
+{
+    s_setreuid_called = 1;
+    s_setreuid_arg0   = ruid;
+    s_setreuid_arg1   = euid;
+    return s_setreuid_ret;
+}
+
+static void InstallPrivDropStubs(int regidRet, int reuidRet,
+    int (**savedRegid)(WGID_T, WGID_T),
+    int (**savedReuid)(WUID_T, WUID_T))
+{
+    *savedRegid       = wsshd_setregid_cb;
+    *savedReuid       = wsshd_setreuid_cb;
+    wsshd_setregid_cb = stub_setregid;
+    wsshd_setreuid_cb = stub_setreuid;
+    s_setregid_ret    = regidRet;
+    s_setreuid_ret    = reuidRet;
+    s_setregid_called = 0;
+    s_setreuid_called = 0;
+    s_setregid_arg0   = s_setregid_arg1 = 0;
+    s_setreuid_arg0   = s_setreuid_arg1 = 0;
+}
+
+static int test_AuthReducePermissionsUser_ok(void)
+{
+    int    ret     = WS_SUCCESS;
+    WUID_T testUid = 1001;
+    WGID_T testGid = 1002;
+    int (*savedRegid)(WGID_T, WGID_T);
+    int (*savedReuid)(WUID_T, WUID_T);
+
+    InstallPrivDropStubs(0, 0, &savedRegid, &savedReuid);
+
+    if (wolfSSHD_AuthReducePermissionsUser(NULL, testUid, testGid)
+            != WS_SUCCESS)
+        ret = WS_FATAL_ERROR;
+    if (ret == WS_SUCCESS && !s_setregid_called)
+        ret = WS_FATAL_ERROR;
+    if (ret == WS_SUCCESS
+            && (s_setregid_arg0 != testGid || s_setregid_arg1 != testGid))
+        ret = WS_FATAL_ERROR;
+    if (ret == WS_SUCCESS && !s_setreuid_called)
+        ret = WS_FATAL_ERROR;
+    if (ret == WS_SUCCESS
+            && (s_setreuid_arg0 != testUid || s_setreuid_arg1 != testUid))
+        ret = WS_FATAL_ERROR;
+
+    wsshd_setregid_cb = savedRegid;
+    wsshd_setreuid_cb = savedReuid;
+    return ret;
+}
+
+static int test_AuthReducePermissionsUser_gid_fail(void)
+{
+    int ret = WS_SUCCESS;
+    int (*savedRegid)(WGID_T, WGID_T);
+    int (*savedReuid)(WUID_T, WUID_T);
+
+    InstallPrivDropStubs(-1, 0, &savedRegid, &savedReuid);
+
+    if (wolfSSHD_AuthReducePermissionsUser(NULL, 1001, 1002)
+            != WS_FATAL_ERROR)
+        ret = WS_FATAL_ERROR;
+    if (ret == WS_SUCCESS && !s_setregid_called)
+        ret = WS_FATAL_ERROR;
+    if (ret == WS_SUCCESS && s_setreuid_called)
+        ret = WS_FATAL_ERROR;
+
+    wsshd_setregid_cb = savedRegid;
+    wsshd_setreuid_cb = savedReuid;
+    return ret;
+}
+
+static int test_AuthReducePermissionsUser_uid_fail(void)
+{
+    int ret = WS_SUCCESS;
+    int (*savedRegid)(WGID_T, WGID_T);
+    int (*savedReuid)(WUID_T, WUID_T);
+
+    InstallPrivDropStubs(0, -1, &savedRegid, &savedReuid);
+
+    if (wolfSSHD_AuthReducePermissionsUser(NULL, 1001, 1002)
+            != WS_FATAL_ERROR)
+        ret = WS_FATAL_ERROR;
+    if (ret == WS_SUCCESS && !s_setreuid_called)
+        ret = WS_FATAL_ERROR;
+
+    wsshd_setregid_cb = savedRegid;
+    wsshd_setreuid_cb = savedReuid;
+    return ret;
+}
+#endif /* !_WIN32 */
+
 const TEST_CASE testCases[] = {
     TEST_DECL(test_ConfigDefaults),
     TEST_DECL(test_ParseConfigLine),
@@ -600,6 +710,11 @@ const TEST_CASE testCases[] = {
     TEST_DECL(test_ConfigFree),
 #ifdef WOLFSSL_BASE64_ENCODE
     TEST_DECL(test_CheckAuthKeysLine),
+#endif
+#ifndef _WIN32
+    TEST_DECL(test_AuthReducePermissionsUser_ok),
+    TEST_DECL(test_AuthReducePermissionsUser_gid_fail),
+    TEST_DECL(test_AuthReducePermissionsUser_uid_fail),
 #endif
 #if defined(WOLFSSH_HAVE_LIBCRYPT) || defined(WOLFSSH_HAVE_LIBLOGIN)
     TEST_DECL(test_CheckPasswordHashUnix),


### PR DESCRIPTION
This PR adds unit tests for wolfSSHD_AuthReducePermissionsUser so that this can prevent any mutations against user privilege drop calls on that.