### PR TITLE
wolfsshd: bind certificate auth to user, fail closed without FPKI

### DIFF
--- a/.github/workflows/x509-interop.yml
+++ b/.github/workflows/x509-interop.yml
@@ -25,7 +25,7 @@ jobs:
         id: cache-wolfssl
         with:
           path: build-dir/
-          key: wolfssh-x509-interop-wolfssl-${{ env.WOLFSSL_REF }}-ubuntu-latest
+          key: wolfssh-x509-interop-wolfssl-${{ env.WOLFSSL_REF }}-all-ubuntu-latest
           lookup-only: true
 
       - name: Checkout, build, and install wolfSSL
@@ -35,7 +35,18 @@ jobs:
           repository: wolfssl/wolfssl
           ref: ${{ env.WOLFSSL_REF }}
           path: wolfssl
-          configure: --enable-ssh --enable-keygen --enable-ed25519 --enable-curve25519
+          # --enable-all defines WOLFSSL_FPKI, which compiles the UPN-vs-username
+          # binding in wolfSSHd (apps/wolfsshd/auth.c). The client cert carries
+          # UPN:fred@example, so user "fred" is bound to the certificate. The
+          # wolfSSHd build still passes -DWOLFSSH_NO_FPKI below so the strict
+          # FPKI profile (FASCN) is not required of the fred test certificate.
+          #
+          # Coverage note: this FPKI build exercises only the WOLFSSL_FPKI
+          # success/binding path of RequestAuthentication. The non-FPKI
+          # fail-closed reject branch (apps/wolfsshd/auth.c) is intentionally
+          # not run here; it is verified at compile time and would need a
+          # separate non-FPKI build to exercise at runtime.
+          configure: --enable-all
           check: false
           install: true
 
@@ -86,7 +97,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build-dir/
-          key: wolfssh-x509-interop-wolfssl-${{ env.WOLFSSL_REF }}-ubuntu-latest
+          key: wolfssh-x509-interop-wolfssl-${{ env.WOLFSSL_REF }}-all-ubuntu-latest
           fail-on-cache-miss: true
 
       - name: Restore PKIX-SSH cache
@@ -198,6 +209,39 @@ jobs:
             fred@127.0.0.1 <<EOF
           exit
           EOF
+
+      - name: Negative test - fred cert must not authenticate as another user
+        working-directory: ./wolfssh/
+        run: |
+          # Regression guard for the cert principal-binding fix: a certificate
+          # issued for "fred" (UPN:fred@example) must not be accepted for a
+          # different SSH username. PreferredAuthentications=publickey plus
+          # BatchMode keep this to a single publickey attempt with no password
+          # fallback. The preceding positive tests already proved connectivity
+          # and that fred's cert works; here we additionally require the failure
+          # to be an authentication denial, so an unrelated ssh error (transport,
+          # host-key, option change) cannot masquerade as a passing negative test.
+          sudo useradd -m otheruser
+          set +e
+          ../build-dir/bin/ssh -o StrictHostKeyChecking=accept-new \
+            -o PreferredAuthentications=publickey \
+            -o BatchMode=yes -o NumberOfPasswordPrompts=0 \
+            -p 22222 -F ssh-pkixssh-config \
+            -i ./keys/fred-key.pem otheruser@127.0.0.1 exit \
+            > ssh-neg.out 2> ssh-neg.err
+          rc=$?
+          set -e
+          cat ssh-neg.err || true
+          if [ "$rc" -eq 0 ]; then
+            echo "SECURITY FAILURE: fred certificate authenticated as otheruser"
+            exit 1
+          fi
+          if ! grep -qi "permission denied" ssh-neg.err; then
+            echo "Negative test inconclusive: ssh failed but not with an auth"
+            echo "denial (possible transport/config error, not a binding reject)"
+            exit 1
+          fi
+          echo "OK: fred certificate correctly rejected for otheruser (auth denied)"
 
       - name: Show wolfSSHd log on failure
         if: failure()

--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -1341,10 +1341,10 @@ static int RequestAuthentication(WS_UserAuthData* authData,
                 ret = WOLFSSH_USERAUTH_REJECTED;
             }
             else {
-                wolfSSH_Log(WS_LOG_INFO,
-                    "[SSHD] Relying on CA for public key check");
             #ifdef WIN32
                 /* Still need to get users token on Windows */
+                wolfSSH_Log(WS_LOG_INFO,
+                    "[SSHD] Relying on CA for public key check");
                 rc = SetupUserTokenWin(usr, &authData->sf.publicKey,
                     wolfSSHD_ConfigGetUserCAKeysFile(usrConf), authCtx);
                 if (rc == WSSHD_AUTH_SUCCESS) {
@@ -1356,8 +1356,23 @@ static int RequestAuthentication(WS_UserAuthData* authData,
                         "[SSHD] Error getting users token.");
                     ret = WOLFSSH_USERAUTH_FAILURE;
                 }
-            #else
+            #elif defined(WOLFSSL_FPKI)
+                /* The UPN-vs-username check above already bound the certificate
+                 * to the requested user, so the CA-verified chain is
+                 * sufficient. */
+                wolfSSH_Log(WS_LOG_INFO,
+                    "[SSHD] Relying on CA for public key check");
                 ret = WOLFSSH_USERAUTH_SUCCESS;
+            #else
+                /* Without FPKI the certificate UPN/principal cannot be read, so
+                 * the requested user cannot be bound to the certificate. Fail
+                 * closed: require AuthorizedKeysFile (per-user key/cert mapping)
+                 * or a wolfSSL build with FPKI. */
+                wolfSSH_Log(WS_LOG_ERROR,
+                    "[SSHD] Certificate authentication cannot bind the requested "
+                    "user without FPKI or AuthorizedKeysFile; rejecting "
+                    "(user=%s)", usr);
+                ret = WOLFSSH_USERAUTH_REJECTED;
             #endif
             }
         }


