### PR TITLE
wolfscp: fix ExtractFileName for separator-less paths

### DIFF
--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -2026,7 +2026,10 @@ static int ExtractFileName(const char* filePath, char* fileName,
         idx++;
     }
 
-    if (separator < 0)
+    /* a path with no separator is a bare file or directory name; the whole
+     * string is then the file name (separator == -1 is handled correctly by
+     * the length math below) */
+    if (pathLen == 0)
         return WS_BAD_ARGUMENT;
 
     fileLen = pathLen - separator - 1;
@@ -2038,6 +2041,14 @@ static int ExtractFileName(const char* filePath, char* fileName,
 
     return ret;
 }
+
+#ifdef WOLFSSH_TEST_INTERNAL
+int wolfSSH_TestScpExtractFileName(const char* filePath, char* fileName,
+                                   word32 fileNameSz)
+{
+    return ExtractFileName(filePath, fileName, fileNameSz);
+}
+#endif
 
 #if !defined(NO_FILESYSTEM)
 
@@ -3150,26 +3161,36 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
                 }
             #endif /* WOLFSSH_HAVE_SYMLINK */
 
-                if (ret == WS_SUCCESS)
+                if (ret == WS_SUCCESS) {
                     ret = ScpPushDir(ssh->fs, sendCtx, peerRequest,
                                      ssh->ctx->heap);
+                    if (ret != WS_SUCCESS) {
+                        WLOG(WS_LOG_ERROR,
+                             "scp: error opening base directory, abort");
+                    }
+                }
 
                 if (ret == WS_SUCCESS) {
                     /* get file name from request */
                     ret = ExtractFileName(peerRequest, fileName, fileNameSz);
+                    if (ret != WS_SUCCESS) {
+                        WLOG(WS_LOG_ERROR,
+                             "scp: error extracting directory name, abort");
+                    }
                 }
 
                 if (ret == WS_SUCCESS) {
                     ret = GetFileStats(ssh->fs, sendCtx, peerRequest, mTime, aTime,
                                        fileMode);
+                    if (ret != WS_SUCCESS) {
+                        WLOG(WS_LOG_ERROR,
+                             "scp: error getting file stats, abort");
+                    }
                 }
 
                 if (ret == WS_SUCCESS) {
                     ret = WS_SCP_ENTER_DIR;
-                } else if (ret != WS_SCP_ABORT) {
-                    /* a rejected symlink root already logged its own reason;
-                     * only note the generic stat failure here */
-                    WLOG(WS_LOG_ERROR, "scp: error getting file stats, abort");
+                } else {
                     ret = WS_SCP_ABORT;
                 }
 

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -5021,6 +5021,91 @@ static int test_SftpRecvSizeBoundAccept(void)
 }
 #endif /* WOLFSSH_SFTP */
 
