### PR TITLE
wolfsshd: reject unsafe ownership/symlink on trust-anchor file loads

### DIFF
--- a/.github/workflows/paramiko-sftp-test.yml
+++ b/.github/workflows/paramiko-sftp-test.yml
@@ -94,8 +94,12 @@ jobs:
           Subsystem sftp internal-sftp
           EOF
           
-          # Set proper permissions for keys
+          # wolfSSHd refuses to load a host key unless it is owned by root or
+          # the daemon's user and is not group or world writable. The daemon is
+          # launched with sudo (euid 0) while the checkout key is owned by the
+          # runner user, so make the key root-owned and 0600.
           chmod 600 ./keys/server-key.pem
+          sudo chown 0:0 ./keys/server-key.pem
           
           # Print debug info
           echo "Contents of sshd_config.txt:"

--- a/.github/workflows/sshd-test.yml
+++ b/.github/workflows/sshd-test.yml
@@ -107,6 +107,10 @@ jobs:
           sudo apt-get -y install valgrind
           touch sshd_config.txt
           ./configure --enable-all LDFLAGS="-L${{ github.workspace }}/build-dir/lib" CPPFLAGS="-I${{ github.workspace }}/build-dir/include -DWOLFSSH_NO_FPKI -DWOLFSSH_NO_SFTP_TIMEOUT -DWOLFSSH_MAX_SFTP_RW=4000000 -DMAX_PATH_SZ=120" --enable-static --disable-shared && make
+          # wolfSSHd refuses a host key not owned by root or the daemon's user.
+          # The daemon runs under sudo (euid 0), so make the key root-owned. Mode
+          # stays 644 (not group/world writable) so other steps can still read it.
+          sudo chown 0:0 ./keys/server-key.pem
           sudo timeout --preserve-status -s 2 5 valgrind --error-exitcode=1 --leak-check=full ./apps/wolfsshd/wolfsshd -D -f sshd_config -h ./keys/server-key.pem -d -p 22222
 
       # regression test, check that cat command does not hang
@@ -119,6 +123,8 @@ jobs:
           cat ./keys/hansel-*.pub > authorized_keys_test
           sed -i.bak "s/hansel/$USER/" ./authorized_keys_test
           ./configure --enable-all LDFLAGS="-L${{ github.workspace }}/build-dir/lib" CPPFLAGS="-I${{ github.workspace }}/build-dir/include -DWOLFSSH_NO_FPKI -DWOLFSSH_NO_SFTP_TIMEOUT -DWOLFSSH_MAX_SFTP_RW=4000000 -DMAX_PATH_SZ=120" --enable-static --disable-shared && make
+          # Host key must be root-owned for the sudo-launched daemon to load it.
+          sudo chown 0:0 ./keys/server-key.pem
           sudo ./apps/wolfsshd/wolfsshd -f sshd_config.txt -h ./keys/server-key.pem -p 22225
           chmod 600 ./keys/hansel-key-rsa.pem
           tail -c 50000 /dev/urandom > test

--- a/.github/workflows/x509-interop.yml
+++ b/.github/workflows/x509-interop.yml
@@ -158,6 +158,12 @@ jobs:
       - name: Start wolfSSHd
         working-directory: ./wolfssh/
         run: |
+          # wolfSSHd refuses a trust anchor not owned by root or the daemon's
+          # user. The daemon runs under sudo (euid 0), so make the host key,
+          # host cert, and user CA root-owned. Modes stay non-group/world
+          # writable so other steps can still read them.
+          sudo chown 0:0 ./keys/server-key.pem ./keys/server-cert.pem \
+            ./keys/ca-cert-ecc.pem
           sudo ./apps/wolfsshd/wolfsshd -f sshd_config -d \
             -E $PWD/wolfsshd-log.txt &
           for i in $(seq 1 20); do

--- a/apps/wolfsshd/test/run_all_sshd_tests.sh
+++ b/apps/wolfsshd/test/run_all_sshd_tests.sh
@@ -83,6 +83,137 @@ else
     fi
 fi
 
