### PR TITLE
Fix the skip guard for Mac environment

### DIFF
--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -630,8 +630,14 @@ static int test_CheckPasswordHashUnix(void)
     int rc;
 
     hash = crypt(correct, salt);
-    if (hash == NULL || hash[0] == '*' || WSTRLEN(hash) == 0) {
-        Log("    crypt() unavailable or refused salt, skipping.\n");
+    /* Skip if crypt() did not honor the $6$ SHA-512 request. macOS/Darwin and
+     * some BSD libc only implement legacy DES, which ignores the modular salt,
+     * truncates the password to 8 bytes, and returns a valid-looking 13-char
+     * hash that begins "$6l..." (no second '$'). A real $6$ hash begins with
+     * "$6$<salt>$", so the prefix check cleanly distinguishes them. */
+    if (hash == NULL || hash[0] == '*' || WSTRLEN(hash) == 0 ||
+            WSTRNCMP(hash, "$6$", 3) != 0) {
+        Log("    crypt() did not honor $6$ SHA-512, skipping.\n");
         return WS_SUCCESS;
     }
     if (WSTRLEN(hash) >= sizeof(stored)) {


### PR DESCRIPTION
## Fix `test_CheckPasswordHashUnix` false-fail on macOS/Darwin

### Summary

`test_CheckPasswordHashUnix` in `apps/wolfsshd/test/test_configuration.c`
false-fails on macOS (and some BSDs) because the platform `crypt(3)` does not
implement the `$6$` (SHA-512) modular-crypt format. This is a test-harness bug,
not a defect in `CheckPasswordHashUnix()` itself.

### Root cause

The test builds a stored hash with a SHA-512 modular-crypt salt:

```c
const char* salt = "$6$wolfsshtestsalt$";
hash = crypt(correct, salt);
```

macOS/Darwin libc `crypt(3)` only supports legacy DES. Given a `$6$…` salt it
silently falls back to DES, using just the first 2 characters as the salt and
**truncating the password to 8 bytes**. Both test passwords share their first
8 bytes (`wolfssh-`), so DES produces an identical hash for the "correct" and
"wrong" passwords. The negative path ("wrong password is rejected") then
genuinely matches, `CheckPasswordHashUnix()` correctly returns
`WSSHD_AUTH_SUCCESS`, and the test fails with `ret=-1001` (binary exits 23).

The existing skip guard only caught the `NULL` / `*` / empty crypt-failure
conventions. The DES fallback returns a valid-looking 13-char hash, so the
guard never tripped and the test proceeded with degenerate coverage.

### Fix

Tighten the skip guard to verify `crypt()` actually honored the `$6$` request
before trusting the negative path. A real SHA-512 hash begins with `$6$<salt>$`;
the DES fallback begins `$6l…` (no second `$`), so a `WSTRNCMP(hash, "$6$", 3)`
prefix check cleanly distinguishes them.

```c
hash = crypt(correct, salt);
if (hash == NULL || hash[0] == '*' || WSTRLEN(hash) == 0 ||
        WSTRNCMP(hash, "$6$", 3) != 0) {
    Log("    crypt() did not honor $6$ SHA-512, skipping.\n");
    return WS_SUCCESS;
}
```

On glibc-based Linux the `$6$` hash is produced as expected and the test runs
normally; only platforms whose `crypt(3)` lacks `$6$` support now skip instead
of false-failing.

### Testing

- `test_configuration` full suite: **PASS** (exit 0) on macOS — the password
  hash case now logs `crypt() did not honor $6$ SHA-512, skipping.`