### PR TITLE
examples/client: add cert-name length bounds check in ParseRFC6187

### DIFF
--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -331,6 +331,9 @@ static int ParseRFC6187(const byte* in, word32 inSz, byte** leafOut,
 
     /* Skip the name */
     ato32(in, &l);
+    if (l > inSz - sizeof(word32))
+        return WS_BUFFER_E;
+
     m += l + sizeof(word32);
 
     /* Get the cert count */


### PR DESCRIPTION
## Summary

`ParseRFC6187` in `examples/client/common.c` read the peer-supplied RFC6187 name length `l` with `ato32()` and then advanced `m += l + sizeof(word32)` without validating `l` against `inSz`. Because `l` is attacker-controlled (the leading length field of the SSH host-key blob), a value larger than `inSz` pushed `m` past `inSz`. The subsequent `inSz - m` unsigned subtraction then underflowed to a large value, so the `< sizeof(word32)` bounds test passed and `ato32(in + m, &count)` read past the end of the `pubKey` buffer.

This adds the same bounds check the sibling `apps/wolfssh/common.c` copy already has, restoring parity between the two implementations.

Addressed by f_6267.

## Changes

- `examples/client/common.c`: in `ParseRFC6187`, reject `l > inSz - sizeof(word32)` with `WS_BUFFER_E` immediately after reading `l`, before computing `m`.

```c
/* Skip the name */
ato32(in, &l);
if (l > inSz - sizeof(word32))
    return WS_BUFFER_E;

m += l + sizeof(word32);
```

## Why it is correct

- The earlier `inSz < sizeof(word32)` check guarantees `inSz - sizeof(word32)` cannot underflow.
- Rejecting oversized `l` keeps `m <= inSz`, so the later `inSz - m` subtractions stay in range and the existing bounds tests work as intended.