+# Self-contained check for the ownership and symlink gate in getBufferFromFile().
+# The host key, host certificate, and user CA all load through the same
+# getBufferFromFile(..., 1) call, so exercising the gate via the host key covers
+# the identical code for the other two trust anchors. Starts a private wolfSSHd
+# with substituted host keys and asserts startup is refused for a symlink, a
+# group/world-writable file, and (when run as a non-root user with sudo) a file
+# owned by another user, and accepted for a proper mode-600 regular file. Does
+# not use the shared daemon, so it runs the same whether or not one was started.
+run_hostkey_perm_check() {
+    printf "host key ownership/symlink gate ... "
+    TOTAL=$((TOTAL+1))
+
+    HK_SSHD=../wolfsshd
+    HK_KEY=../../../keys/server-key.pem
+    HK_PORT=22399
+    if [ ! -x "$HK_SSHD" ] || [ ! -f "$HK_KEY" ]; then
+        printf "SKIPPED\n"
+        SKIPPED=$((SKIPPED+1))
+        return
+    fi
+
+    HK_WORK=$(mktemp -d 2>/dev/null) || HK_WORK=$(mktemp -d -t sshdperm)
+    if [ -z "$HK_WORK" ] || [ ! -d "$HK_WORK" ]; then
+        printf "SKIPPED (mktemp failed)\n"
+        SKIPPED=$((SKIPPED+1))
+        return
+    fi
+
+    cp "$HK_KEY" "$HK_WORK/hostkey.pem" || {
+        printf "SKIPPED (could not prepare hostkey)\n"
+        SKIPPED=$((SKIPPED+1))
+        rm -rf "$HK_WORK"
+        return
+    }
+    chmod 600 "$HK_WORK/hostkey.pem"
+    touch "$HK_WORK/authorized_keys"
+    hk_cfg() {
+        cat > "$HK_WORK/cfg" <<EOF
+Port $HK_PORT
+Protocol 2
+PermitRootLogin yes
+PasswordAuthentication yes
+UsePrivilegeSeparation no
+UseDNS no
+HostKey $1
+AuthorizedKeysFile $HK_WORK/authorized_keys
+EOF
+    }
+
+    # Load happens during startup before the listener; start, poll the log
+    # rather than sleeping a fixed time, then stop. Both the host key load and
+    # the listener emit a line, so stop as soon as either appears (max ~15s).
+    # $1 (optional): "sudo" to launch the daemon as root for the owner branch.
+    hk_run() {
+        HK_PRE="$1"
+        $HK_PRE "$HK_SSHD" -D -d -f "$HK_WORK/cfg" -p $HK_PORT > "$HK_WORK/log.txt" 2>&1 &
+        HK_PID=$!
+        i=0
+        while [ $i -lt 15 ]; do
+            if grep -qE "Listening on port|Refusing to load" "$HK_WORK/log.txt" 2>/dev/null; then
+                break
+            fi
+            sleep 1
+            i=$((i+1))
+        done
+        # When launched via sudo, $HK_PID is the sudo pid, not the daemon, and
+        # sudo does not reliably forward the signal, so match the daemon by port.
+        # This guarantees a regression cannot leave a root daemon bound to it.
+        if [ -n "$HK_PRE" ]; then
+            $HK_PRE pkill -f "$HK_SSHD.*$HK_PORT" 2>/dev/null
+        else
+            kill $HK_PID 2>/dev/null
+        fi
+        wait $HK_PID 2>/dev/null
+    }
+
+    hk_fail() {
+        printf "FAILED!\n%s\n" "$1"
+        cat "$HK_WORK/log.txt"
+        rm -rf "$HK_WORK"
+        if [ "$USING_LOCAL_HOST" == 1 ]; then
+            printf "Shutting down test wolfSSHd\n"
+            stop_wolfsshd
+        fi
+        exit 1
+    }
+
+    # proper mode-600 regular file must load. The only gate failure here is the
+    # daemon refusing a properly-owned key; any other reason the daemon does not
+    # reach the listener (port in use, environment cannot run the daemon) is
+    # unrelated to the gate, so skip rather than fail the whole suite.
+    hk_cfg "$HK_WORK/hostkey.pem"; hk_run
+    if grep -q "Refusing to load" "$HK_WORK/log.txt"; then
+        hk_fail "valid host key was refused"
+    fi
+    if ! grep -q "Listening on port" "$HK_WORK/log.txt"; then
+        printf "SKIPPED (daemon could not listen)\n"
+        SKIPPED=$((SKIPPED+1))
+        rm -rf "$HK_WORK"
+        return
+    fi
+
+    # symlink must be refused
+    ln -s "$HK_WORK/hostkey.pem" "$HK_WORK/link.pem"
+    hk_cfg "$HK_WORK/link.pem"; hk_run
+    grep -q "Refusing to load" "$HK_WORK/log.txt" || hk_fail "symlinked host key was not refused"
+
+    # non-regular file (FIFO) must be refused. Skip where mkfifo is unavailable.
+    if mkfifo "$HK_WORK/fifo.pem" 2>/dev/null; then
+        hk_cfg "$HK_WORK/fifo.pem"; hk_run
+        grep -q "Refusing to load" "$HK_WORK/log.txt" || hk_fail "FIFO host key was not refused"
+    fi
+
+    # group/world-writable file must be refused
+    cp "$HK_KEY" "$HK_WORK/ww.pem"; chmod 666 "$HK_WORK/ww.pem"
+    hk_cfg "$HK_WORK/ww.pem"; hk_run
+    grep -q "Refusing to load" "$HK_WORK/log.txt" || hk_fail "world-writable host key was not refused"
+
+    # Owner-rejection branch (st_uid != 0 && st_uid != geteuid()): the primary
+    # substitution vector. The mode-600 host key is owned by the invoking user,
+    # so launching the daemon as root (euid 0) must refuse it. Needs a non-root
+    # invoker and non-interactive sudo; skip the sub-case otherwise.
+    if [ "`id -u`" -ne 0 ] && sudo -n true 2>/dev/null; then
+        hk_cfg "$HK_WORK/hostkey.pem"; hk_run sudo
+        grep -q "Refusing to load" "$HK_WORK/log.txt" || hk_fail "non-root-owned host key was not refused under root daemon"
+    fi
+
+    rm -rf "$HK_WORK"
+    printf "PASSED\n"
+}
+
 run_test() {
     printf "$1 ... "
     ./"$1" "$TEST_HOST" "$TEST_PORT" "$USER" &> stdout.txt
@@ -136,6 +267,8 @@ else
 
     # add additional tests here, check on var USING_LOCAL_HOST if can make sshd
     # server start/restart with changes
+
+    run_hostkey_perm_check
 
     if [ "$USING_LOCAL_HOST" == 1 ]; then
         printf "Shutting down test wolfSSHd\n"

--- a/apps/wolfsshd/test/start_sshd.sh
+++ b/apps/wolfsshd/test/start_sshd.sh
@@ -1,10 +1,82 @@
 #!/bin/bash
 
+# Holds the per-daemon temp dir used for root-owned trust-anchor copies, so
+# stop_wolfsshd can remove it. Empty when no copies were made.
+SSHD_KEYDIR=""
+
 # starts up a sshd session, takes in the sshd_config file as an argument
 start_wolfsshd() {
     CURRENT_PIDS=`ps -e | grep wolfsshd | grep -oE "[0-9]+"`
+
+    ORIGCFG="$1"
+    CONFIG="$ORIGCFG"
+    # Reset so each invocation is self-contained regardless of call ordering.
+    SSHD_KEYDIR=""
+
+    # wolfSSHd refuses to load a trust-anchor file that is not owned by the
+    # daemon's user. This shared daemon is launched with sudo (euid 0) while the
+    # repository key files are owned by the checkout user, so copy each
+    # configured host key, host cert, and user CA into a private dir, make the
+    # copies root-owned, and emit a temp config pointing at them. The
+    # version-controlled files are left untouched so the suite stays re-runnable.
+    if grep -qE '^(HostKey|HostCertificate|TrustedUserCAKeys)[[:space:]]' "$ORIGCFG"; then
+        SSHD_KEYDIR=$(mktemp -d 2>/dev/null) || SSHD_KEYDIR=$(mktemp -d -t sshdkeys)
+        if [ -z "$SSHD_KEYDIR" ] || [ ! -d "$SSHD_KEYDIR" ]; then
+            printf "WARNING: could not create temp dir for trust-anchor copies; using original config\n" >&2
+            SSHD_KEYDIR=""
+        else
+            CONFIG="$SSHD_KEYDIR/sshd_config"
+            : > "$CONFIG" || { printf "WARNING: could not write %s; using original config\n" "$CONFIG" >&2; CONFIG="$ORIGCFG"; rm -rf "$SSHD_KEYDIR"; SSHD_KEYDIR=""; }
+        fi
+        # Only rewrite when the temp config was set up. On any fallback above
+        # SSHD_KEYDIR is empty and CONFIG still points at ORIGCFG; running the
+        # loop then would read from and append to the same file, never reaching
+        # EOF (runaway append) and would also operate on "/anchorN.pem" at the
+        # filesystem root. Skipping it leaves the original config untouched.
+        if [ -n "$SSHD_KEYDIR" ]; then
+            n=0
+            # Rewrite the config line by line. For each trust-anchor directive
+            # copy the file to a counter-named destination (so distinct
+            # directories with the same basename do not collide) and emit the
+            # directive pointing at the copy. Paths are built by string assembly,
+            # not sed, so a checkout path containing regex or glob metacharacters
+            # cannot corrupt the rewrite. The directive keyword is the first
+            # field and the path is the remainder, so a path containing spaces is
+            # preserved. The "|| [ -n "$line" ]" keeps a final line lacking a
+            # trailing newline from being dropped.
+            while IFS= read -r line || [ -n "$line" ]; do
+                read -r key src <<EOF
+$line
+EOF
+                case "$key" in
+                HostKey|HostCertificate|TrustedUserCAKeys)
+                    if [ -n "$src" ] && [ -e "$src" ]; then
+                        n=`expr $n + 1`
+                        dst="$SSHD_KEYDIR/anchor$n.pem"
+                        if ! cp "$src" "$dst"; then
+                            printf "WARNING: could not copy %s; using original path\n" "$src" >&2
+                            printf '%s\n' "$line" >> "$CONFIG"
+                            continue
+                        fi
+                        chmod go-w "$dst"
+                        if ! sudo chown 0 "$dst"; then
+                            printf "WARNING: could not chown %s to root; daemon may refuse to load it\n" "$src" >&2
+                        fi
+                        printf '%s %s\n' "$key" "$dst" >> "$CONFIG"
+                    else
+                        printf '%s\n' "$line" >> "$CONFIG"
+                    fi
+                    ;;
+                *)
+                    printf '%s\n' "$line" >> "$CONFIG"
+                    ;;
+                esac
+            done < "$ORIGCFG"
+        fi
+    fi
+
     # find a port
