### PR TITLE
wolfsshd: expand AuthorizedKeysFile %u/%h/%% tokens per user

### DIFF
--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -131,9 +131,6 @@ struct WOLFSSHD_AUTH {
         #define MAX_LINE_SZ 900
     #endif
 #endif
-#ifndef MAX_PATH_SZ
-    #define MAX_PATH_SZ 80
-#endif
 
 #if 0
 /* this could potentially be useful in a deeply embedded future port */
@@ -505,15 +502,122 @@ static int CheckPasswordUnix(const char* usr, const byte* pw, word32 pwSz, WOLFS
 
 static const char authKeysDefault[] = ".ssh/authorized_keys";
 
-/* Resolve the authorized keys file path for a user. The pattern is the user's
- * configured AuthorizedKeysFile (resolved per request from the per-user config)
- * and is passed in explicitly rather than read from shared state so concurrent
- * authentications (e.g. Windows threaded mode) cannot race on it. A NULL or
- * empty pattern falls back to the default authorized_keys location. */
-static int ResolveAuthKeysPath(const char* homeDir, const char* pattern,
+/* Expand AuthorizedKeysFile tokens (%% literal, %h home dir, %u user name)
+ * from pattern into out. Unrecognized tokens fail closed so a per-user pattern
+ * cannot collapse to one shared path. Returns WS_SUCCESS or a negative error. */
+static int ExpandAuthKeysTokens(const char* pattern, const char* homeDir,
+                                const char* user, char* out, word32 outSz)
+{
+    int ret = WS_SUCCESS;
+    word32 outIdx = 0;
+    word32 i = 0;
+    word32 patSz;
+    word32 insSz;
+    const char* ins;
+    char lit[2];
+
+    if (pattern == NULL || out == NULL || outSz == 0) {
+        ret = WS_BAD_ARGUMENT;
+    }
+
+    if (ret == WS_SUCCESS) {
+        patSz = (word32)WSTRLEN(pattern);
+        lit[1] = '\0';
+
+        while (ret == WS_SUCCESS && i < patSz) {
+            ins = NULL;
+
+            if (pattern[i] == '%' && (i + 1) < patSz) {
+                switch (pattern[i + 1]) {
+                    case '%':
+                        lit[0] = '%';
+                        ins = lit;
+                        break;
+                    case 'h':
+                        ins = homeDir;
+                        break;
+                    case 'u':
+                        ins = user;
+                        break;
+                    default:
+                        wolfSSH_Log(WS_LOG_ERROR,
+                            "[SSHD] Unsupported AuthorizedKeysFile token");
+                        ret = WS_FATAL_ERROR;
+                        break;
+                }
+                /* token recognized but its value is unavailable */
+                if (ret == WS_SUCCESS && ins == NULL) {
+                    wolfSSH_Log(WS_LOG_ERROR,
+                        "[SSHD] No value for AuthorizedKeysFile token");
+                    ret = WS_FATAL_ERROR;
+                }
+                i += 2;
+            }
+            else {
+                /* literal character (including a trailing lone '%') */
+                lit[0] = pattern[i];
+                ins = lit;
+                i += 1;
+            }
+
+            if (ret == WS_SUCCESS) {
+                insSz = (word32)WSTRLEN(ins);
+                /* leave room for the terminating null */
+                if (outIdx + insSz >= outSz) {
+                    wolfSSH_Log(WS_LOG_ERROR,
+                        "[SSHD] Path for key file larger than max allowed");
+                    ret = WS_FATAL_ERROR;
+                }
+                else {
+                    WMEMCPY(out + outIdx, ins, insSz);
+                    outIdx += insSz;
+                }
+            }
+        }
+    }
+
+    if (ret == WS_SUCCESS) {
+        out[outIdx] = '\0';
+    }
+
+    return ret;
+}
+
+/* True for a fully qualified path. POSIX roots only at '/'; Windows also roots
+ * at a '\' or a drive letter followed by a separator ("X:\"). A bare "X:" is
+ * drive-relative, not absolute, so it is left to resolve under the home dir. */
+static int IsAbsoluteAuthKeysPath(const char* path)
+{
+    int ret = 0;
+
+    if (path != NULL) {
+        if (path[0] == '/') {
+            ret = 1;
+        }
+#ifdef _WIN32
+        else if (path[0] == '\\') {
+            ret = 1;
+        }
+        else if (((path[0] >= 'A' && path[0] <= 'Z') ||
+                  (path[0] >= 'a' && path[0] <= 'z')) && path[1] == ':' &&
+                 (path[2] == '\\' || path[2] == '/')) {
+            ret = 1;
+        }
+#endif
+    }
+
+    return ret;
+}
+
+/* Resolve the authorized keys file path for a user. The pattern is passed in
+ * explicitly so concurrent authentications cannot race on it, and its tokens
+ * are expanded so each user resolves to a distinct path. */
+WOLFSSHD_STATIC int ResolveAuthKeysPath(const char* homeDir,
+                               const char* pattern, const char* user,
                                char* resolved)
 {
     int ret = WS_SUCCESS;
+    char expanded[MAX_PATH_SZ];
     char* idx;
     int homeDirSz;
     const char* suffix = authKeysDefault;
@@ -524,24 +628,19 @@ static int ResolveAuthKeysPath(const char* homeDir, const char* pattern,
 
     if (ret == WS_SUCCESS) {
         if (pattern != NULL && *pattern != 0) {
-            /* TODO: token substitutions (e.g. %h) */
-            if (*pattern == '/') {
-                /* Absolute path is used as-is. Error out rather than
-                 * silently truncate when it does not fit, mirroring the
-                 * relative-path branch below. */
-                if (WSTRLEN(pattern) >= MAX_PATH_SZ) {
-                    wolfSSH_Log(WS_LOG_ERROR,
-                        "[SSHD] Path for key file larger than max allowed");
-                    ret = WS_FATAL_ERROR;
-                }
-                else {
-                    WSTRNCPY(resolved, pattern, MAX_PATH_SZ - 1);
-                    resolved[MAX_PATH_SZ - 1] = '\0';
-                }
+            ret = ExpandAuthKeysTokens(pattern, homeDir, user, expanded,
+                                       (word32)sizeof(expanded));
+            if (ret != WS_SUCCESS) {
+                wolfSSH_Log(WS_LOG_ERROR,
+                    "[SSHD] Failed to expand AuthorizedKeysFile pattern");
+            }
+            /* expanded is NUL-terminated and shorter than MAX_PATH_SZ */
+            else if (IsAbsoluteAuthKeysPath(expanded)) {
+                WMEMCPY(resolved, expanded, WSTRLEN(expanded) + 1);
                 return ret;
             }
             else {
-                suffix = pattern;
+                suffix = expanded;
             }
         }
     }
@@ -559,8 +658,8 @@ static int ResolveAuthKeysPath(const char* homeDir, const char* pattern,
             XMEMCPY(idx, homeDir, homeDirSz);
             idx += homeDirSz;
             *(idx++) = '/';
-            /* Intentionally copying the null term from suffix. */
-            XMEMCPY(idx, suffix, WSTRLEN(suffix));
+            /* the bound check above leaves room for suffix and its null term */
+            XMEMCPY(idx, suffix, WSTRLEN(suffix) + 1);
         }
     }
 
@@ -784,6 +883,7 @@ int wolfSSHD_OpenSecureFile(const char* path, WUID_T ownerUid,
 }
 
 static int SearchForPubKey(const char* path, const char* authKeysFile,
+                           const char* user,
                            const WS_UserAuthData_PublicKey* pubKeyCtx,
                            WUID_T uid, int strictModes)
 {
@@ -797,7 +897,7 @@ static int SearchForPubKey(const char* path, const char* authKeysFile,
     int rc = 0;
 
     WMEMSET(authKeysPath, 0, sizeof(authKeysPath));
-    rc = ResolveAuthKeysPath(path, authKeysFile, authKeysPath);
+    rc = ResolveAuthKeysPath(path, authKeysFile, user, authKeysPath);
     if (rc != WS_SUCCESS) {
         wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Failed to resolve authorized keys"
             " file path.");
@@ -980,8 +1080,9 @@ static int CheckPublicKeyUnix(const char* name,
         }
 
         if (ret == WSSHD_AUTH_SUCCESS) {
-            ret = SearchForPubKey(pwInfo->pw_dir, authorizedKeysFile, pubKeyCtx,
-                pwInfo->pw_uid, wolfSSHD_ConfigGetStrictModes(authCtx->conf));
+            ret = SearchForPubKey(pwInfo->pw_dir, authorizedKeysFile, name,
+                pubKeyCtx, pwInfo->pw_uid,
+                wolfSSHD_ConfigGetStrictModes(authCtx->conf));
         }
     }
 
@@ -1325,7 +1426,7 @@ static int CheckPublicKeyWIN(const char* usr,
             if (ret == WSSHD_AUTH_SUCCESS) {
                 r[rSz-1] = L'\0';
 
-                ret = SearchForPubKey(r, authorizedKeysFile, pubKeyCtx, 0,
+                ret = SearchForPubKey(r, authorizedKeysFile, usr, pubKeyCtx, 0,
                     wolfSSHD_ConfigGetStrictModes(authCtx->conf));
                 if (ret != WSSHD_AUTH_SUCCESS) {
                     wolfSSH_Log(WS_LOG_ERROR,

--- a/apps/wolfsshd/auth.h
+++ b/apps/wolfsshd/auth.h
@@ -99,6 +99,8 @@ int CheckPasswordHashUnix(const char* input, char* stored);
 #endif
 int CheckAuthKeysLine(char* line, word32 lineSz, const byte* key,
                       word32 keySz);
+int ResolveAuthKeysPath(const char* homeDir, const char* pattern,
+                        const char* user, char* resolved);
 int CAKeysFileDiffers(const char* a, const char* b);
 int wolfSSHD_GetUserAuthTypes(const WOLFSSHD_CONFIG* usrConf);
 #endif

--- a/apps/wolfsshd/configuration.h
+++ b/apps/wolfsshd/configuration.h
@@ -39,6 +39,10 @@ typedef struct WOLFSSHD_CONFIG WOLFSSHD_CONFIG;
 #define WOLFSSHD_PRIV_SANDBOX 1
 #define WOLFSSHD_PRIV_OFF     2
 
+#ifndef MAX_PATH_SZ
+    #define MAX_PATH_SZ 80
+#endif
+
 WOLFSSHD_CONFIG* wolfSSHD_ConfigNew(void* heap);
 void wolfSSHD_ConfigFree(WOLFSSHD_CONFIG* conf);
 int wolfSSHD_ConfigLoad(WOLFSSHD_CONFIG* conf, const char* filename);

--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -1900,6 +1900,130 @@ static int test_OpenSecureFile(void)
 }
 #endif /* !_WIN32 */
 
+/* Verify AuthorizedKeysFile token substitution so an absolute pattern with %u
+ * resolves to a per-user path instead of the same literal string for every
+ * user. */
+static int test_ResolveAuthKeysPath(void)
+{
+    int ret = WS_SUCCESS;
+    int rc;
+    word32 i;
+    char resolved[MAX_PATH_SZ];
+    char longPat[MAX_PATH_SZ + 16];
+    char longHome[MAX_PATH_SZ];
+    static const struct {
+        const char* home;
+        const char* pattern;
+        const char* user;
+        int expectRet;
+        const char* expect;
+    } vectors[] = {
+        /* absolute pattern with %u resolves to a distinct path per user */
+        { "/home/alice", "/etc/ssh/keys/%u", "alice", WS_SUCCESS,
+          "/etc/ssh/keys/alice" },
+        { "/home/bob",   "/etc/ssh/keys/%u", "bob",   WS_SUCCESS,
+          "/etc/ssh/keys/bob" },
+        /* %h expands to the home directory */
+        { "/home/alice", "%h/.ssh/authorized_keys", "alice", WS_SUCCESS,
+          "/home/alice/.ssh/authorized_keys" },
+        /* %% is a literal percent */
+        { "/home/alice", "/keys/100%%/%u", "alice", WS_SUCCESS,
+          "/keys/100%/alice" },
+        /* relative pattern is taken under the home directory */
+        { "/home/alice", "keys/%u", "alice", WS_SUCCESS,
+          "/home/alice/keys/alice" },
+#ifdef _WIN32
+        /* drive-letter and backslash roots are absolute on Windows */
+        { "/home/alice", "C:\\keys\\%u", "alice", WS_SUCCESS,
+          "C:\\keys\\alice" },
+        { "/home/alice", "\\keys\\%u", "alice", WS_SUCCESS,
+          "\\keys\\alice" },
+#else
+        /* on POSIX they are relative, taken under the home directory */
+        { "/home/alice", "C:\\keys\\%u", "alice", WS_SUCCESS,
+          "/home/alice/C:\\keys\\alice" },
+        { "/home/alice", "\\keys\\%u", "alice", WS_SUCCESS,
+          "/home/alice/\\keys\\alice" },
+#endif
+        /* a bare "X:" is drive-relative, not absolute, on either platform and
+         * so resolves under the home directory */
+        { "/home/alice", "C:keys\\%u", "alice", WS_SUCCESS,
+          "/home/alice/C:keys\\alice" },
+        { "/home/alice", "C:%u", "alice", WS_SUCCESS,
+          "/home/alice/C:alice" },
+        /* NULL pattern falls back to the default location */
+        { "/home/alice", NULL, "alice", WS_SUCCESS,
+          "/home/alice/.ssh/authorized_keys" },
+        /* a trailing lone '%' is treated as a literal */
+        { "/home/alice", "/etc/keys/%u%", "alice", WS_SUCCESS,
+          "/etc/keys/alice%" },
+        /* unrecognized token fails closed */
+        { "/home/alice", "/etc/keys/%q", "alice", WS_FATAL_ERROR, NULL },
+        /* recognized token with no available value (NULL user) fails closed */
+        { "/home/alice", "/etc/keys/%u", NULL, WS_FATAL_ERROR, NULL },
+    };
+
+    for (i = 0; ret == WS_SUCCESS && i < sizeof(vectors) / sizeof(vectors[0]);
+         i++) {
+        Log("    Testing scenario: pattern \"%s\" user \"%s\".",
+            vectors[i].pattern != NULL ? vectors[i].pattern : "(null)",
+            vectors[i].user != NULL ? vectors[i].user : "(null)");
+        /* non-zero fill so a missing null terminator cannot pass unnoticed */
+        WMEMSET(resolved, 0xA5, sizeof(resolved));
+        rc = ResolveAuthKeysPath(vectors[i].home, vectors[i].pattern,
+                                 vectors[i].user, resolved);
+        if (rc != vectors[i].expectRet) {
+            Log(" FAILED (rc=%d).\n", rc);
+            ret = WS_FATAL_ERROR;
+        }
+        else if (vectors[i].expect != NULL &&
+                 WSTRCMP(resolved, vectors[i].expect) != 0) {
+            Log(" FAILED (got \"%s\").\n", resolved);
+            ret = WS_FATAL_ERROR;
+        }
+        else {
+            Log(" PASSED.\n");
+        }
+    }
+
+    /* an expansion that exceeds MAX_PATH_SZ fails closed */
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: over-length pattern is rejected.");
+        WMEMSET(longPat, 'a', sizeof(longPat) - 1);
+        longPat[0] = '/';
+        longPat[sizeof(longPat) - 1] = '\0';
+        WMEMSET(resolved, 0, sizeof(resolved));
+        rc = ResolveAuthKeysPath("/home/alice", longPat, "alice", resolved);
+        if (rc == WS_FATAL_ERROR) {
+            Log(" PASSED.\n");
+        }
+        else {
+            Log(" FAILED (rc=%d).\n", rc);
+            ret = WS_FATAL_ERROR;
+        }
+    }
+
+    /* a relative pattern under a long home directory fails closed */
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: relative pattern under long home is "
+            "rejected.");
+        WMEMSET(longHome, 'a', sizeof(longHome) - 1);
+        longHome[0] = '/';
+        longHome[sizeof(longHome) - 1] = '\0';
+        WMEMSET(resolved, 0, sizeof(resolved));
+        rc = ResolveAuthKeysPath(longHome, "keys/%u", "alice", resolved);
+        if (rc == WS_FATAL_ERROR) {
+            Log(" PASSED.\n");
+        }
+        else {
+            Log(" FAILED (rc=%d).\n", rc);
+            ret = WS_FATAL_ERROR;
+        }
+    }
+
+    return ret;
+}
+
 const TEST_CASE testCases[] = {
     TEST_DECL(test_ConfigDefaults),
     TEST_DECL(test_ParseConfigLine),
@@ -1917,6 +2041,7 @@ const TEST_CASE testCases[] = {
     TEST_DECL(test_IncludeRecursionBound),
     TEST_DECL(test_GetUserAuthTypes),
     TEST_DECL(test_ConfigSetAuthKeysFile),
+    TEST_DECL(test_ResolveAuthKeysPath),
     TEST_DECL(test_ConfigFree),
 #ifndef _WIN32
     TEST_DECL(test_OpenSecureFile),


### PR DESCRIPTION
## wolfsshd: expand AuthorizedKeysFile %u/%h/%% tokens per user

### Problem

`ResolveAuthKeysPath` copied an absolute `AuthorizedKeysFile` pattern into the
resolved path verbatim, with no token substitution (a `TODO` marked the gap).
A common OpenSSH-migration config such as:

```
AuthorizedKeysFile /etc/ssh/keys/%u
```

resolved to the literal `/etc/ssh/keys/%u` for **every** user. If a file existed
at that un-substituted path, its keys were accepted for any valid system user,
collapsing per-user key isolation.

Addressed by f_5827.

### Fix

- Add `ExpandAuthKeysTokens()` — expands `%u` (user), `%h` (home dir), and `%%`
  (literal `%`) into a bounds-checked buffer. Unrecognized tokens and
  over-length expansions **fail closed** (`WS_FATAL_ERROR`) rather than reaching
  the filesystem.
- `ResolveAuthKeysPath()` now takes the connecting user and expands the pattern
  before the absolute/relative decision, so both branches honor substitution and
  each user resolves to a distinct path.
- Thread the username through `SearchForPubKey()` → `CheckPublicKeyUnix` (Unix)
  and `CheckPublicKeyWIN` (Windows). Both call sites already held it; no new
  `getpwnam`/lookup is introduced and no shared mutable state is added.

### Token semantics

| Token | Expands to        |
|-------|-------------------|
| `%u`  | connecting user   |
| `%h`  | user home dir     |
| `%%`  | literal `%`       |

A recognized token with no value (e.g. `%u` with a NULL user) and any
unrecognized token fail closed. A trailing lone `%` is treated as a literal.

### Platform notes

Absolute-path detection is `/`-rooted on POSIX; on Windows it additionally
recognizes a `\`-root or a drive-letter (`X:`) root, guarded by `#ifdef _WIN32`
so a POSIX relative pattern beginning with `\` or `<letter>:` is not misread.

### Testing

- New `test_ResolveAuthKeysPath` unit test (13 scenarios): per-user `%u`
  (`alice` vs `bob`), `%h`, `%%`, relative, default-NULL fallback, trailing `%`,
  unrecognized token, NULL-user fail-closed, expansion over-length, relative
  home-dir over-length, and platform-aware drive-letter/backslash handling.
- `MAX_PATH_SZ` moved to `configuration.h` so the test buffer tracks the real
  contract; `ResolveAuthKeysPath` exposed to the tests via `WOLFSSHD_STATIC`.
- Verified under ASan + UBSan (clean), with negative controls confirming the
  tests catch both the verbatim-copy regression and a removed bounds check.
- Native Windows MSVC build (VS Build Tools 2022, x64): `auth.c` /
  `configuration.c` compile with no new warnings; default test set
  (api-test, unit-test, testsuite) passes.

### Files changed

- `apps/wolfsshd/auth.c`
- `apps/wolfsshd/auth.h`
- `apps/wolfsshd/configuration.h`
- `apps/wolfsshd/test/test_configuration.c`