### PR TITLE
Bound KEXINIT name-list parsing to prevent pre-auth CPU DoS

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3908,11 +3908,19 @@ static int GetNameListRaw(byte* idList, word32* idListSz,
         const byte* nameList, word32 nameListSz)
 {
     const byte* name = nameList;
-    word32 nameSz = 0, nameListIdx = 0, idListIdx = 0;
+    word32 nameSz = 0, nameListIdx = 0, idListIdx = 0, tokenCount = 0;
     int ret = WS_SUCCESS;
 
     if (idList == NULL || nameList == NULL || idListSz == NULL) {
         return WS_BAD_ARGUMENT;
+    }
+
+    /* Reject oversized name-lists to bound the per-token NameToId scan cost.
+     * Applies to every list parsed here; the built-in canned lists are far
+     * under these caps. */
+    if (nameListSz > WOLFSSH_MAX_NAMELIST_SZ) {
+        WLOG(WS_LOG_ERROR, "Name list too large");
+        return WS_BUFFER_E;
     }
 
     /*
@@ -3929,6 +3937,11 @@ static int GetNameListRaw(byte* idList, word32* idListSz,
 
         if (nameListIdx == nameListSz || name[nameSz] == ',') {
             byte id;
+
+            if (++tokenCount > WOLFSSH_MAX_NAMELIST_CNT) {
+                WLOG(WS_LOG_ERROR, "Too many names in list");
+                return WS_BUFFER_E;
+            }
 
             id = NameToId((char*)name, nameSz);
             {

--- a/tests/regress.c
+++ b/tests/regress.c
@@ -2877,6 +2877,104 @@ static void TestKexInitReservedNonZeroRejected(void)
     wolfSSH_CTX_free(ctx);
 }
 
+/* Run a KEXINIT whose KEX-algorithms field is kexList through DoKexInit. The
+ * list uses unknown tokens, so on accept it fails to match
+ * (WS_MATCH_KEX_ALGO_E); a list rejected by the caps returns WS_BUFFER_E. */
+static int RunKexInitKexListCase(const char* kexList)
+{
+    WOLFSSH_CTX* ctx;
+    WOLFSSH* ssh;
+    byte* payload;
+    word32 payloadSz;
+    word32 idx = 0;
+    int ret;
+    word32 bufSz = WOLFSSH_MAX_NAMELIST_SZ + 2048;
+
+    ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
+    AssertNotNull(ctx);
+    ssh = wolfSSH_new(ctx);
+    AssertNotNull(ssh);
+    AssertIntEQ(wolfSSH_SetAlgoListKex(ssh, FPF_KEX_GOOD), WS_SUCCESS);
+    AssertIntEQ(wolfSSH_SetAlgoListKey(ssh, FPF_KEY_GOOD), WS_SUCCESS);
+
+    payload = (byte*)WMALLOC(bufSz, NULL, DYNTYPE_BUFFER);
+    AssertNotNull(payload);
+
+    payloadSz = BuildKexInitPayload(ssh, kexList, FPF_KEY_GOOD, 0,
+            payload, bufSz);
+    ret = wolfSSH_TestDoKexInit(ssh, payload, payloadSz, &idx);
+
+    WFREE(payload, NULL, DYNTYPE_BUFFER);
+    wolfSSH_free(ssh);
+    wolfSSH_CTX_free(ctx);
+
+    return ret;
+}
+
+/* Build "a,a,...,a" with count unknown tokens into a freshly allocated,
+ * NULL-terminated buffer. */
+static char* BuildTokenListStr(word32 count)
+{
+    char* list;
+    word32 listSz;
+    word32 i;
+
+    AssertTrue(count > 0);
+    listSz = (count * 2) - 1;
+
+    list = (char*)WMALLOC(listSz + 1, NULL, DYNTYPE_STRING);
+    AssertNotNull(list);
+    for (i = 0; i < count; i++) {
+        list[i * 2] = 'a';
+        if (i + 1 < count)
+            list[(i * 2) + 1] = ',';
+    }
+    list[listSz] = '\0';
+
+    return list;
+}
+
+/* Build a single unknown token of byteSz 'a' characters. */
+static char* BuildSingleTokenStr(word32 byteSz)
+{
+    char* list;
+
+    list = (char*)WMALLOC(byteSz + 1, NULL, DYNTYPE_STRING);
+    AssertNotNull(list);
+    WMEMSET(list, 'a', byteSz);
+    list[byteSz] = '\0';
+
+    return list;
+}
+
+/* Lock in both KEXINIT name-list boundaries (name count and byte size) so a
+ * future retune or refactor that disables the bound or flips the off-by-one
+ * fails here. */
+static void TestKexInitNameListCaps(void)
+{
+    char* list;
+
+    /* Exactly the name-count cap parses (then fails to match). */
+    list = BuildTokenListStr(WOLFSSH_MAX_NAMELIST_CNT);
+    AssertIntEQ(RunKexInitKexListCase(list), WS_MATCH_KEX_ALGO_E);
+    WFREE(list, NULL, DYNTYPE_STRING);
+
+    /* One past the name-count cap is rejected. */
+    list = BuildTokenListStr(WOLFSSH_MAX_NAMELIST_CNT + 1);
+    AssertIntEQ(RunKexInitKexListCase(list), WS_BUFFER_E);
+    WFREE(list, NULL, DYNTYPE_STRING);
+
+    /* Exactly the byte cap parses (then fails to match). */
+    list = BuildSingleTokenStr(WOLFSSH_MAX_NAMELIST_SZ);
+    AssertIntEQ(RunKexInitKexListCase(list), WS_MATCH_KEX_ALGO_E);
+    WFREE(list, NULL, DYNTYPE_STRING);
+
+    /* One past the byte cap is rejected. */
+    list = BuildSingleTokenStr(WOLFSSH_MAX_NAMELIST_SZ + 1);
+    AssertIntEQ(RunKexInitKexListCase(list), WS_BUFFER_E);
+    WFREE(list, NULL, DYNTYPE_STRING);
+}
+
 #if !defined(WOLFSSH_NO_AES_CBC) && !defined(WOLFSSH_NO_AES_CTR) \
     && !defined(WOLFSSH_NO_HMAC_SHA1) && !defined(WOLFSSH_NO_HMAC_SHA2_256)
 static void TestIndependentAlgoNegotiation(void)
@@ -4181,6 +4279,7 @@ int main(int argc, char** argv)
     && !defined(WOLFSSH_NO_RSA_SHA2_256)
     TestFirstPacketFollows();
     TestKexInitReservedNonZeroRejected();
+    TestKexInitNameListCaps();
     TestDoKexInitRejectsWhenPeerIsKeying();
 #endif
 #if !defined(WOLFSSH_NO_ECDH_SHA2_NISTP256) && !defined(WOLFSSH_NO_RSA) \

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -464,6 +464,14 @@ enum NameIdType {
     /* This is from RFC 4253 section 6.1. */
     #define MAX_PACKET_SZ 35000
 #endif
+#ifndef WOLFSSH_MAX_NAMELIST_SZ
+    /* Per-field byte cap on a peer-supplied SSH name-list. */
+    #define WOLFSSH_MAX_NAMELIST_SZ 4096
+#endif
+#ifndef WOLFSSH_MAX_NAMELIST_CNT
+    /* Per-field cap on the number of names in a name-list. */
+    #define WOLFSSH_MAX_NAMELIST_CNT 64
+#endif
 #ifndef WOLFSSH_DEFAULT_GEXDH_MIN
     #define WOLFSSH_DEFAULT_GEXDH_MIN 1024
 #endif


### PR DESCRIPTION
## Summary

`GetNameListRaw` parsed peer-supplied SSH name-lists with no per-field byte or token-count limit. For every comma-delimited token it called `NameToId`, which does a linear scan of the ~55-entry `NameIdMap` (a `WSTRLEN` + `XMEMCMP` per entry). Repeated *unknown* tokens are never stored in `idList` (only the first is kept), so the existing "no more space" guard never trips and the loop keeps scanning every token.

A single `SSH_MSG_KEXINIT` can carry name-list fields up to `MAX_PACKET_SZ`, and `DoKexInit` parses **eight** of them — before authentication. A field of `a,a,a,…` (≈16K single-char tokens in 32 KB) yields O(tokens × map) work per field, measured at ~5.3 ms CPU per max-size KEXINIT. Sustained flooding from parallel connections can saturate a server core without ever completing user auth.

This is a pre-authentication algorithmic-complexity DoS addressed by f_5726.

## Fix

Cap each parsed name-list in `GetNameListRaw`:

- `WOLFSSH_MAX_NAMELIST_SZ` (4096) — per-field byte limit, rejected up front.
- `WOLFSSH_MAX_NAMELIST_CNT` (64) — per-field name-count limit, checked before each `NameToId` call.

Either limit exceeded returns `WS_BUFFER_E`. Both caps are `#ifndef`-guarded so they remain tunable.

The caps sit well above any legitimate list: `NameIdMap` has fewer than 64 entries, and the built-in canned algorithm lists are a few hundred bytes — so real handshakes are unaffected. The bound applies to every list parsed through this function (the canned lists are far under the caps).

```c
/* Reject oversized name-lists to bound the per-token NameToId scan cost.
 * Applies to every list parsed here; the built-in canned lists are far
 * under these caps. */
if (nameListSz > WOLFSSH_MAX_NAMELIST_SZ) {
    WLOG(WS_LOG_ERROR, "Name list too large");
    return WS_BUFFER_E;
}
...
if (++tokenCount > WOLFSSH_MAX_NAMELIST_CNT) {
    WLOG(WS_LOG_ERROR, "Too many names in list");
    return WS_BUFFER_E;
}
```

## Tests

Added `TestKexInitNameListCaps()` in `tests/regress.c`, driving crafted KEXINIT payloads through the existing `wolfSSH_TestDoKexInit` → `GetNameList` → `GetNameListRaw` path. The tokens are unknown (`a,a,…`) so `idList` never fills for an unrelated reason — the cap is the only thing under test. Both boundaries are locked in:

| Case | Field | Expected |
|------|-------|----------|
| name count at cap | 64 names | parses, then `WS_MATCH_KEX_ALGO_E` |
| name count over cap | 65 names | `WS_BUFFER_E` |
| byte size at cap | 4096-byte token | parses, then `WS_MATCH_KEX_ALGO_E` |
| byte size over cap | 4097-byte token | `WS_BUFFER_E` |

## Verification

- `./configure --enable-all` + full `make check` (10 suites) — all PASS.
- Rebuilt with `-fsanitize=address,undefined`; full `make check` — all PASS, no ASan/UBSan reports. (macOS: LeakSanitizer unsupported, so leak detection disabled; the new test pairs every `WMALLOC` with a `WFREE` on all paths.)
- Negative control: with the token cap neutralized, the 65-name case returned `-1050` (`WS_MATCH_KEX_ALGO_E`) instead of `-1004` (`WS_BUFFER_E`) and the test failed as expected — confirming it catches the regression.

## Files changed

- `wolfssh/internal.h` — add `WOLFSSH_MAX_NAMELIST_SZ` / `WOLFSSH_MAX_NAMELIST_CNT`.
- `src/internal.c` — enforce both caps in `GetNameListRaw`.
- `tests/regress.c` — add `TestKexInitNameListCaps()` and helpers.