### PR TITLE
Add upper limit of max window size and packet size, Add unit tests

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -2518,8 +2518,12 @@ int wolfSSH_CTX_SetWindowPacketSize(WOLFSSH_CTX* ctx,
     if (ctx == NULL)
         return WS_BAD_ARGUMENT;
 
+    if (windowSz != 0 && windowSz > WINDOW_SZ_UPPER_BOUND)
+        return WS_BAD_ARGUMENT;
     if (windowSz == 0)
         windowSz = DEFAULT_WINDOW_SZ;
+    if (maxPacketSz != 0 && maxPacketSz > MAX_PACKET_SZ)
+        return WS_BAD_ARGUMENT;
     if (maxPacketSz == 0)
         maxPacketSz = DEFAULT_MAX_PACKET_SZ;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -642,6 +642,51 @@ static void test_wolfSSH_CTX_UsePrivateKey_buffer_pem(void)
 }
 
 
+static void test_wolfSSH_CTX_SetWindowPacketSize(void)
+{
+    WOLFSSH_CTX* ctx = NULL;
+
+    /* NULL ctx must be rejected. */
+    AssertIntEQ(WS_BAD_ARGUMENT,
+            wolfSSH_CTX_SetWindowPacketSize(NULL, 0, 0));
+
+    ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
+    AssertNotNull(ctx);
+
+    /* Both zero: should default without error. */
+    AssertIntEQ(WS_SUCCESS,
+            wolfSSH_CTX_SetWindowPacketSize(ctx, 0, 0));
+
+    /* windowSz exactly at upper bound: must succeed and be stored. */
+    AssertIntEQ(WS_SUCCESS,
+            wolfSSH_CTX_SetWindowPacketSize(ctx, WINDOW_SZ_UPPER_BOUND, 0));
+    AssertIntEQ(WINDOW_SZ_UPPER_BOUND, (int)ctx->windowSz);
+
+    /* windowSz one above upper bound: must fail. */
+    AssertIntEQ(WS_BAD_ARGUMENT,
+            wolfSSH_CTX_SetWindowPacketSize(ctx,
+                    WINDOW_SZ_UPPER_BOUND + 1, 0));
+
+    /* maxPacketSz exactly at transport limit: must succeed and be stored. */
+    AssertIntEQ(WS_SUCCESS,
+            wolfSSH_CTX_SetWindowPacketSize(ctx, 0, MAX_PACKET_SZ));
+    AssertIntEQ(MAX_PACKET_SZ, (int)ctx->maxPacketSz);
+
+    /* maxPacketSz one above transport limit: must fail. */
+    AssertIntEQ(WS_BAD_ARGUMENT,
+            wolfSSH_CTX_SetWindowPacketSize(ctx, 0, MAX_PACKET_SZ + 1));
+
+    /* Both valid non-zero values: must succeed and be stored. */
+    AssertIntEQ(WS_SUCCESS,
+            wolfSSH_CTX_SetWindowPacketSize(ctx,
+                    DEFAULT_WINDOW_SZ, DEFAULT_MAX_PACKET_SZ));
+    AssertIntEQ(DEFAULT_WINDOW_SZ, (int)ctx->windowSz);
+    AssertIntEQ(DEFAULT_MAX_PACKET_SZ, (int)ctx->maxPacketSz);
+
+    wolfSSH_CTX_free(ctx);
+}
+
+
 static void test_wolfSSH_CertMan(void)
 {
 #ifdef WOLFSSH_CERTMAN
@@ -2139,6 +2184,7 @@ int wolfSSH_ApiTest(int argc, char** argv)
     test_wolfSSH_CTX_UsePrivateKey_buffer();
     test_wolfSSH_CTX_UseCert_buffer();
     test_wolfSSH_CTX_UsePrivateKey_buffer_pem();
+    test_wolfSSH_CTX_SetWindowPacketSize();
     test_wolfSSH_CertMan();
     test_wolfSSH_ReadKey();
     test_wolfSSH_ReadKey_badPad();

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -449,6 +449,10 @@ enum NameIdType {
 #ifndef DEFAULT_WINDOW_SZ
     #define DEFAULT_WINDOW_SZ (128 * 1024)
 #endif
+#ifndef WINDOW_SZ_UPPER_BOUND
+    /* Upper bound accepted by wolfSSH_CTX_SetWindowPacketSize(). */
+    #define WINDOW_SZ_UPPER_BOUND (256 * 1024)
+#endif
 #ifndef DEFAULT_MAX_PACKET_SZ
     /* This is from RFC 4253 section 6.1. */
     #define DEFAULT_MAX_PACKET_SZ 32768


### PR DESCRIPTION
This PR adds following things:

- Adds upper bounds for maximum window size and packet size to harden wolfSSH_CTX_SetWindowPacketSize.
- Adds unit tests to exercise it.

Addressed by f_5572