### PR TITLE
Add server-side IsMessageAllowed pre-auth gate regression tests

### DIFF
--- a/tests/regress.c
+++ b/tests/regress.c
@@ -79,6 +79,7 @@ static void ResetSession(WOLFSSH* ssh)
     }
     ssh->isKeying = 0;
     ssh->connectState = CONNECT_BEGIN;
+    ssh->acceptState = ACCEPT_BEGIN;
     ssh->error = 0;
 }
 
@@ -1413,6 +1414,125 @@ static void TestChannelAllowedAfterAuth(WOLFSSH* ssh)
             WS_MSG_RECV);
     AssertTrue(allowed);
 }
+
+
+#ifndef NO_WOLFSSH_SERVER
+/* The client gate tests above run against a client endpoint, so the server
+ * branch of IsMessageAllowed was never exercised. The tests below drive a
+ * server endpoint to cover its pre-authentication message gate. */
+
+/* Reject connection-protocol messages on the server before user
+ * authentication completes. */
+static void TestServerChannelBlockedBeforeAuth(WOLFSSH* ssh)
+{
+    int allowed;
+
+    ResetSession(ssh);
+    /* The state just below the auth-complete boundary
+     * (ACCEPT_SERVER_USERAUTH_SENT). */
+    ssh->acceptState = ACCEPT_CLIENT_USERAUTH_DONE;
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_CHANNEL_OPEN,
+            WS_MSG_RECV);
+    AssertFalse(allowed);
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_GLOBAL_REQUEST,
+            WS_MSG_RECV);
+    AssertFalse(allowed);
+}
+
+
+/* Allow connection-protocol messages on the server once user authentication
+ * completes. Pins the acceptState boundary against a relaxed comparison. */
+static void TestServerChannelAllowedAfterAuth(WOLFSSH* ssh)
+{
+    int allowed;
+
+    ResetSession(ssh);
+    ssh->acceptState = ACCEPT_SERVER_USERAUTH_SENT;
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_CHANNEL_OPEN,
+            WS_MSG_RECV);
+    AssertTrue(allowed);
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_GLOBAL_REQUEST,
+            WS_MSG_RECV);
+    AssertTrue(allowed);
+}
+
+
+/* Reject the user auth request while the server is still keying, then accept
+ * it once keyed. Pins the pre-keyed message-range bound. */
+static void TestServerUserauthBlockedBeforeKeyed(WOLFSSH* ssh)
+{
+    int allowed;
+
+    ResetSession(ssh);
+    ssh->acceptState = ACCEPT_SERVER_KEXINIT_SENT;
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_USERAUTH_REQUEST,
+            WS_MSG_RECV);
+    AssertFalse(allowed);
+
+    ssh->acceptState = ACCEPT_CLIENT_USERAUTH_DONE;
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_USERAUTH_REQUEST,
+            WS_MSG_RECV);
+    AssertTrue(allowed);
+}
+
+
+/* Reject the user auth messages that only the server sends, while still
+ * accepting the keyboard-interactive info response that it receives. */
+static void TestServerOnlyUserauthMsgsBlocked(WOLFSSH* ssh)
+{
+    int allowed;
+
+    ResetSession(ssh);
+    ssh->acceptState = ACCEPT_CLIENT_USERAUTH_DONE;
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_USERAUTH_FAILURE,
+            WS_MSG_RECV);
+    AssertFalse(allowed);
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_USERAUTH_SUCCESS,
+            WS_MSG_RECV);
+    AssertFalse(allowed);
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_USERAUTH_INFO_RESPONSE,
+            WS_MSG_RECV);
+    AssertTrue(allowed);
+}
+
+
+/* The server accepts a service request only once keyed, and never accepts
+ * the service accept that only it sends. */
+static void TestServerServiceRequestStateGated(WOLFSSH* ssh)
+{
+    int allowed;
+
+    ResetSession(ssh);
+    ssh->acceptState = ACCEPT_KEYED;
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_SERVICE_REQUEST,
+            WS_MSG_RECV);
+    AssertTrue(allowed);
+
+    ssh->acceptState = ACCEPT_SERVER_KEXINIT_SENT;
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_SERVICE_REQUEST,
+            WS_MSG_RECV);
+    AssertFalse(allowed);
+
+    allowed = wolfSSH_TestIsMessageAllowed(ssh, MSGID_SERVICE_ACCEPT,
+            WS_MSG_RECV);
+    AssertFalse(allowed);
+    /* Of the messages exercised here, only SERVICE_ACCEPT sets an error
+     * on reject. */
+    AssertIntEQ(ssh->error, WS_MSGID_NOT_ALLOWED_E);
+}
+#endif /* NO_WOLFSSH_SERVER */
+
 
 static void TestChannelOpenCallbackRejectSendsOpenFail(void)
 {
@@ -4338,6 +4458,10 @@ int main(int argc, char** argv)
 {
     WOLFSSH_CTX* ctx;
     WOLFSSH* ssh;
+#ifndef NO_WOLFSSH_SERVER
+    WOLFSSH_CTX* serverCtx;
+    WOLFSSH* serverSsh;
+#endif
 
     (void)argc;
     (void)argv;
@@ -4349,6 +4473,14 @@ int main(int argc, char** argv)
 
     ssh = wolfSSH_new(ctx);
     AssertNotNull(ssh);
+
+#ifndef NO_WOLFSSH_SERVER
+    serverCtx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
+    AssertNotNull(serverCtx);
+
+    serverSsh = wolfSSH_new(serverCtx);
+    AssertNotNull(serverSsh);
+#endif
 
     TestClientParseDestination();
 #ifdef WOLFSSH_TEST_INTERNAL
@@ -4364,6 +4496,13 @@ int main(int argc, char** argv)
     TestPublicKeyFailureAborts(ssh);
     TestChannelBlockedBeforeAuth(ssh);
     TestChannelAllowedAfterAuth(ssh);
+#ifndef NO_WOLFSSH_SERVER
+    TestServerChannelBlockedBeforeAuth(serverSsh);
+    TestServerChannelAllowedAfterAuth(serverSsh);
+    TestServerUserauthBlockedBeforeKeyed(serverSsh);
+    TestServerOnlyUserauthMsgsBlocked(serverSsh);
+    TestServerServiceRequestStateGated(serverSsh);
+#endif
     TestChannelOpenCallbackRejectSendsOpenFail();
     TestSecondSessionChannelRejected();
 #ifdef WOLFSSH_FWD
@@ -4459,6 +4598,11 @@ int main(int argc, char** argv)
     ResetSession(ssh);
     wolfSSH_free(ssh);
     wolfSSH_CTX_free(ctx);
+#ifndef NO_WOLFSSH_SERVER
+    ResetSession(serverSsh);
+    wolfSSH_free(serverSsh);
+    wolfSSH_CTX_free(serverCtx);
+#endif
     wolfSSH_Cleanup();
 
     printf("regress: PASS\n");


### PR DESCRIPTION
## Add server-side coverage for the IsMessageAllowed pre-auth gate

### Background

`IsMessageAllowed` (`src/internal.c`) dispatches to `IsMessageAllowedServer`
or `IsMessageAllowedClient` based on `ssh->ctx->side`, and is the per-message
pre-authentication gate invoked from `DoPacket`. Every
`wolfSSH_TestIsMessageAllowed` call in `tests/regress.c` ran against the single
client-endpoint `ssh` created in `main()`, so only the client branch was
exercised. The entire server gate (`IsMessageAllowedServer`) had no test of its
blocking behavior, so mutations of its pre-auth checks could survive the suite.

This is a test-coverage gap. There is no production code change.
Addressed by f_6519.

### What this PR does

Adds server-endpoint regression tests that mirror the existing client gate
tests. A single shared server `ctx`/`ssh` is created in `main()` (guarded by
`#ifndef NO_WOLFSSH_SERVER`), symmetric with the existing client pair, and each
test calls `ResetSession` then sets `acceptState` before asserting.

New tests in `tests/regress.c`:

- `TestServerChannelBlockedBeforeAuth` / `TestServerChannelAllowedAfterAuth` -
  `CHANNEL_OPEN` and `GLOBAL_REQUEST` are blocked one state below the
  auth-complete boundary and allowed at `ACCEPT_SERVER_USERAUTH_SENT`. Together
  these pin the `acceptState < ACCEPT_SERVER_USERAUTH_SENT` comparison.
- `TestServerUserauthBlockedBeforeKeyed` - the user auth request is blocked
  while the server is still keying and accepted once keyed (pins the pre-keyed
  message-range bound).
- `TestServerOnlyUserauthMsgsBlocked` - the user auth messages only the server
  sends (`USERAUTH_FAILURE`, `USERAUTH_SUCCESS`) are rejected, while the
  keyboard-interactive `USERAUTH_INFO_RESPONSE` the server receives is allowed.
- `TestServerServiceRequestStateGated` - `SERVICE_REQUEST` is accepted only
  once keyed, `SERVICE_ACCEPT` is never accepted, and the `SERVICE_ACCEPT`
  reject sets `WS_MSGID_NOT_ALLOWED_E`.

`ResetSession` now also clears `acceptState` so the harness baseline is
symmetric for both endpoint kinds.

### Note on mutation coverage

Of the two mutants originally suspected to survive, only one is real and
killable:

- Relaxing `acceptState < ACCEPT_SERVER_USERAUTH_SENT` to `<=` is a real mutant:
  it blocks a legitimate post-auth `CHANNEL_OPEN`. `TestServerChannelAllowedAfterAuth`
  catches it.
- Deleting the `if (MSGIDLIMIT_POST_USERAUTH(msg)) return 0;` block is an
  equivalent mutant for the return value: `MSGIDLIMIT_POST_USERAUTH(x)` is
  `x >= 80`, and every such message also trips the following
  `msg > MSGID_USERAUTH_REQUEST && msg != MSGID_USERAUTH_INFO_RESPONSE` check,
  which returns 0 anyway. Neither path sets `ssh->error`, so no test can
  distinguish it. It is intentionally not targeted.

### Testing

Built with `./configure --enable-all` and ran the regression suite:

```
$ ./tests/regress.test
...
regress: PASS
```

Negative control: relaxing the boundary comparison to `<=` makes
`TestServerChannelAllowedAfterAuth` fail, confirming the new test detects the
mutation; reverted afterward.

### Files changed

- `tests/regress.c` - five new server gate tests, shared server fixture in
  `main()`, and `acceptState` reset in `ResetSession`.