-    sudo ../wolfsshd -d -E ./log.txt -f $1
+    sudo ../wolfsshd -d -E ./log.txt -f "$CONFIG"
 
     # set the PID of started sshd
     NEW_PID=`ps -e | grep wolfsshd | grep -oE "[0-9]+"`
@@ -16,4 +88,11 @@ start_wolfsshd() {
 stop_wolfsshd() {
     printf "Stopping SSHD, killing pid $PID\n"
     sudo kill $PID
+
+    # The temp dir is owned by the invoking user, so its root-owned key copies
+    # can be removed without sudo.
+    if [ -n "$SSHD_KEYDIR" ]; then
+        rm -rf "$SSHD_KEYDIR"
+        SSHD_KEYDIR=""
+    fi
 }

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -46,6 +46,19 @@
 
 #include <signal.h>
 
+#ifndef _WIN32
+    /* Used by getBufferFromFile() to load security-critical files without
+     * following an attacker-supplied symlink or trusting an unsafe owner. */
+    #include <fcntl.h>
+    #include <sys/stat.h>
+    #include <unistd.h>
+    #ifndef O_NOFOLLOW
+        /* Older platforms lack O_NOFOLLOW; the lstat() pre-check still
+         * rejects a symlinked leaf there. */
+        #define O_NOFOLLOW 0
+    #endif
+#endif
+
 #ifdef NO_INLINE
     #include <wolfssh/misc.h>
 #else
@@ -235,20 +248,88 @@ static void freeBufferFromFile(byte* buf, void* heap)
 }
 
 
