### PR TITLE
Convert file permission hex constants to octal

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -675,8 +675,7 @@ int wChmod(const char *path, int mode)
     SYS_FS_RESULT ret;
     SYS_FS_FILE_DIR_ATTR attr = 0;
 
-    /* mode is the octal value i.e 666 is 0x1B6 */
-    if ((mode & 0x180) != 0x180) { /* not octal 6XX read only */
+    if ((mode & 0600) != 0600) {
         attr |= SYS_FS_ATTR_RDO;
     }
 

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -2243,14 +2243,14 @@ static int GetFileStats(void *fs, ScpSendCtx* ctx, const char* fileName,
 
     *fileMode = 0555 |
         (ctx->s.dwFileAttributes & FILE_ATTRIBUTE_READONLY ? 0 : 0200);
-    *fileMode |= (ctx->s.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? 0x4000 : 0;
+    *fileMode |= (ctx->s.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ? 040000 : 0;
 #else
     if (WSTAT(fs, fileName, &ctx->s) < 0) {
         ret = WS_BAD_FILE_E;
         #ifdef WOLFSSL_NUCLEUS
         if (WSTRLEN(fileName) < 4 && WSTRLEN(fileName) > 2 &&
                 fileName[1] == ':') {
-            *fileMode = 0x1ED; /* octal 755 */
+            *fileMode = 0755;
             ret = WS_SUCCESS;
         }
         #endif
@@ -2258,13 +2258,13 @@ static int GetFileStats(void *fs, ScpSendCtx* ctx, const char* fileName,
     else {
     #ifdef WOLFSSL_NUCLEUS
         if (ctx->s.fattribute & ARDONLY) {
-            *fileMode = 0x124; /* octal 444 */
+            *fileMode = 0444;
         }
         if (ctx->s.fattribute == ANORMAL) { /* ANORMAL = 0 */
-            *fileMode = 0x1B6; /* octal 666 */
+            *fileMode = 0666;
         }
         if (ctx->s.fattribute == ADIRENT) {
-            *fileMode = 0x1ED; /* octal 755 */
+            *fileMode = 0755;
         }
         *mTime = ctx->s.fupdate;
         *aTime = ctx->s.faccdate;

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -2867,17 +2867,17 @@ static int SFTP_CreateLongName(WS_SFTPNAME* name)
         else {
             perm[i++] = '-';
         }
-        perm[i++] = (tmp & 0x100)?'r':'-';
-        perm[i++] = (tmp & 0x080)?'w':'-';
-        perm[i++] = (tmp & 0x040)?'x':'-';
+        perm[i++] = (tmp & 0400)?'r':'-';
+        perm[i++] = (tmp & 0200)?'w':'-';
+        perm[i++] = (tmp & 0100)?'x':'-';
 
-        perm[i++] = (tmp & 0x020)?'r':'-';
-        perm[i++] = (tmp & 0x010)?'w':'-';
-        perm[i++] = (tmp & 0x008)?'x':'-';
+        perm[i++] = (tmp & 0040)?'r':'-';
+        perm[i++] = (tmp & 0020)?'w':'-';
+        perm[i++] = (tmp & 0010)?'x':'-';
 
-        perm[i++] = (tmp & 0x004)?'r':'-';
-        perm[i++] = (tmp & 0x002)?'w':'-';
-        perm[i++] = (tmp & 0x001)?'x':'-';
+        perm[i++] = (tmp & 0004)?'r':'-';
+        perm[i++] = (tmp & 0002)?'w':'-';
+        perm[i++] = (tmp & 0001)?'x':'-';
     }
     totalSz += i;
     perm[i] = '\0';
@@ -4731,14 +4731,14 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
     WMEMSET(atr, 0, sizeof(WS_SFTP_FILEATRB));
     if (sz > 2 && fileName[sz - 2] == ':' && ret == NUF_NOFILE) {
         atr->flags |= WOLFSSH_FILEATRB_PERM;
-        atr->per |= 0x4000;
+        atr->per |= 040000;
         return WS_SUCCESS;
     }
 
     /* handle case of "/" */
     if (sz < 3 && fileName[0] == WS_DELIM && ret == NUF_NOFILE) {
         atr->flags |= WOLFSSH_FILEATRB_PERM;
-        atr->per |= 0x4000;
+        atr->per |= 040000;
         return WS_SUCCESS;
     }
 
@@ -4755,16 +4755,16 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
         byte atrib = stats.fattribute;
         atr->flags |= WOLFSSH_FILEATRB_PERM;
         if (atrib & ADIRENT) {
-            atr->per |= 0x41ED; /* 755 with directory */
+            atr->per |= 040755;
         }
         else {
-            atr->per |= 0x8000;
+            atr->per |= 0100000;
         }
         if ((atrib & 0x01) == ANORMAL) {
-            atr->per |= 0x1ED; /* octal 755 */
+            atr->per |= 0755;
         }
         if (atrib & ARDONLY) {
-            atr->per |= 0x124; /* octal 444 */
+            atr->per |= 0444;
         }
     }
 
@@ -4812,16 +4812,16 @@ static int SFTP_GetAttributes_Handle(WOLFSSH* ssh, byte* handle, int handleSz,
         byte atrib = stats.fattribute;
         atr->flags |= WOLFSSH_FILEATRB_PERM;
         if (atrib & ADIRENT) {
-            atr->per |= 0x41ED; /* 755 with directory */
+            atr->per |= 040755;
         }
         else {
-            atr->per |= 0x8000;
+            atr->per |= 0100000;
         }
         if ((atrib & 0x01) == ANORMAL) {
-            atr->per |= 0x1ED; /* octal 755 */
+            atr->per |= 0755;
         }
         if (atrib & ARDONLY) {
-            atr->per |= 0x124; /* octal 444 */
+            atr->per |= 0444;
         }
     }
 
@@ -4909,7 +4909,7 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
     /* handle case of '<drive>:/.' */
     if ((sz >= 3) && (WSTRNCMP(fileName + sz - 3, ":/.", 3) == 0)) {
         atr->flags |= WOLFSSH_FILEATRB_PERM;
-        atr->per |= 0x4000;
+        atr->per |= 040000;
         return WS_SUCCESS;
     }
 
@@ -4932,16 +4932,16 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
     /* file permissions */
     atr->flags |= WOLFSSH_FILEATRB_PERM;
     if (search_data.ATTRIBUTE & MFS_ATTR_DIR_NAME) {
-        atr->per |= 0x41ED; /* 755 with directory */
+        atr->per |= 040755;
     } else {
-        atr->per |= 0x8000;
+        atr->per |= 0100000;
     }
 
     /* check for read only */
     if (search_data.ATTRIBUTE & MFS_ATTR_READ_ONLY) {
-        atr->per |= 0x124; /* octal 444 */
+        atr->per |= 0444;
     } else {
-        atr->per |= 0x1ED; /* octal 755 */
+        atr->per |= 0755;
     }
 
     return WS_SUCCESS;
@@ -4985,16 +4985,16 @@ static int SFTP_GetAttributes_Handle(WOLFSSH* ssh, byte* handle, int handleSz,
     /* file permissions */
     atr->flags |= WOLFSSH_FILEATRB_PERM;
     if (search_data.ATTRIBUTE & MFS_ATTR_DIR_NAME) {
-        atr->per |= 0x41ED; /* 755 with directory */
+        atr->per |= 040755;
     } else {
-        atr->per |= 0x8000;
+        atr->per |= 0100000;
     }
 
     /* check for read only */
     if (search_data.ATTRIBUTE & MFS_ATTR_READ_ONLY) {
-        atr->per |= 0x124; /* octal 444 */
+        atr->per |= 0444;
     } else {
-        atr->per |= 0x1ED; /* octal 755 */
+        atr->per |= 0755;
     }
 
     return WS_SUCCESS;
@@ -5074,7 +5074,7 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
     WMEMSET(atr, 0, sizeof(WS_SFTP_FILEATRB));
     if (sz > 2 && fileName[sz - 2] == ':') {
         atr->flags |= WOLFSSH_FILEATRB_PERM;
-        atr->per |= 0x4000;
+        atr->per |= 040000;
         return WS_SUCCESS;
     }
 
@@ -5082,7 +5082,7 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
     /* Calling f_stat for "/" returns FR_INVALID_NAME. So we simulate the result. */
     if (sz < 3 && fileName[0] == WS_DELIM) {
         atr->flags |= WOLFSSH_FILEATRB_PERM;
-        atr->per |= 0x4000;
+        atr->per |= 040000;
         return WS_SUCCESS;
     }
 
@@ -5100,16 +5100,16 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
         byte atrib = info.fattrib;
         atr->flags |= WOLFSSH_FILEATRB_PERM;
         if (atrib & AM_DIR) {
-            atr->per |= 0x41ED; /* 755 with directory */
+            atr->per |= 040755;
         }
         else {
-            atr->per |= 0x8000;
+            atr->per |= 0100000;
         }
         if ((atrib & AM_ARC) == AM_ARC) {
-            atr->per |= 0x1ED; /* octal 755 */
+            atr->per |= 0755;
         }
         if ((atrib & AM_SYS) || (atrib & AM_RDO)) {
-            atr->per |= 0x124; /* octal 444 */
+            atr->per |= 0444;
         }
     }
 
@@ -5142,16 +5142,16 @@ static int SFTP_GetAttributes_Handle(WOLFSSH* ssh, byte* handle, int handleSz,
         byte atrib = info.fattrib;
         atr->flags |= WOLFSSH_FILEATRB_PERM;
         if (atrib & AM_DIR) {
-            atr->per |= 0x41ED; /* 755 with directory */
+            atr->per |= 040755;
         }
         else {
-            atr->per |= 0x8000;
+            atr->per |= 0100000;
         }
         if ((atrib & AM_ARC) == AM_ARC) {
-            atr->per |= 0x1ED; /* octal 755 */
+            atr->per |= 0755;
         }
         if ((atrib & AM_RDO) || (atrib & AM_SYS)) {
-            atr->per |= 0x124; /* octal 444 */
+            atr->per |= 0444;
         }
     }
 
@@ -5227,18 +5227,18 @@ static int SFTP_GetAttributesStat(WS_SFTP_FILEATRB* atr, WSTAT_T* stats)
     /* file permissions */
     atr->flags |= WOLFSSH_FILEATRB_PERM;
     if ((stats->fattrib & SYS_FS_ATTR_DIR) & SYS_FS_ATTR_MASK) {
-        atr->per |= 0x41ED; /* 755 with directory */
+        atr->per |= 040755;
     }
     else {
-        atr->per |= 0x8000;
+        atr->per |= 0100000;
     }
 
     /* check for read only */
     if ((stats->fattrib & SYS_FS_ATTR_RDO) & SYS_FS_ATTR_MASK) {
-        atr->per |= 0x124; /* octal 444 */
+        atr->per |= 0444;
     }
     else {
-        atr->per |= 0x1ED; /* octal 755 */
+        atr->per |= 0755;
     }
 
     /* last modified time */
@@ -5260,8 +5260,7 @@ static int SFTP_GetAttributesHelper(WS_SFTP_FILEATRB* atr, const char* fName)
     if (res == SYS_FS_RES_SUCCESS) {
         if (WSTRCMP(fName, buffer) == 0) {
             atr->flags |= WOLFSSH_FILEATRB_PERM;
-            atr->per |= 0x41ED; /* 755 with directory */
-            atr->per |= 0x1ED;  /* octal 755 */
+            atr->per |= 040755;
 
             atr->flags |= WOLFSSH_FILEATRB_SIZE;
             atr->sz[0] = 0;
@@ -8085,7 +8084,7 @@ int wolfSSH_SFTP_MKDIR(WOLFSSH* ssh, char* dir, WS_SFTP_FILEATRB* atr)
 
                 /* @TODO handle setting attributes */
                 WOLFSSH_UNUSED(atr);
-                wolfSSH_SFTP_buffer_c32toa(&state->buffer, 0x000001FF);
+                wolfSSH_SFTP_buffer_c32toa(&state->buffer, 0777);
 
                 ret = wolfSSH_SFTP_buffer_set_size(&state->buffer,
                         wolfSSH_SFTP_buffer_idx(&state->buffer));

--- a/tests/api.c
+++ b/tests/api.c
@@ -1399,7 +1399,7 @@ static void test_wolfSSH_SFTP_SendReadPacket(void)
         while (tmp != NULL) {
             if ((tmp->atrb.sz[0] > 0) &&
                     (tmp->atrb.flags & WOLFSSH_FILEATRB_PERM) &&
-                    !(tmp->atrb.per & 0x4000)) {
+                    !(tmp->atrb.per & 040000)) {
                 break;
             }
             tmp = tmp->next;

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -159,7 +159,7 @@ extern "C" {
 
         /* Set attribute value */
         atr = atr & 0xF0; /* clear first byte */
-        if (mode == 0x124) {
+        if (mode == 0444) {
             atr |= ARDONLY;   /* set read only value */
         }
         else {
@@ -232,7 +232,7 @@ extern "C" {
         }
 
         /* set file attributes */
-        if (mode == 0x124) {
+        if (mode == 0444) {
             /* set read only value */
             attribute |= MFS_ATTR_READ_ONLY;
             err = ioctl(mfs_ptr, IO_IOCTL_SET_FILE_ATTR, (uint32_t*)&attr);
@@ -1280,7 +1280,7 @@ extern "C" {
 
         /* Set attribute value */
         atr = atr & 0xF0; /* clear first byte */
-        if (mode == 0x124) {
+        if (mode == 0444) {
             atr |= AM_RDO;   /* set read only value */
         }
         else {


### PR DESCRIPTION
Replace hex literals (0x1ED, 0x124, 0x4000, etc.) with octal equivalents (0755, 0444, 040000) in SCP/SFTP attribute handling