### PR TITLE
wolfsshd: fix peer-controlled over-read in Windows pseudo-console resize

### DIFF
--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1019,8 +1019,8 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
          * avoid over-reading the stack buffer. */
         cmdWSizeSz = WSNPRINTF(cmdWSize, sizeof(cmdWSize), "\x1b[8;%u;%ut",
             ssh->heightRows, ssh->widthChar);
-        if (cmdWSizeSz < 0 || cmdWSizeSz > (int)sizeof(cmdWSize)) {
-            cmdWSizeSz = (int)sizeof(cmdWSize);
+        if (cmdWSizeSz < 0 || cmdWSizeSz >= (int)sizeof(cmdWSize)) {
+            cmdWSizeSz = (int)sizeof(cmdWSize) - 1;
         }
         if (WriteFile(ptyIn, cmdWSize, cmdWSizeSz, &wrtn, 0) != TRUE) {
             WLOG(WS_LOG_ERROR, "Issue with pseudo console resize");

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1002,8 +1002,10 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
     }
 
     if (ret == WS_SUCCESS) {
-        char cmdWSize[20];
-        int cmdWSizeSz = 20;
+        /* Worst case "\x1b[8;%u;%ut" with two 10-digit word32 values is 26
+         * bytes plus the terminator; size generously. */
+        char cmdWSize[32];
+        int cmdWSizeSz;
         DWORD wrtn = 0;
 
         wolfSSH_Log(WS_LOG_INFO, "[SSHD] Successfully created process for "
@@ -1011,8 +1013,15 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
 
         WaitForInputIdle(processInfo.hProcess, 1000);
 
-        /* Send initial terminal size to pseudo console with VT control sequence */
-        cmdWSizeSz = snprintf(cmdWSize, cmdWSizeSz, "\x1b[8;%d;%dt", ssh->heightRows, ssh->widthChar);
+        /* Send initial terminal size to pseudo console with VT control sequence.
+         * heightRows/widthChar are peer-supplied word32 values, so format them
+         * with %u and clamp the return value before handing it to WriteFile to
+         * avoid over-reading the stack buffer. */
+        cmdWSizeSz = WSNPRINTF(cmdWSize, sizeof(cmdWSize), "\x1b[8;%u;%ut",
+            ssh->heightRows, ssh->widthChar);
+        if (cmdWSizeSz < 0 || cmdWSizeSz > (int)sizeof(cmdWSize)) {
+            cmdWSizeSz = (int)sizeof(cmdWSize);
+        }
         if (WriteFile(ptyIn, cmdWSize, cmdWSizeSz, &wrtn, 0) != TRUE) {
             WLOG(WS_LOG_ERROR, "Issue with pseudo console resize");
             ret = WS_FATAL_ERROR;


### PR DESCRIPTION
# Description

In the Windows variant of SHELL_Subsystem, the initial pty-resize VT escape sequence was formatted into a 20-byte stack buffer and the snprintf return value was passed unchecked to WriteFile.
```
char cmdWSize[20];
int cmdWSizeSz = 20;
cmdWSizeSz = snprintf(cmdWSize, cmdWSizeSz, "\x1b[8;%d;%dt",
    ssh->heightRows, ssh->widthChar);
WriteFile(ptyIn, cmdWSize, cmdWSizeSz, &wrtn, 0);
```
heightRows and widthChar are word32 values supplied by the authenticated peer via pty-req. For large decimal dimensions, C99 snprintf returns the length it would have written (>20), so WriteFile reads past the end of the 20-byte stack buffer, leaking adjacent stack contents into the pseudo-console fed to the child shell. With legacy MSVC _snprintf truncation semantics (returns -1), the cast to DWORD becomes ~4 GiB and can crash with an access violation.

# Changes

- Enlarge cmdWSize to 32 bytes to hold the worst-case \x1b[8;%u;%ut expansion (26 bytes + NUL).
- Format with %u since the values are unsigned word32, and use the repo's WSNPRINTF macro (consistent with other calls in this file).
- Clamp the return value before WriteFile to handle both the C99 (>size) and legacy MSVC (-1) cases.

Addressed by f_4581