-/* set bufSz to size wanted if too small and buf is null */
-static byte* getBufferFromFile(const char* fileName, word32* bufSz, void* heap)
+/* Reads a file into a newly allocated buffer. When secure is non-zero the file
+ * holds a trust anchor (host key, host cert, or user CA) so the load is refused
+ * unless it is a regular file, reached without a symlink, owned by root or the
+ * daemon's effective user, and not group or world writable. This blocks a local
+ * user from substituting the file via a symlink or a writable parent directory.
+ * set bufSz to size wanted if too small and buf is null */
+static byte* getBufferFromFile(const char* fileName, word32* bufSz, void* heap,
+        int secure)
 {
     FILE* file;
     byte* buf = NULL;
     long fileSz;
     word32 readSz;
+#ifndef _WIN32
+    struct stat lst;
+    struct stat st;
+    int fd;
+    int flags;
+#endif
 
     WOLFSSH_UNUSED(heap);
+#ifdef _WIN32
+    WOLFSSH_UNUSED(secure);
+#endif
 
     if (fileName == NULL) return NULL;
 
+#ifndef _WIN32
+    if (secure) {
+        /* lstat() rejects a symlink or any non-regular leaf such as a FIFO or
+         * device, O_NOFOLLOW keeps open() from following a symlink, and
+         * O_NONBLOCK keeps open() from blocking on a FIFO swapped in after the
+         * lstat(). The owner and mode checks run on the opened fd so there is
+         * no window to swap the file after the check. */
+        if (lstat(fileName, &lst) != 0 || !S_ISREG(lst.st_mode)) {
+            wolfSSH_Log(WS_LOG_ERROR,
+                "[SSHD] Refusing to load %s: missing or not a regular file",
+                fileName);
+            return NULL;
+        }
+        fd = open(fileName, O_RDONLY | O_NOFOLLOW | O_NONBLOCK);
+        if (fd < 0) {
+            wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Unable to open %s", fileName);
+            return NULL;
+        }
+        if (fstat(fd, &st) != 0) {
+            wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Unable to stat %s", fileName);
+            close(fd);
+            return NULL;
+        }
+        if (!S_ISREG(st.st_mode) ||
+                (st.st_uid != 0 && st.st_uid != geteuid()) ||
+                (st.st_mode & (S_IWGRP | S_IWOTH)) != 0) {
+            wolfSSH_Log(WS_LOG_ERROR,
+                "[SSHD] Refusing to load %s: must be a regular file owned by "
+                "root or the daemon and not group or world writable", fileName);
+            close(fd);
+            return NULL;
+        }
+        /* The target is a regular file, so clear O_NONBLOCK before the
+         * buffered reads below, which expect ordinary blocking semantics. */
+        flags = fcntl(fd, F_GETFL);
+        if (flags != -1)
+            (void)fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+        file = fdopen(fd, "rb");
+        if (file == NULL) {
+            close(fd);
+            return NULL;
+        }
+    }
+    else {
+        if (WFOPEN(NULL, &file, fileName, "rb") != 0)
+            return NULL;
+    }
+#else
+    /* The secure ownership and symlink gate is POSIX only. Windows has no
+     * comparable uid model and relies on filesystem ACLs to protect the
+     * trust-anchor files, so the file is opened directly regardless of the
+     * secure flag. */
     if (WFOPEN(NULL, &file, fileName, "rb") != 0)
         return NULL;
+#endif
     WFSEEK(NULL, file, 0, WSEEK_END);
     fileSz = WFTELL(NULL, file);
     if (fileSz < 0) {
@@ -329,7 +410,7 @@ static int SetupCTX(WOLFSSHD_CONFIG* conf, WOLFSSH_CTX** ctx,
     if (ret == WS_SUCCESS) {
 #ifndef NO_FILESYSTEM
         *banner = getBufferFromFile(wolfSSHD_ConfigGetBanner(conf),
-                NULL, heap);
+                NULL, heap, 0);
 #endif
         if (*banner) {
             wolfSSH_CTX_SetBanner(*ctx, (char*)*banner);
@@ -349,7 +430,7 @@ static int SetupCTX(WOLFSSHD_CONFIG* conf, WOLFSSH_CTX** ctx,
             byte* data;
             word32 dataSz = 0;
 
-            data = getBufferFromFile(hostKey, &dataSz, heap);
+            data = getBufferFromFile(hostKey, &dataSz, heap, 1);
             if (data == NULL) {
                 wolfSSH_Log(WS_LOG_ERROR,
                     "[SSHD] Error reading host key file.");
@@ -393,10 +474,10 @@ static int SetupCTX(WOLFSSHD_CONFIG* conf, WOLFSSH_CTX** ctx,
             byte*  data;
             word32 dataSz = 0;
 
-            data = getBufferFromFile(hostCert, &dataSz, heap);
+            data = getBufferFromFile(hostCert, &dataSz, heap, 1);
             if (data == NULL) {
                 wolfSSH_Log(WS_LOG_ERROR,
-                    "[SSHD] Error reading host key file.");
+                    "[SSHD] Error reading host certificate file.");
                 ret = WS_MEMORY_E;
 
             }
@@ -439,7 +520,7 @@ static int SetupCTX(WOLFSSHD_CONFIG* conf, WOLFSSH_CTX** ctx,
 
 
             wolfSSH_Log(WS_LOG_INFO, "[SSHD] Using CA keys file %s", caCert);
-            data = getBufferFromFile(caCert, &dataSz, heap);
+            data = getBufferFromFile(caCert, &dataSz, heap, 1);
             if (data == NULL) {
                 wolfSSH_Log(WS_LOG_ERROR,
                     "[SSHD] Error reading CA cert file.");


### PR DESCRIPTION
## Description
SetupCTX() in apps/wolfsshd/wolfsshd.c loads the host key, host certificate, and user CA through getBufferFromFile(), which called WFOPEN(..., "rb") with no stat/lstat/fstat/O_NOFOLLOW guard. The most dangerous is UserCAKeysFile: its buffer is handed to wolfSSH_CTX_AddRootCert_buffer, installing a trusted root CA for user-auth certificate verification.
A local non-root attacker who can pre-create a symlink at the configured path (or drop a file via a writable ancestor directory) before the root-launched daemon starts gets an attacker-controlled CA into the trust store, then authenticates as any user (including root) with a cert signed by that CA — bypassing pubkey and password auth. Same missing-ownership root cause as the tracked HostKeyFile finding and the host-cert load.
Addressed by f_5901.
## Changes
### Fix (`apps/wolfsshd/wolfsshd.c`)
Added an `int secure` parameter to `getBufferFromFile()`. When set (POSIX only), the file is validated before it is read:
- **`lstat()`** rejects a symlink or any non-regular leaf (FIFO / device / directory).
- **`open(O_RDONLY | O_NOFOLLOW | O_NONBLOCK)`** won't follow a symlink and can't block on a FIFO swapped in after the `lstat()`.
- **`fstat()`** on the opened fd (TOCTOU-free) requires a regular file, owned by root or the daemon's euid, and not group/world writable.
- **`O_NONBLOCK`** is cleared before the buffered reads.
Any failure logs and returns `NULL`; each call site already maps `NULL` to an error and skips the load, so the daemon **fails closed**.

Windows keeps the existing `WFOPEN` path (no comparable uid model; relies on filesystem ACLs), with a comment noting the intentional platform exemption.
This closes the `UserCAKeysFile` issue and also covers the `HostKeyFile` finding and the host-cert load with the same gate.
### New Test
Added new tests to exercise the new code path