### PR TITLE
wolfsshd: fix uninitialized fileNames[] deref in HandleInclude

### DIFF
--- a/apps/wolfsshd/configuration.c
+++ b/apps/wolfsshd/configuration.c
@@ -723,7 +723,7 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value, int depth)
 
             if (ret == WS_SUCCESS) {
                 if (!WOPENDIR(NULL, conf->heap, &d, path)) {
-                    word32 fileCount = 0, i, j;
+                    word32 fileCount = 0, fileFilled = 0, i, j;
                     char** fileNames = NULL;
 
                     /* Count up the number of files */
@@ -749,6 +749,12 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value, int depth)
                         if (fileNames == NULL) {
                             ret = WS_MEMORY_E;
                         }
+                        else {
+                            /* Zero so any slot not filled by the second pass
+                             * (e.g. files removed from the directory between
+                             * the two passes) is NULL rather than garbage. */
+                            WMEMSET(fileNames, 0, fileCount * sizeof(char*));
+                        }
                     }
 
                     if (ret == WS_SUCCESS) {
@@ -764,21 +770,33 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value, int depth)
                             if (dir->d_type != DT_DIR)
                         #endif
                             {
+                                /* Duplicate the name; readdir() may reuse its
+                                 * dirent storage on the next call, so the
+                                 * pointer cannot be retained across the loop. */
+                                char* nameCopy = WSTRDUP(dir->d_name, conf->heap,
+                                        DYNTYPE_PATH);
+                                if (nameCopy == NULL) {
+                                    ret = WS_MEMORY_E;
+                                    break;
+                                }
                                 /* Insert in string order */
                                 for (j = 0; j < i; j++) {
-                                    if (WSTRCMP(dir->d_name, fileNames[j])
-                                            < 0) {
+                                    if (WSTRCMP(nameCopy, fileNames[j]) < 0) {
                                         WMEMMOVE(fileNames+j+1, fileNames+j,
                                                 (i - j)*sizeof(char*));
                                         break;
                                     }
                                 }
-                                fileNames[j] = dir->d_name;
+                                fileNames[j] = nameCopy;
                                 i++;
                             }
                         }
+                        /* Only process slots actually filled by the second
+                         * pass; the directory may have shrunk since the
+                         * count pass. */
+                        fileFilled = i;
 
-                        for (i = 0; i < fileCount; i++) {
+                        for (i = 0; ret == WS_SUCCESS && i < fileFilled; i++) {
                             /* Check if filename prefix matches */
                             if (prefixLen > 0) {
                                 if ((int)WSTRLEN(fileNames[i]) <= prefixLen) {
@@ -817,6 +835,14 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value, int depth)
                             }
                         }
 
+                        /* Free the duplicated names. fileFilled counts the
+                         * slots actually populated, so every entry below it
+                         * holds a valid pointer. */
+                        for (i = 0; i < fileFilled; i++) {
+                            if (fileNames[i] != NULL) {
+                                WFREE(fileNames[i], conf->heap, DYNTYPE_PATH);
+                            }
+                        }
                         if (fileNames != NULL) {
                             WFREE(fileNames, conf->heap, DYNTYPE_PATH);
                         }


### PR DESCRIPTION
## Description

Fixes a TOCTOU-induced uninitialized-pointer dereference in `HandleInclude`
(`apps/wolfsshd/configuration.c`) that can crash `wolfsshd` with a SIGSEGV.

`HandleInclude` walks an `Include` directory using **two separate `readdir`
passes** split by `WREWINDDIR`:

1. **Pass 1** counts non-directory entries into `fileCount`.
2. `fileNames` is allocated with `WMALLOC(fileCount * sizeof(char*))` — **without
   zero-initialization**.
3. **Pass 2** fills the array but is bounded by
   `i < fileCount && (dir = WREADDIR(...)) != NULL`, so it stops early if
   `readdir` returns `NULL`.
4. The processing loop then iterated the **full** `fileCount`, calling
   `WSTRLEN(fileNames[i])` / `WSNPRINTF(...)` on every slot.

If the directory shrinks between the two passes (a local user removing files
from a writable `Include` directory, e.g. a group-writable
`/etc/ssh/sshd_config.d/`), the second pass fills fewer slots than `fileCount`.
The tail slots `[fileFilled .. fileCount-1]` remain uninitialized, and the
processing loop dereferences those garbage pointers, crashing the daemon at
start/restart. No SSH authentication is required to trigger it.

## Fix

- **Bound the processing loop to the actual fill count.** Capture the number of
  slots populated by the second pass (`fileFilled = i;`) and iterate
  `for (i = 0; i < fileFilled; i++)` instead of `i < fileCount`. This is the
  fix that closes the uninitialized read.
- **Zero-initialize the array after allocation** (`WMEMSET(fileNames, 0, ...)`)
  as defense-in-depth, so any slot not reached by the second pass is `NULL`
  rather than garbage and the code fails safe against future changes.

The opposite direction (more files appearing in pass 2) was already safe — the
`i < fileCount` guard stops the second pass at the allocated size.

## Testing

- `./configure --enable-sshd && make` — clean build.
- `apps/wolfsshd/test/test_configuration` — all `Include` / wildcard cases pass,
  including `Include sshd_config.d/*.conf`, which exercises this exact two-pass
  path and confirms no regression in the normal (`fileFilled == fileCount`)
  case.