### PR TITLE
Check Include path truncation in sshd config

### DIFF
--- a/apps/wolfsshd/configuration.c
+++ b/apps/wolfsshd/configuration.c
@@ -798,18 +798,17 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value, int depth)
                                             WSTRLEN(fileNames[i]) -
                                             WSTRLEN(postfix),
                                             postfix, WSTRLEN(postfix))
-                                        == 0) {
-                                    WSNPRINTF(filepath, PATH_MAX, "%s/%s", path,
-                                             fileNames[i]);
-                                }
-                                else {
+                                        != 0) {
                                     /* Not a match */
                                     continue;
                                 }
                             }
-                            else {
-                                WSNPRINTF(filepath, PATH_MAX, "%s/%s", path,
-                                         fileNames[i]);
+                            ret = WSNPRINTF(filepath, PATH_MAX, "%s/%s", path,
+                                        fileNames[i]);
+                            if (ret < 0 || ret >= PATH_MAX) {
+                                /* Path is too long for the buffer */
+                                ret = WS_INVALID_PATH_E;
+                                break;
                             }
                             ret = ConfigLoad(conf, filepath, depth);
                             if (ret != WS_SUCCESS) {


### PR DESCRIPTION
HandleInclude built the wildcard include path with WSNPRINTF without checking the result, silently truncating over-long paths (flagged by GCC 12 as -Werror=format-truncation). Merge the duplicate WSNPRINTF calls and return WS_INVALID_PATH_E when the path does not fit.