### PR TITLE
Fix broken user_settings.h flip in windows-check workflow

### DIFF
--- a/.github/workflows/windows-check.yml
+++ b/.github/workflows/windows-check.yml
@@ -43,13 +43,12 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}wolfssl
       run: nuget restore ${{env.WOLFSSL_SOLUTION_FILE_PATH}}
 
-    - name: updated user_settings.h for sshd and x509
+    - name: Update user_settings.h for sshd and x509
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: cp ${{env.USER_SETTINGS_H_NEW}} ${{env.USER_SETTINGS_H}}
-
-    - name: replace wolfSSL user_settings.h with wolfSSH user_settings.h
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: get-content ${{env.USER_SETTINGS_H_NEW}} | %{$_ -replace "if 0","if 1"}
+      shell: bash
+      run: |
+        sed -i 's/#if 0/#if 1/g' ${{env.USER_SETTINGS_H_NEW}}
+        cp ${{env.USER_SETTINGS_H_NEW}} ${{env.USER_SETTINGS_H}}
 
     - name: Build wolfssl library
       working-directory: ${{env.GITHUB_WORKSPACE}}wolfssl
@@ -117,11 +116,12 @@ jobs:
 
     # These env paths already include the wolfssh/ and wolfssl/ checkout
     # prefixes, so they must run from the workspace root (as the build job does).
-    - name: updated user_settings.h for sshd and x509
-      run: cp ${{env.USER_SETTINGS_H_NEW}} ${{env.USER_SETTINGS_H}}
-
-    - name: replace wolfSSL user_settings.h with wolfSSH user_settings.h
-      run: get-content ${{env.USER_SETTINGS_H_NEW}} | %{$_ -replace "if 0","if 1"}
+    - name: Update user_settings.h for sshd and x509
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      shell: bash
+      run: |
+        sed -i 's/#if 0/#if 1/g' ${{env.USER_SETTINGS_H_NEW}}
+        cp ${{env.USER_SETTINGS_H_NEW}} ${{env.USER_SETTINGS_H}}
 
     # WholeProgramOptimization=false disables /GL so the v142-independent objects
     # link without a cross-version code-generation requirement (C1047).

--- a/tests/api.c
+++ b/tests/api.c
@@ -1389,7 +1389,7 @@ static void test_wolfSSH_agent_signrequest_success(void)
 
 
 #if defined(WOLFSSH_SFTP) && !defined(NO_WOLFSSH_CLIENT) && \
-    !defined(SINGLE_THREADED)
+    !defined(SINGLE_THREADED) && !defined(USE_WINDOWS_API)
 
 byte userPassword[256];
 
@@ -2615,7 +2615,8 @@ static void test_wolfSSH_SFTP_SetDefaultPath(void) { ; }
 
 #if defined(WOLFSSH_SCP) && !defined(NO_WOLFSSH_CLIENT) && \
     !defined(SINGLE_THREADED) && !defined(NO_FILESYSTEM) && \
-    !defined(WOLFSSH_SCP_USER_CALLBACKS) && !defined(WOLFSSH_ZEPHYR)
+    !defined(WOLFSSH_SCP_USER_CALLBACKS) && !defined(WOLFSSH_ZEPHYR) && \
+    !defined(USE_WINDOWS_API)
 
 /* Upper bound on non-blocking retry iterations. A legitimate transfer across a
  * forced rekey completes in well under this; the bound keeps a regression from

--- a/tests/api.c
+++ b/tests/api.c
@@ -3708,6 +3708,8 @@ int wolfSSH_ApiTest(int argc, char** argv)
 #ifdef WOLFSSH_TEST_BLOCK
     return 77;
 #else
+    WSTARTTCP();
+
     AssertIntEQ(wolfSSH_Init(), WS_SUCCESS);
 
     #if defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,2)


### PR DESCRIPTION
## Summary

Repairs Windows CI coverage that was silently broken, plus the two latent
test issues that surfaced once it started working. Three commits:

1. **`.github/workflows/windows-check.yml`** — fix the broken `user_settings.h`
   feature flip in both the `build` and `asan-tests` jobs.
2. **`tests/api.c`** — initialize Winsock in `api-test`.
3. **`tests/api.c`** — exclude the threaded echoserver tests from `api-test` on
   Windows.

Commits 2 and 3 are fallout the flip fix exposed: with the features finally
compiled in, `api-test` ran code on Windows CI that had never run there before.

## 1. Fix the broken user_settings.h flip

The old step

```powershell
get-content $f | %{$_ -replace "if 0","if 1"}
```

pipes the modified text to the console and **never writes the file back** (no
`Set-Content`/`Out-File`). Both `#if 0` blocks in `ide/winvs/user_settings.h`
(X509 and SSHD) therefore stayed off, so the Windows build silently compiled the
library and app **without** `WOLFSSH_SSHD`, `WOLFSSH_CERTS`, `WOLFSSH_SFTP`, or
X509 — while staying green. The job stopped covering every feature it was named
for.

Replaced with the write-in-place pattern already proven in `windows-sftp.yml`:

```yaml
    - name: Update user_settings.h for sshd and x509
      working-directory: ${{env.GITHUB_WORKSPACE}}
      shell: bash
      run: |
        sed -i 's/#if 0/#if 1/g' ${{env.USER_SETTINGS_H_NEW}}
        cp ${{env.USER_SETTINGS_H_NEW}} ${{env.USER_SETTINGS_H}}
```

`ide/winvs/user_settings.h` has exactly two `#if 0` blocks and nothing else uses
`#if 0`, so the anchored substitution flips precisely the two intended blocks.
The `asan-tests` job (added to `master` after this branch first forked) carried
an identical broken `get-content` flip, so the same fix is applied there.

## 2. Initialize Winsock in api-test

With the flip repaired, `api-test` compiled in the SCP/SFTP rekey tests for the
first time. The first one aborted at setup:

```
wolfSSH error: no entry for host
api-test failed under ASAN (exit 1)
```

These tests resolve the loopback address via `gethostbyname()` in
`build_addr()`. On Windows `gethostbyname()` returns NULL until `WSAStartup()`
has run, and `api-test`'s entry point called `wolfSSH_Init()` without first
calling `WSTARTTCP()` (unlike `testsuite.c` and `kex.c`). Added `WSTARTTCP()`
before `wolfSSH_Init()`. The macro is empty off Windows.

## 3. Exclude threaded echoserver tests on Windows

Past the Winsock fix, the SCP rekey test then failed with `ctx => NULL` at the
post-connect assertion. The threaded echoserver tests synchronize with the
server via `SignalTcpReady`/`WaitTcpReady`, which are POSIX-only and compile to
no-ops on MSVC (no `_POSIX_THREADS`). Without the readiness handshake the server
never reports its port and the client connects before the listener is up, so the
client context comes back NULL.

The block guards already excluded `SINGLE_THREADED` and `WOLFSSH_ZEPHYR` — the
other cases where these primitives are no-ops — but omitted `USE_WINDOWS_API`,
an inconsistency that was harmless only because `api-test` never ran on Windows
CI. Added `!defined(USE_WINDOWS_API)` to both block guards so the tests compile
to their existing stubs on Windows, matching the guard the same functions
already use on their networked subsections.

## Testing

- `grep -rn "get-content" .github/workflows/` returns nothing — no broken flips
  remain.
- Windows `build` and `asan-tests` jobs green.