### PR TITLE
Add timeout to TPM SSH workflow to prevent multi-hour hangs

### DIFF
--- a/.github/workflows/tpm-ssh.yml
+++ b/.github/workflows/tpm-ssh.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test-tpm-ssh:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -139,8 +140,8 @@ jobs:
         ./examples/echoserver/echoserver -1 -s key.ssh &
         echo "Echoserver (authorized TPM client key) PID: $!"
         sleep 2
-        ./examples/client/client -i ../wolftpm/keyblob.bin -u hansel \
-            -K ThisIsMyKeyAuth
+        timeout 20 ./examples/client/client -i ../wolftpm/keyblob.bin \
+            -u hansel -K ThisIsMyKeyAuth
 
     - name: Archive test artifacts
       if: always()


### PR DESCRIPTION
The TPM SSH Test workflow has no job timeout, so it inherits GitHub's 6-hour default. [This run](https://github.com/wolfSSL/wolfssh/actions/runs/27791148184/attempts/1) hung for ~2 hours before being cancelled.

Changes:
- Add `timeout-minutes: 20` at the job level so any hung matrix leg is killed instead of running for hours. The job normally finishes in a few minutes.
- Wrap the client public-key auth step in `timeout 20`. Unlike the host-key test (already wrapped in `timeout 20`), the bare `client` invocation had no timeout and is the most likely indefinite-hang source — this makes it fail fast and cleanly rather than consuming the full job budget.