+#if defined(WOLFSSH_TEST_INTERNAL) && defined(WOLFSSH_SCP) && \
+    !defined(WOLFSSH_SCP_USER_CALLBACKS)
+/* Exercises ExtractFileName, the SCP source helper that splits the leaf name
+ * from a request path. A bare name with no path separator must be accepted
+ * (the whole string is the file name); this is the recursive-source
+ * regression. */
+static int test_ScpExtractFileName(void)
+{
+    char name[64];
+    int ret;
+
+    /* bare name, no separator: whole string is the file name (regression) */
+    WMEMSET(name, 0, sizeof(name));
+    ret = wolfSSH_TestScpExtractFileName("scp_rk_src", name, sizeof(name));
+    if (ret != WS_SUCCESS || WSTRCMP(name, "scp_rk_src") != 0)
+        return -900;
+
+    /* leading "./" prefix */
+    WMEMSET(name, 0, sizeof(name));
+    ret = wolfSSH_TestScpExtractFileName("./scp_rk_src", name, sizeof(name));
+    if (ret != WS_SUCCESS || WSTRCMP(name, "scp_rk_src") != 0)
+        return -901;
+
+    /* relative nested path */
+    WMEMSET(name, 0, sizeof(name));
+    ret = wolfSSH_TestScpExtractFileName("a/b/c", name, sizeof(name));
+    if (ret != WS_SUCCESS || WSTRCMP(name, "c") != 0)
+        return -902;
+
+    /* absolute path */
+    WMEMSET(name, 0, sizeof(name));
+    ret = wolfSSH_TestScpExtractFileName("/tmp/x/y", name, sizeof(name));
+    if (ret != WS_SUCCESS || WSTRCMP(name, "y") != 0)
+        return -903;
+
+    /* empty path is rejected */
+    ret = wolfSSH_TestScpExtractFileName("", name, sizeof(name));
+    if (ret != WS_BAD_ARGUMENT)
+        return -904;
+
+    /* NULL arguments are rejected */
+    ret = wolfSSH_TestScpExtractFileName(NULL, name, sizeof(name));
+    if (ret != WS_BAD_ARGUMENT)
+        return -905;
+    ret = wolfSSH_TestScpExtractFileName("scp_rk_src", NULL, sizeof(name));
+    if (ret != WS_BAD_ARGUMENT)
+        return -906;
+
+    /* destination too small for name plus null terminator */
+    ret = wolfSSH_TestScpExtractFileName("scp_rk_src", name, 4);
+    if (ret != WS_SCP_PATH_LEN_E)
+        return -907;
+
+    /* bare "." and ".." are accepted as-is (separator-less leaf names); the
+     * recursive walk skips "."/".." directory entries separately */
+    WMEMSET(name, 0, sizeof(name));
+    ret = wolfSSH_TestScpExtractFileName(".", name, sizeof(name));
+    if (ret != WS_SUCCESS || WSTRCMP(name, ".") != 0)
+        return -908;
+
+    WMEMSET(name, 0, sizeof(name));
+    ret = wolfSSH_TestScpExtractFileName("..", name, sizeof(name));
+    if (ret != WS_SUCCESS || WSTRCMP(name, "..") != 0)
+        return -909;
+
+    /* trailing separator yields an empty leaf name with success */
+    WMEMSET(name, 0, sizeof(name));
+    ret = wolfSSH_TestScpExtractFileName("a/b/", name, sizeof(name));
+    if (ret != WS_SUCCESS || WSTRCMP(name, "") != 0)
+        return -910;
+
+    /* exact-fit boundary of the (fileLen + 1 > fileNameSz) size check:
+     * "scp_rk_src" is 10 chars, so 11 just fits and 10 is one too small */
+    WMEMSET(name, 0, sizeof(name));
+    ret = wolfSSH_TestScpExtractFileName("scp_rk_src", name, 11);
+    if (ret != WS_SUCCESS || WSTRCMP(name, "scp_rk_src") != 0)
+        return -911;
+    ret = wolfSSH_TestScpExtractFileName("scp_rk_src", name, 10);
+    if (ret != WS_SCP_PATH_LEN_E)
+        return -912;
+
+    return 0;
+}
+#endif /* WOLFSSH_TEST_INTERNAL && WOLFSSH_SCP && !WOLFSSH_SCP_USER_CALLBACKS */
+
 #endif /* WOLFSSH_TEST_INTERNAL */
 
 /* Error Code And Message Test */
@@ -5252,6 +5337,13 @@ int wolfSSH_UnitTest(int argc, char** argv)
     unitResult = test_ScpRecvCallback_SymlinkGuard();
     printf("ScpRecvCallback_SymlinkGuard: %s\n",
             (unitResult == 0 ? "SUCCESS" : "FAILED"));