### PR DESCRIPTION
# wolfsshd: bind certificate auth to the requested user (fail closed without FPKI)

## Summary

Fixes a high-severity authentication-defaults issue addressed by f_4578: on the
wolfSSHd certificate public-key path, a CA-signed certificate was accepted as
**any** requested SSH username when `AuthorizedKeysFile` was unset and the build
did not define `WOLFSSL_FPKI`. The username-to-certificate binding
(UPN-vs-username) is only compiled under `WOLFSSL_FPKI`, which is off by default,
so a default build using `TrustedUserCAKeys` would let any cert signed by the
trusted CA log in as `root` or any other user.

This binds the certificate to the requested user on the CA-only path and fails
closed when no binding mechanism is available.

## Changes

### `apps/wolfsshd/auth.c` — `RequestAuthentication()`
The CA-only certificate branch (cert present, no `AuthorizedKeysFile`) is split
into three explicit cases:

| Build | Behavior |
|-------|----------|
| `WIN32` | get the user token via `SetupUserTokenWin` (unchanged) |
| `WOLFSSL_FPKI` | rely on the CA chain — the UPN-vs-username check above already bound the cert to the user (unchanged) |
| **neither** | **fail closed**: `WOLFSSH_USERAUTH_REJECTED` |

Without FPKI the certificate UPN/principal cannot be read, so the requested user
cannot be bound to the certificate. The operator must either build wolfSSL with
FPKI (UPN binding) or set `AuthorizedKeysFile` (per-user key/cert mapping via
`checkPublicKeyCb`).

Note: `WOLFSSL_FPKI` (wolfSSL, enables UPN parsing in auth.c) and
`WOLFSSH_NO_FPKI` (wolfSSH, skips certman's strict FASCN profile) are
independent; an FPKI-enabled wolfSSL with `-DWOLFSSH_NO_FPKI` gets UPN binding
without requiring full FPKI profile extensions on the certificate.

### `.github/workflows/x509-interop.yml`
The scheduled interop job built wolfSSL **without** FPKI and authenticated `fred`
via the CA-only path, so the auth change would have rejected it. Updated so the
interop job validates the **secure** binding path instead:

- Build wolfSSL with `--enable-all` (defines `WOLFSSL_FPKI`, enabling the
  UPN-vs-username binding). 
- Keep `-DWOLFSSH_NO_FPKI` on the wolfSSHd build so the strict FPKI profile
  (FASCN) is not required of the `fred` test certificate.
- Bump the wolfSSL cache key (`...-all-...`) so the new build config is not
  masked by a stale cached (non-FPKI) wolfSSL.
- **Add a negative test**: a certificate issued for `fred` must not authenticate
  as a different user (`otheruser`). The assertion requires the failure to be an
  authentication denial (`Permission denied`), so an unrelated ssh/transport
  error cannot masquerade as a passing negative test.

## Security impact

Before: any certificate signed by `TrustedUserCAKeys` could authenticate as any
username on a default (non-FPKI) build with no `AuthorizedKeysFile`.

After: certificate auth requires the requested username to be bound to the
certificate (UPN under FPKI, or `AuthorizedKeysFile` mapping); otherwise it is
rejected.

## Compatibility

This is a behavior change for non-Windows, non-FPKI deployments that relied on
CA-only certificate auth without `AuthorizedKeysFile` — such logins now fail
closed. Affected operators should enable FPKI or configure `AuthorizedKeysFile`.

## Verification

- FPKI build (`--enable-all` / default): builds clean with `-Werror`.
- Non-FPKI build (wolfSSL without FPKI): builds clean with `-Werror`; confirmed
  only the fail-closed reject branch is emitted (UPN block excluded).
- wolfSSHd unit tests (`apps/wolfsshd/test/test_configuration`): no new failures
  (the one pre-existing `test_CheckPasswordHashUnix` failure is an unrelated
  macOS `crypt()` quirk, reproduced on the unmodified tree).
- ASan + UBSan run of the affected tests: no sanitizer reports.
