### PR TITLE
Static Analysis Fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4423,13 +4423,15 @@ static int DoKexInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
     }
     /* Extension Info Flag */
     if (ret == WS_SUCCESS) {
-        /* Only checking for this is we are server. Our client does
-         * not have anything to say to a server, yet. */
-        if (side == WOLFSSH_ENDPOINT_SERVER && !ssh->extInfoSent) {
+        /* Determine whether we should send EXT_INFO after NEWKEYS based on
+         * whether the peer advertised ext-info-c (server) or ext-info-s
+         * (client). */
+        if (!ssh->extInfoSent) {
             byte extInfo;
 
-            /* Match the client accepts extInfo. */
-            algoId = ID_EXTINFO_C;
+            /* Match the peer accepts extInfo. */
+            algoId = (side == WOLFSSH_ENDPOINT_SERVER)
+                ? ID_EXTINFO_C : ID_EXTINFO_S;
             extInfo = MatchIdLists(side, list, listSz, &algoId, 1);
             ssh->sendExtInfo = extInfo == algoId;
         }
@@ -11314,6 +11316,10 @@ int SendKexInit(WOLFSSH* ssh)
             kexAlgoNamesPlus = ",ext-info-c";
             kexAlgoNamesPlusSz = (word32)WSTRLEN(kexAlgoNamesPlus);
         }
+        else {
+            kexAlgoNamesPlus = ",ext-info-s";
+            kexAlgoNamesPlusSz = (word32)WSTRLEN(kexAlgoNamesPlus);
+        }
 
         kexAlgoNamesSz = AlgoListSz(ssh->algoListKex);
         encAlgoNamesSz = AlgoListSz(ssh->algoListCipher);
@@ -14207,7 +14213,8 @@ int SendServiceAccept(WOLFSSH* ssh, byte serviceId)
 static const char serverSigAlgsName[] = "server-sig-algs";
 
 
-int SendExtInfo(WOLFSSH* ssh)
+#ifndef NO_WOLFSSH_SERVER
+static int SendExtInfoServer(WOLFSSH* ssh)
 {
     byte* output;
     word32 idx;
@@ -14215,11 +14222,7 @@ int SendExtInfo(WOLFSSH* ssh)
     word32 serverSigAlgsNameSz = 0;
     int ret = WS_SUCCESS;
 
-    WLOG(WS_LOG_DEBUG, "Entering SendExtInfo()");
-
-    if (ssh == NULL) {
-        ret = WS_BAD_ARGUMENT;
-    }
+    WLOG(WS_LOG_DEBUG, "Entering SendExtInfoServer()");
 
     if (ret == WS_SUCCESS) {
         keyAlgoNamesSz = AlgoListSz(ssh->algoListKeyAccepted);
@@ -14257,6 +14260,51 @@ int SendExtInfo(WOLFSSH* ssh)
                                * sent after SSH_MSG_NEWKEYS or after
                                * SSH_MSG_USERAUTH_SUCCESS. Not on re-key */
         ret = wolfSSH_SendPacket(ssh);
+    }
+
+    WLOG(WS_LOG_DEBUG, "Leaving SendExtInfoServer(), ret = %d", ret);
+    return ret;
+}
+#endif /* NO_WOLFSSH_SERVER */
+
+
+#ifndef NO_WOLFSSH_CLIENT
+static int SendExtInfoClient(WOLFSSH* ssh)
+{
+    int ret = WS_SUCCESS;
+
+    WOLFSSH_UNUSED(ssh);
+    WLOG(WS_LOG_DEBUG, "Entering SendExtInfoClient()");
+    /* This is currently a stub. Our client doesn't have anything to say. */
+    WLOG(WS_LOG_DEBUG, "Leaving SendExtInfoClient(), ret = %d", ret);
+
+    return ret;
+}
+#endif /* NO_WOLFSSH_CLIENT */
+
+
+int SendExtInfo(WOLFSSH* ssh)
+{
+    int ret = WS_SUCCESS;
+
+    WLOG(WS_LOG_DEBUG, "Entering SendExtInfo()");
+
+    if (ssh == NULL || ssh->ctx == NULL) {
+        ret = WS_BAD_ARGUMENT;
+    }
+
+    if (ret == WS_SUCCESS) {
+        /* Disabling server and client is checked at compile time. */
+    #ifndef NO_WOLFSSH_SERVER
+        if (ssh->ctx->side == WOLFSSH_ENDPOINT_SERVER) {
+            ret = SendExtInfoServer(ssh);
+        }
+    #endif
+    #ifndef NO_WOLFSSH_CLIENT
+        if (ssh->ctx->side == WOLFSSH_ENDPOINT_CLIENT) {
+            ret = SendExtInfoClient(ssh);
+        }
+    #endif
     }
 
     WLOG(WS_LOG_DEBUG, "Leaving SendExtInfo(), ret = %d", ret);

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -3689,20 +3689,46 @@ int wolfSSH_SFTP_RecvWrite(WOLFSSH* ssh, int reqId, byte* data, word32 maxSz)
             return WS_BUFFER_E;
         }
 
-        ret = WPWRITE(ssh->fs, fd, (byte*)str, strSz, ofst);
-        if (ret < 0) {
-    #if defined(WOLFSSL_NUCLEUS) && defined(DEBUG_WOLFSSH)
-            if (ret == NUF_NOSPC) {
-                WLOG(WS_LOG_SFTP, "Ran out of memory");
+        {
+            word32 written = 0;
+
+            /* Retry while WPWRITE makes forward progress; bail on error
+             * or zero return to avoid spinning on a stuck backend. */
+            while (written < strSz) {
+                ret = WPWRITE(ssh->fs, fd, (byte*)str + written,
+                        strSz - written, ofst);
+                if (ret <= 0) {
+                    break;
+                }
+                written += (word32)ret;
+                /* Advance the split 64-bit offset, propagating carry. */
+                ofst[0] += (word32)ret;
+                if (ofst[0] < (word32)ret) {
+                    ofst[1] += 1;
+                }
             }
-    #endif
-            WLOG(WS_LOG_SFTP, "Error writing to file");
-            res  = err;
-            type = WOLFSSH_FTP_FAILURE;
-            ret  = WS_INVALID_STATE_E;
-        }
-        else {
-            ret = WS_SUCCESS;
+
+            if (ret < 0) {
+        #if defined(WOLFSSL_NUCLEUS) && defined(DEBUG_WOLFSSH)
+                if (ret == NUF_NOSPC) {
+                    WLOG(WS_LOG_SFTP, "Ran out of memory");
+                }
+        #endif
+                WLOG(WS_LOG_SFTP, "Error writing to file");
+                res  = err;
+                type = WOLFSSH_FTP_FAILURE;
+                ret  = WS_INVALID_STATE_E;
+            }
+            else if (written != strSz) {
+                WLOG(WS_LOG_SFTP, "Short write: %u of %u bytes",
+                        written, strSz);
+                res  = err;
+                type = WOLFSSH_FTP_FAILURE;
+                ret  = WS_INVALID_STATE_E;
+            }
+            else {
+                ret = WS_SUCCESS;
+            }
         }
     }
 

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -1127,7 +1127,7 @@ extern "C" {
                 fseek(fd, ofst, 0);
             }
 
-            return fwrite(buf, sz, 1, fd);
+            return fwrite(buf, sizeof(unsigned char), sz, fd);
         }
         #define WPWRITE(fs,fd,b,s,o) wPwrite((fd),(b),(s),(o))
     #endif
@@ -1143,7 +1143,7 @@ extern "C" {
             fseek(fd, ofst, 0);
         }
 
-        return fread(buf, 1, sz, fd);
+        return fread(buf, sizeof(unsigned char), sz, fd);
     }
     #define WPREAD(fs,fd,b,s,o)  wPread((fd),(b),(s),(o))
 #endif


### PR DESCRIPTION
- SendKexInit: advertise ext-info-s (F-3448): Server now advertises ext-info-s per RFC 8308 Section 2.1. Splits SendExtInfo into server/client variants gated by NO_WOLFSSH_SERVER/NO_WOLFSSH_CLIENT; client path is currently a stub.
- SFTP: retry short writes (F-3880): wolfSSH_SFTP_RecvWrite loops WPWRITE until the chunk is fully written, advancing the split 64-bit offset with carry. Returns WOLFSSH_FTP_FAILURE on error or a zero return so clients see truncation instead of a silent success.