### PR TITLE
Mask special bits from peer-supplied SCP receive mode

### DIFF
--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -863,8 +863,9 @@ static int GetScpFileMode(WOLFSSH* ssh, byte* buf, word32 bufSz,
     }
 
     if (ret == WS_SUCCESS) {
-        /* store file mode */
-        ssh->scpFileMode = mode;
+        /* store file mode, masking off setuid/setgid/sticky bits from the
+         * peer-supplied value to match the send path */
+        ssh->scpFileMode = mode & WOLFSSH_MODE_MASK;
         /* eat trailing space */
         if (bufSz >= (word32)(idx +1))
             idx++;
@@ -874,6 +875,15 @@ static int GetScpFileMode(WOLFSSH* ssh, byte* buf, word32 bufSz,
 
     return ret;
 }
+
+
+#ifdef WOLFSSH_TEST_INTERNAL
+int wolfSSH_TestScpGetFileMode(WOLFSSH* ssh, byte* buf, word32 bufSz,
+        word32* inOutIdx)
+{
+    return GetScpFileMode(ssh, buf, bufSz, inOutIdx);
+}
+#endif /* WOLFSSH_TEST_INTERNAL */
 
 
 /* Locates first space present in given string (buf) and sets inOutIdx

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -1147,6 +1147,81 @@ static int test_DoUserAuthBanner(void)
     return result;
 }
 
+#if defined(WOLFSSH_TEST_INTERNAL) && defined(WOLFSSH_SCP)
+/* Verify GetScpFileMode strips setuid/setgid/sticky bits from a peer-supplied
+ * SCP C/D record mode, matching the masking already done on the send path.
+ * The receive path cannot be exercised end-to-end because both peers mask the
+ * mode before transmitting, so this drives the parser directly. */
+static int test_ScpGetFileMode(void)
+{
+    WOLFSSH_CTX* ctx = NULL;
+    WOLFSSH* ssh = NULL;
+    static const char* hdrs[] = {
+        "C4755 0 f\n",  /* setuid set */
+        "D2755 0 d\n",  /* setgid set */
+        "D1755 0 d\n",  /* sticky set */
+        "D7777 0 d\n",  /* all special bits set */
+        "C0644 0 f\n"   /* ordinary mode, unaffected */
+    };
+    static const int expected[] = { 0755, 0755, 0755, 0777, 0644 };
+    /* records the parser must reject */
+    static const char* badHdrs[] = {
+        "C8755 0 f\n",  /* '8' is not an octal digit */
+        "X4755 0 f\n",  /* prefix is neither 'C' nor 'D' */
+        "C75"           /* shorter than the mode field */
+    };
+    int result = 0;
+    int ret;
+    int i;
+    word32 idx;
+
+    ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
+    if (ctx == NULL)
+        return -420;
+    ssh = wolfSSH_new(ctx);
+    if (ssh == NULL) {
+        wolfSSH_CTX_free(ctx);
+        return -421;
+    }
+
+    for (i = 0; i < (int)(sizeof(hdrs) / sizeof(hdrs[0])); i++) {
+        idx = 0;
+        ssh->scpFileMode = 0;
+        ret = wolfSSH_TestScpGetFileMode(ssh, (byte*)hdrs[i],
+                (word32)WSTRLEN(hdrs[i]), &idx);
+        if (ret != WS_SUCCESS) {
+            result = -422;
+            break;
+        }
+        if (ssh->scpFileMode != expected[i]) {
+            result = -423;
+            break;
+        }
+        /* index advances past the 'C'/'D', four mode octets, and the
+         * trailing space */
+        if (idx != 6) {
+            result = -424;
+            break;
+        }
+    }
+
+    for (i = 0; result == 0 &&
+            i < (int)(sizeof(badHdrs) / sizeof(badHdrs[0])); i++) {
+        idx = 0;
+        ret = wolfSSH_TestScpGetFileMode(ssh, (byte*)badHdrs[i],
+                (word32)WSTRLEN(badHdrs[i]), &idx);
+        if (ret != WS_BAD_ARGUMENT) {
+            result = -425;
+            break;
+        }
+    }
+
+    wolfSSH_free(ssh);
+    wolfSSH_CTX_free(ctx);
+    return result;
+}
+#endif /* WOLFSSH_TEST_INTERNAL && WOLFSSH_SCP */
+
 static int test_ChannelPutData(void)
 {
     WOLFSSH_CTX* ctx = NULL;
@@ -4005,6 +4080,12 @@ int wolfSSH_UnitTest(int argc, char** argv)
     unitResult = test_ChannelPutData();
     printf("ChannelPutData: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));
     testResult = testResult || unitResult;
+
+#if defined(WOLFSSH_TEST_INTERNAL) && defined(WOLFSSH_SCP)
+    unitResult = test_ScpGetFileMode();
+    printf("ScpGetFileMode: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));
+    testResult = testResult || unitResult;
+#endif
 
     unitResult = test_MsgHighwater();
     printf("MsgHighwater: %s\n", (unitResult == 0 ? "SUCCESS" : "FAILED"));

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1407,6 +1407,10 @@ enum WS_MessageIdLimits {
     WOLFSSH_API int wolfSSH_TestDoUserAuthRequest(WOLFSSH* ssh, byte* buf,
             word32 len, word32* idx);
     WOLFSSH_API int wolfSSH_TestHighwaterCheck(WOLFSSH* ssh, byte side);
+#ifdef WOLFSSH_SCP
+    WOLFSSH_API int wolfSSH_TestScpGetFileMode(WOLFSSH* ssh, byte* buf,
+            word32 bufSz, word32* inOutIdx);
+#endif /* WOLFSSH_SCP */
 #ifndef WOLFSSH_NO_DH
     WOLFSSH_API int wolfSSH_TestKeyAgreeDh_client(WOLFSSH* ssh, byte hashId,
             const byte* f, word32 fSz);


### PR DESCRIPTION
## Description

The SCP receive path did not mask setuid/setgid/sticky bits out of the
peer-supplied file mode before using it. `GetScpFileMode()` parsed the octal
mode from a peer-sent `C`/`D` record (e.g. `D4755 0 dirname`) and stored the
raw value into `ssh->scpFileMode` without masking. That unmasked value then
propagated to:

- the default `wsScpRecvCallback`, which passes it straight to `WMKDIR()` for
  directory creation, and
- any custom `scpRecvCb` callback (the documented API contract handed the
  callback an unmasked mode).

The **send** path already masks with `WOLFSSH_MODE_MASK` (0777) at
`src/wolfscp.c:318` and `:355`; the receive path had no equivalent. As a
result an authenticated peer could force creation of sticky/setgid
directories inside the SCP base path (the kernel strips setuid/setgid from
`mkdir()` on Linux but preserves sticky; setgid also survives on BSD/macOS),
and a custom callback that applied the mode via `chmod()` while running as
root could end up creating setuid files.

## Fix

Mask the peer-supplied mode at the single point where it is stored, mirroring
the send path:

```c
/* src/wolfscp.c, GetScpFileMode() */
ssh->scpFileMode = mode & WOLFSSH_MODE_MASK;
```

Masking at the storage point protects every downstream consumer (`scpRecvCb`,
the default callback, and `WMKDIR`) at once. This strips setuid (04000),
setgid (02000), and sticky (01000) while leaving ordinary permission bits
untouched.

## Tests

Added `test_ScpGetFileMode` to `tests/unit.c`. End-to-end coverage is not
possible because both peers mask the mode on send, so the test drives the
parser directly via a new `WOLFSSH_TEST_INTERNAL` wrapper
(`wolfSSH_TestScpGetFileMode`). It covers:

- **Masking:** `C4755`->`0755`, `D2755`->`0755`, `D1755`->`0755`,
  `D7777`->`0777`, and an ordinary-mode control `C0644`->`0644`.
- **Index advancement:** asserts `idx` is moved past the prefix, four mode
  octets, and trailing space.
- **Rejection paths:** invalid octal digit (`C8755`), bad prefix (`X4755`),
  and a buffer shorter than the mode field (`C75`) all return
  `WS_BAD_ARGUMENT`.

## Verification

- Normal build clean; `scripts/scp.test` passes (regular-file transfers
  unaffected).
- `tests/unit.test` passes (exit 0, zero failures), including the new test.
- **Negative controls:** reverting the mask makes the masking assertions fail;
  mutating the `idx`/rejection expectations makes those assertions fail —
  confirming each assertion is real.
- Built and run under ASan+UBSan (LeakSanitizer disabled on macOS): no
  AddressSanitizer or UBSan reports, including the short-buffer case.

## Files changed

- `src/wolfscp.c` — mask the mode in `GetScpFileMode`; add
  `wolfSSH_TestScpGetFileMode` test wrapper.
- `wolfssh/internal.h` — declare the test wrapper (guarded by
  `WOLFSSH_TEST_INTERNAL` + `WOLFSSH_SCP`).
- `tests/unit.c` — add and register `test_ScpGetFileMode`.