+    testResult = testResult || unitResult;
+#endif
+
+#if defined(WOLFSSH_TEST_INTERNAL) && defined(WOLFSSH_SCP) && \
+    !defined(WOLFSSH_SCP_USER_CALLBACKS)
+    unitResult = test_ScpExtractFileName();
+    printf("ScpExtractFileName: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));
     testResult = testResult || unitResult;
 #endif
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1463,6 +1463,10 @@ enum WS_MessageIdLimits {
     WOLFSSH_API int wolfSSH_TestDoUserAuthRequestEd25519(WOLFSSH* ssh,
             WS_UserAuthData* authData);
 #endif /* !WOLFSSH_NO_ED25519 */
+#if defined(WOLFSSH_SCP) && !defined(WOLFSSH_SCP_USER_CALLBACKS)
+    WOLFSSH_API int wolfSSH_TestScpExtractFileName(const char* filePath,
+            char* fileName, word32 fileNameSz);
+#endif /* WOLFSSH_SCP && !WOLFSSH_SCP_USER_CALLBACKS */
 #endif /* WOLFSSH_TEST_INTERNAL */
 
 /* dynamic memory types */


### PR DESCRIPTION
## Fix recursive SCP source abort on separator-less paths

### Problem

A recursive SCP source request for a **bare relative name** with no path separator — e.g. `scp -r -f scp_rk_src` — aborted immediately after sending the top-level directory message, transferring no files. The receiving side saw `WS_SUCCESS` but ended up with an empty destination. Absolute paths and any path containing a `/` worked fine.

### Root cause

`ExtractFileName()` rejected any path with no `/` or `\` separator:

```c
if (separator < 0)
    return WS_BAD_ARGUMENT;
```

In the recursive first-request path, `ScpPushDir()` opened the directory successfully, but the following `ExtractFileName(peerRequest, ...)` returned `WS_BAD_ARGUMENT` (-1002) for the bare name. The failure then fell into a branch mislabeled `"scp: error getting file stats, abort"` — so the log pointed at `GetFileStats`, which was never actually reached. The same helper feeds the single-file request path, so a single-file GET of a bare filename had the same latent bug.

A path with no separator is a valid bare file/directory name (the whole string is the leaf name); the existing length math already handles the `separator == -1` case, so only the early-return guard was wrong.

### Changes

- **`src/wolfscp.c` — `ExtractFileName()`**: reject only a genuinely empty path (`if (pathLen == 0)`) instead of any separator-less path. No behavior change for paths containing a separator (absolute paths unchanged). Fixes both the recursive-source and single-file request paths.
- **`src/wolfscp.c` — recursive first-request branch**: split the single misleading `"error getting file stats"` log into per-step messages (open base directory / extract name / get file stats), so a future failure names the actual culprit. Keeps the existing fallthrough cleanup style.
- **`tests/unit.c` — `test_ScpExtractFileName`**: new unit test covering bare name, `./` prefix, nested, absolute, `.`/`..`, trailing separator, empty, `NULL` args, too-small buffer, and the exact size-check boundary. `ExtractFileName` stays `static`; the test reaches it through a new `wolfSSH_TestScpExtractFileName` wrapper guarded by `WOLFSSH_TEST_INTERNAL`.
- **`wolfssh/internal.h`**: prototype for the test wrapper inside the existing `WOLFSSH_TEST_INTERNAL` block, sub-guarded by `WOLFSSH_SCP && !WOLFSSH_SCP_USER_CALLBACKS`.

### Notes

`ExtractFileName` was never a path-traversal guard — `../x`-style paths always have `separator >= 0` and passed through unchanged; only a trivial bare `.`/`..` was incidentally rejected before. Accepting `.`/`..` now matches real scp semantics (`scp -r host:. dst`); `.`/`..` directory *entries* are still skipped during the recursive walk, and sink-side path confinement is separate.

### Testing

- `tests/unit.test` → `ScpExtractFileName: SUCCESS`. Negative control: with the old guard restored the test FAILS (exit 1), so it genuinely catches the bug.
- ASan + UBSan unit build (`-fsanitize=address,undefined`, no LeakSanitizer on macOS) → clean.
- `scripts/scp.test` → `ALL Tests Passed` (single-file client path unaffected).
- End-to-end: recursive transfer of a relative source tree (`big.txt`, `sub/s.txt`, `top.txt`) completes byte-identical (`diff -r` clean) against `examples/echoserver`.