### PR TITLE
wolfssh/client: reject unsanitized fields before known_hosts write

### DIFF
--- a/apps/wolfssh/common.c
+++ b/apps/wolfssh/common.c
@@ -193,20 +193,82 @@ void ClientIPOverride(int flag)
 #endif /* WOLFSSH_CERTS */
 
 
-static int AppendKeyToFile(const char* filename, const char* name,
-        const char* type, const char* key)
+/* A known_hosts entry is whitespace-delimited and newline-terminated. Each
+ * stored field must be non-empty and free of spaces and control bytes,
+ * otherwise it could inject extra fields or a forged entry into the file.
+ * Returns WS_SUCCESS when the field is safe to store, WS_BAD_ARGUMENT
+ * otherwise. */
+static int IsFieldStorable(const char* field)
 {
-    WFILE *f;
-    int ret;
+    const char* p;
+    int ret = WS_SUCCESS;
 
-    ret = WFOPEN(NULL, &f, filename, "a");
-    if (ret == 0 && f != WBADFILE) {
-        fprintf(f, "%s %s %s\n", name, type, key);
-        WFCLOSE(NULL, f);
+    if (field == NULL || *field == '\0') {
+        ret = WS_BAD_ARGUMENT;
+    }
+    else {
+        for (p = field; *p != '\0'; p++) {
+            if ((unsigned char)*p <= ' ' || (unsigned char)*p == 0x7f) {
+                ret = WS_BAD_ARGUMENT;
+                break;
+            }
+        }
     }
 
     return ret;
 }
+
+
+static int AppendKeyToFile(const char* filename, const char* name,
+        const char* type, const char* key)
+{
+    WFILE *f = WBADFILE;
+    int ret;
+
+    /* The host name comes from the command line and the key type comes from
+     * the peer's host-key blob; both are untrusted and must not carry field or
+     * line separators. The key is Base64 and cannot contain a separator, so
+     * the same check on it only guards against a NULL or empty value reaching
+     * fprintf. */
+    ret = IsFieldStorable(name);
+    if (ret == WS_SUCCESS) {
+        ret = IsFieldStorable(type);
+    }
+    if (ret == WS_SUCCESS) {
+        ret = IsFieldStorable(key);
+    }
+    if (ret == WS_SUCCESS) {
+        ret = WFOPEN(NULL, &f, filename, "a");
+        if (ret == 0 && f != WBADFILE) {
+            /* Check the write and the close so a failed or truncated entry
+             * (for example on a full disk) is reported rather than appearing
+             * to pin the key. The close flushes buffered output, so a write
+             * error can surface there. */
+            if (fprintf(f, "%s %s %s\n", name, type, key) < 0) {
+                ret = WS_BAD_FILE_E;
+            }
+            if (WFCLOSE(NULL, f) != 0 && ret == WS_SUCCESS) {
+                ret = WS_BAD_FILE_E;
+            }
+        }
+        else if (ret == 0) {
+            /* WFOPEN reported success but produced no usable handle; surface
+             * an error instead of silently returning success. */
+            ret = WS_BAD_FILE_E;
+        }
+    }
+
+    return ret;
+}
+
+
+#ifdef WOLFSSH_TEST_INTERNAL
+int wolfSSH_TestAppendKeyToFile(const char* filename, const char* name,
+        const char* type, const char* key)
+{
+    return AppendKeyToFile(filename, name, type, key);
+}
+#endif
 
 
 static int FingerprintKey(const byte* pubKey, word32 pubKeySz, char* out)

--- a/apps/wolfssh/common.h
+++ b/apps/wolfssh/common.h
@@ -34,5 +34,9 @@ WOLFSSH_LOCAL void ClientIPOverride(int flag);
 WOLFSSH_LOCAL void ClientFreeBuffers(void);
 WOLFSSH_LOCAL int ClientParseDestination(const char* in, char** user,
         char** hostname, word16* port);
+#ifdef WOLFSSH_TEST_INTERNAL
+WOLFSSH_LOCAL int wolfSSH_TestAppendKeyToFile(const char* filename,
+        const char* name, const char* type, const char* key);
+#endif
 
 #endif /* APPS_WOLFSSH_COMMON_H */

--- a/tests/regress.c
+++ b/tests/regress.c
@@ -342,6 +342,43 @@ static void FreeChannelOpenHarness(ChannelOpenHarness* harness)
     #endif
 #endif
 
+/* Read a whole file into buf, returning the byte count (0 on any failure).
+ * Used by the DH KEX regression below and by TestAppendKeyToFile, so it is
+ * available whenever either of those is compiled. */
+#if defined(KEXDH_REPLY_REGRESS_KEX_ALGO) || defined(WOLFSSH_TEST_INTERNAL)
+static word32 LoadFileBuffer(const char* path, byte* buf, word32 bufSz)
+{
+    WFILE* file;
+    long fileSz;
+    word32 readSz;
+
+    if (path == NULL || buf == NULL || bufSz == 0) {
+        return 0;
+    }
+
+    if (WFOPEN(NULL, &file, path, "rb") != 0 || file == WBADFILE) {
+        return 0;
+    }
+    WFSEEK(NULL, file, 0, WSEEK_END);
+    fileSz = WFTELL(NULL, file);
+    WREWIND(NULL, file);
+
+    if (fileSz <= 0 || (word32)fileSz > bufSz) {
+        WFCLOSE(NULL, file);
+        return 0;
+    }
+
+    readSz = (word32)WFREAD(NULL, buf, 1, fileSz, file);
+    WFCLOSE(NULL, file);
+
+    if (readSz != (word32)fileSz) {
+        return 0;
+    }
+
+    return readSz;
+}
+#endif /* KEXDH_REPLY_REGRESS_KEX_ALGO || WOLFSSH_TEST_INTERNAL */
+
 #ifdef KEXDH_REPLY_REGRESS_KEX_ALGO
 
 #define REGRESS_DUPLEX_QUEUE_SZ 32768U
@@ -428,38 +465,6 @@ static word32 AppendBlob(byte* buf, word32 bufSz, word32 idx,
 {
     idx = AppendUint32(buf, bufSz, idx, dataSz);
     return AppendData(buf, bufSz, idx, data, dataSz);
-}
-
-static word32 LoadFileBuffer(const char* path, byte* buf, word32 bufSz)
-{
-    WFILE* file;
-    long fileSz;
-    word32 readSz;
-
-    if (path == NULL || buf == NULL || bufSz == 0) {
-        return 0;
-    }
-
-    if (WFOPEN(NULL, &file, path, "rb") != 0 || file == WBADFILE) {
-        return 0;
-    }
-    WFSEEK(NULL, file, 0, WSEEK_END);
-    fileSz = WFTELL(NULL, file);
-    WREWIND(NULL, file);
-
-    if (fileSz <= 0 || (word32)fileSz > bufSz) {
-        WFCLOSE(NULL, file);
-        return 0;
-    }
-
-    readSz = (word32)WFREAD(NULL, buf, 1, fileSz, file);
-    WFCLOSE(NULL, file);
-
-    if (readSz != (word32)fileSz) {
-        return 0;
-    }
-
-    return readSz;
 }
 
 static int RegressionClientUserAuth(byte authType,
@@ -3579,6 +3584,109 @@ static void TestClientParseDestination(void)
 }
 
 
+#ifdef WOLFSSH_TEST_INTERNAL
+/* AppendKeyToFile must refuse a host name or key type that carries whitespace
+ * or control bytes, so an attacker-controlled value cannot inject extra fields
+ * or a forged entry into the known_hosts file. Exercised through the
+ * wolfSSH_TestAppendKeyToFile hook. */
+static void TestAppendKeyToFile(void)
+{
+    const char* path = "regress_known_hosts.tmp";
+    char buf[128];
+    word32 readSz;
+
+    /* A clean name and type write one well-formed, newline-terminated entry. */
+    (void)remove(path);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host.example.com",
+                "ssh-rsa", "AAAA"), WS_SUCCESS);
+    WMEMSET(buf, 0, sizeof(buf));
+    readSz = LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1);
+    AssertTrue(readSz > 0);
+    AssertIntEQ(WSTRCMP(buf, "host.example.com ssh-rsa AAAA\n"), 0);
+
+    /* A second call appends rather than truncating, preserving the first
+     * entry (the file is opened in append mode). */
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host2.example.com",
+                "ssh-ed25519", "BBBB"), WS_SUCCESS);
+    WMEMSET(buf, 0, sizeof(buf));
+    readSz = LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1);
+    AssertTrue(readSz > 0);
+    AssertIntEQ(WSTRCMP(buf,
+                "host.example.com ssh-rsa AAAA\n"
+                "host2.example.com ssh-ed25519 BBBB\n"), 0);
+
+    /* A newline in the name would forge an extra entry; it is rejected and
+     * nothing is written to the file. */
+    (void)remove(path);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path,
+                "127.0.0.1\nevil.example.com ssh-rsa BBBB", "ssh-rsa", "CCCC"),
+            WS_BAD_ARGUMENT);
+    AssertIntEQ(LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1), 0);
+
+    /* A space in the name would forge extra fields; it is rejected. */
+    (void)remove(path);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "real.example.com other",
+                "ssh-rsa", "CCCC"), WS_BAD_ARGUMENT);
+    AssertIntEQ(LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1), 0);
+
+    /* The key type is peer-supplied and is checked the same way: a newline in
+     * it is rejected and nothing is written. */
+    (void)remove(path);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host.example.com",
+                "ssh-rsa\nevil.example.com ssh-rsa DDDD", "EEEE"),
+            WS_BAD_ARGUMENT);
+    AssertIntEQ(LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1), 0);
+
+    /* Tab, carriage return, and DEL (0x7f) are rejected too, and each leaves
+     * the file unwritten. */
+    (void)remove(path);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host\tname", "ssh-rsa",
+                "CCCC"), WS_BAD_ARGUMENT);
+    AssertIntEQ(LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1), 0);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host\rname", "ssh-rsa",
+                "CCCC"), WS_BAD_ARGUMENT);
+    AssertIntEQ(LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1), 0);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host\x7fname", "ssh-rsa",
+                "CCCC"), WS_BAD_ARGUMENT);
+    AssertIntEQ(LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1), 0);
+
+    /* A NULL or empty name, type, or key is rejected and nothing is written.
+     * The key check guards fprintf against a NULL or empty value. */
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, NULL, "ssh-rsa", "CCCC"),
+            WS_BAD_ARGUMENT);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "", "ssh-rsa", "CCCC"),
+            WS_BAD_ARGUMENT);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host.example.com", "",
+                "CCCC"), WS_BAD_ARGUMENT);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host.example.com", "ssh-rsa",
+                NULL), WS_BAD_ARGUMENT);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "host.example.com", "ssh-rsa",
+                ""), WS_BAD_ARGUMENT);
+    AssertIntEQ(LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1), 0);
+
+    /* High-bit (non-ASCII) bytes are only above the control range, so an
+     * internationalized host name is stored intact rather than rejected. This
+     * pins the unsigned-char handling: a signed-char compare would wrongly
+     * reject 0x80-0xff. */
+    (void)remove(path);
+    AssertIntEQ(wolfSSH_TestAppendKeyToFile(path, "h\xC3\xA9st", "ssh-rsa",
+                "AAAA"), WS_SUCCESS);
+    WMEMSET(buf, 0, sizeof(buf));
+    readSz = LoadFileBuffer(path, (byte*)buf, sizeof(buf) - 1);
+    AssertTrue(readSz > 0);
+    AssertIntEQ(WSTRCMP(buf, "h\xC3\xA9st ssh-rsa AAAA\n"), 0);
+
+    /* When the file cannot be opened (here, a path under a directory that does
+     * not exist), the function reports the failure rather than claiming
+     * success. */
+    AssertTrue(wolfSSH_TestAppendKeyToFile("regress_no_such_dir/known_hosts",
+                "host.example.com", "ssh-rsa", "AAAA") != WS_SUCCESS);
+
+    (void)remove(path);
+}
+#endif /* WOLFSSH_TEST_INTERNAL */
+
+
 int main(int argc, char** argv)
 {
     WOLFSSH_CTX* ctx;
@@ -3596,6 +3704,9 @@ int main(int argc, char** argv)
     AssertNotNull(ssh);
 
     TestClientParseDestination();
+#ifdef WOLFSSH_TEST_INTERNAL
+    TestAppendKeyToFile();
+#endif
     TestAuthMessageBlockedDuringKeying(ssh);
     TestUserauthFailureDuringKeying(ssh);
     TestPasswordLeakAborts(ssh);


### PR DESCRIPTION
## Reject unsanitized fields before writing `known_hosts`

### Summary

The wolfssh client wrote the destination host name (from `argv`) and the
peer-supplied key-type verbatim into `~/.ssh/known_hosts` via
`fprintf(f, "%s %s %s\n", name, type, key)`. Since entries are
whitespace-delimited and newline-terminated, an attacker-influenced value with
a newline could **inject a forged trusted entry**, and a space/tab could
**forge fields**.
Addressed by f_5136.

### Fix (`apps/wolfssh/common.c`)

- New `static IsFieldStorable()`: rejects a field that is `NULL`, empty, or
  contains a space/control byte (`(unsigned char)c <= ' '`) or `0x7f`,
  returning `WS_BAD_ARGUMENT`. High-bit (UTF-8/IDN) bytes are allowed.
- `AppendKeyToFile` validates `name`, `type`, and `key` before opening the
  file, so a malformed value never reaches `fprintf`. `type` matters because
  it is copied verbatim from the peer's host-key blob; the `key` check is a
  NULL/empty guard (Base64 carries no separators).
- `AppendKeyToFile` stays `static` — no production symbol/behavior change.

### Testing (`tests/regress.c`)

New `TestAppendKeyToFile`, reached via a `#ifdef WOLFSSH_TEST_INTERNAL` wrapper
(`wolfSSH_Test*` convention; absent from production builds). Covers: clean
write + a second **append** that preserves the prior entry; rejection of
newline/space/tab/CR/DEL and `NULL`/empty in `name`/`type`/`key`, each
asserting nothing is written; and a high-bit name accepted intact.

### Verification

`regress.test` passes; each guard confirmed with a negative control (reverting
the check fails the matching case); clean under ASan + UBSan (LeakSanitizer
n/a on macOS); production `wolfssh` app builds clean.