### PR TITLE
examples/client: guard rxBuf indexing against negative stream_read error

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1170,8 +1170,10 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
             }
         } while (ret == WS_WANT_READ || ret == WS_WANT_WRITE);
 
-        rxBuf[ret] = '\0';
-        printf("Server said: %s\n", rxBuf);
+        if (ret > 0 && ret < (int)sizeof(rxBuf)) {
+            rxBuf[ret] = '\0';
+            printf("Server said: %s\n", rxBuf);
+        }
 
 #if defined(WOLFSSL_PTHREADS) && defined(WOLFSSL_TEST_GLOBAL_REQ)
         sleep(10);


### PR DESCRIPTION
**Background**
In client_test examples/client/client.c, the non-keepOpen read loop reuses ret for both the byte count and the error code. When wolfSSH_stream_read returns ≤0, ret is overwritten with wolfSSH_get_error(ssh). The do/while continuation only re-tests for WS_WANT_READ/WS_WANT_WRITE, so a WS_CHAN_RXD (-1057) result exits the loop with ret still negative.
The following line then did:
```
rxBuf[ret] = '\0';   /* rxBuf[-1057] -> OOB write before the 80-byte stack buffer */
printf("Server said: %s\n", rxBuf);  /* prints un-terminated buffer */
```
This is a stack out-of-bounds write and an uninitialized/un-terminated read.

**Changes**
Guard the terminator and print so they only run for a valid byte count:
```
if (ret > 0 && ret < (int)sizeof(rxBuf)) {
    rxBuf[ret] = '\0';
    printf("Server said: %s\n", rxBuf);
}
```

Addressed by f_4104