### PR TITLE
Zeroize SFTP file payload buffers before freeing

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -72,6 +72,7 @@ jobs:
           '',
           '--enable-all',
           '--enable-sftp',
+          '--enable-sftp --disable-sftp-zeroize',
           '--enable-scp',
           '--enable-keyboard-interactive',
           '--enable-shell',

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,11 @@ AC_ARG_ENABLE([sftp],
     [AS_HELP_STRING([--enable-sftp],[Enable SFTP support (default: disabled)])],
     [ENABLED_SFTP=$enableval],[ENABLED_SFTP=no])
 
+# SFTP buffer zeroization
+AC_ARG_ENABLE([sftp-zeroize],
+    [AS_HELP_STRING([--disable-sftp-zeroize],[Disable zeroization of SFTP file payload buffers before free (default: enabled)])],
+    [ENABLED_SFTP_ZEROIZE=$enableval],[ENABLED_SFTP_ZEROIZE=yes])
+
 # SSHD
 AC_ARG_ENABLE([sshd],
     [AS_HELP_STRING([--enable-sshd],[Enable SSHD support (default: disabled)])],
@@ -235,6 +240,8 @@ AS_IF([test "x$ENABLED_SCP" = "xyes"],
       [AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSH_SCP"])
 AS_IF([test "x$ENABLED_SFTP" = "xyes"],
       [AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSH_SFTP"])
+AS_IF([test "x$ENABLED_SFTP_ZEROIZE" = "xno"],
+      [AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSH_NO_SFTP_BUFFER_ZERO"])
 AS_IF([test "x$ENABLED_FWD" = "xyes"],
       [AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSH_FWD"])
 AS_IF([test "x$ENABLED_TERM" = "xyes"],
@@ -342,6 +349,7 @@ AS_ECHO(["   * psuedo-terminal:           $ENABLED_TERM"])
 AS_ECHO(["   * echoserver shell support:  $ENABLED_SHELL"])
 AS_ECHO(["   * scp:                       $ENABLED_SCP"])
 AS_ECHO(["   * sftp:                      $ENABLED_SFTP"])
+AS_ECHO(["   * sftp buffer zeroize:       $ENABLED_SFTP_ZEROIZE"])
 AS_ECHO(["   * sshd:                      $ENABLED_SSHD"])
 AS_ECHO(["   * ssh client:                $ENABLED_SSHCLIENT"])
 AS_ECHO(["   * agent:                     $ENABLED_AGENT"])

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -470,6 +470,12 @@ static int wolfSSH_SFTP_buffer_set_size(WS_SFTP_BUFFER* buffer, word32 sz)
         return WS_BAD_ARGUMENT;
     }
 
+#ifndef WOLFSSH_NO_SFTP_BUFFER_ZERO
+    /* wipe any payload in the region being trimmed off before shrinking */
+    if (buffer->data != NULL && sz < buffer->sz) {
+        ForceZero(buffer->data + sz, buffer->sz - sz);
+    }
+#endif
     buffer->sz = sz;
     return WS_SUCCESS;
 }
@@ -793,12 +799,15 @@ static int wolfSSH_SFTP_buffer_read(WOLFSSH* ssh, WS_SFTP_BUFFER* buffer,
 static void wolfSSH_SFTP_buffer_free(WOLFSSH* ssh, WS_SFTP_BUFFER* buffer)
 {
     if (ssh != NULL && buffer != NULL) {
-        buffer->idx = 0;
-        buffer->sz  = 0;
         if (buffer->data != NULL) {
+#ifndef WOLFSSH_NO_SFTP_BUFFER_ZERO
+            ForceZero(buffer->data, buffer->sz);
+#endif
             WFREE(buffer->data, ssh->ctx->heap, DYNTYPE_BUFFER);
             buffer->data = NULL;
         }
+        buffer->idx = 0;
+        buffer->sz  = 0;
     }
 }
 
@@ -1424,6 +1433,9 @@ static void wolfSSH_SFTP_RecvSetSend(WOLFSSH* ssh, byte* buf, int sz)
 
     /* free up existing data if needed */
     if (buf != state->buffer.data && state->buffer.data != NULL) {
+#ifndef WOLFSSH_NO_SFTP_BUFFER_ZERO
+        ForceZero(state->buffer.data, state->buffer.sz);
+#endif
         WFREE(state->buffer.data, ssh->ctx->heap, DYNTYPE_BUFFER);
         state->buffer.data = NULL;
     }


### PR DESCRIPTION
# Zeroize SFTP file payload buffers before freeing

## Summary

The shared SFTP receive/send buffer can hold transferred file contents, but it
was released with `WFREE` only. Freed heap could retain SFTP file data until
allocator reuse, exposing sensitive file contents to local memory disclosure or
forensic tooling.

This PR zeroizes SFTP buffers that may carry file payload before they are freed
or trimmed, and adds a build gate so deployments can opt out for bulk-transfer
throughput.

## Changes

### Zeroization

- **`wolfSSH_SFTP_buffer_free()`** — `ForceZero(buffer->data, buffer->sz)` before
  `WFREE`. Covers the read-response path and every per-state buffer release that
  funnels through this helper.
- **`wolfSSH_SFTP_RecvSetSend()`** — `ForceZero` before the `WFREE`, kept inside
  the existing `buf != state->buffer.data` aliasing guard so the outgoing
  response buffer (when it aliases the request buffer) is never wiped.
- **`wolfSSH_SFTP_buffer_set_size()`** — wipe the trimmed-off region
  (`ForceZero(buffer->data + sz, buffer->sz - sz)`) before shrinking. This helper
  reduces a buffer's logical length without reallocating, so without this a
  shrink could strand file payload past the new size. Pairing the shrink-time
  wipe with the free-time wipe gives a clean invariant: every sensitive byte is
  cleared either when it is trimmed off or when the buffer is freed.

`ForceZero` is already declared in `wolfssh/misc.h` (included by `wolfsftp.c`);
no new include is needed. All three functions are `static` — no public API or
signature change.

### Build gate

New `WOLFSSH_NO_SFTP_BUFFER_ZERO` macro gates the three zeroization sites,
secure-by-default (zeroization enabled unless explicitly disabled). The wipe of
bulk read/write response buffers is a measurable per-chunk cost on large
transfers, so deployments that prioritize throughput over this defense-in-depth
can opt out.

- `configure.ac` — `--disable-sftp-zeroize` (default enabled), emits
  `-DWOLFSSH_NO_SFTP_BUFFER_ZERO` when disabled, plus a config-summary line.
- The three sites use direct `#ifndef` guards (no wrapper macro) so `ForceZero`
  stays visible for security auditing.

### CI

- `.github/workflows/os-check.yml` — added `--enable-sftp --disable-sftp-zeroize`
  to the build matrix so the disabled code path is compiled and `make check`-ed
  on ubuntu/macos across the wolfSSL version matrix. The default (zeroize-on)
  path is already covered by the existing `--enable-sftp` / `--enable-all`
  entries.

## Scope notes

This wipes buffers that actually carry file payload. It intentionally does not
wipe never-written uninitialized slack (e.g. the tail of a short-read server
response buffer), which never held this request's file data and is outside the
finding's scope. The client read path reads file data into the caller-provided
`out` buffer, not a wolfSSH-owned buffer, so there is nothing for wolfSSH to
wipe there.

## Testing

- `./configure --enable-sftp && make && make check` — 7/7 pass.
- `./configure --enable-sftp --disable-sftp-zeroize && make && make check` —
  7/7 pass (disabled path builds and runs).