### PR TITLE
Fix WS_KeySignature leak on DoAsn1Key private-key error paths

### DIFF
--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1892,23 +1892,23 @@ static int DoAsn1Key(const byte* in, word32 inSz, byte** out,
             newKey = (byte*)WMALLOC(inSz, heap, DYNTYPE_PRIVKEY);
             if (newKey == NULL) {
                 ret = WS_MEMORY_E;
-                return ret;
             }
         }
+        else if (*outSz < inSz) {
+            WLOG(WS_LOG_DEBUG, "DER private key output size too small");
+            ret = WS_BUFFER_E;
+        }
         else {
-            if (*outSz < inSz) {
-                WLOG(WS_LOG_DEBUG, "DER private key output size too small");
-                ret = WS_BUFFER_E;
-                return ret;
-            }
             newKey = *out;
         }
 
-        *out = newKey;
-        *outSz = inSz;
-        WMEMCPY(newKey, in, inSz);
-        *outType = (const byte*)IdToName(ret);
-        *outTypeSz = (word32)WSTRLEN((const char*)*outType);
+        if (ret > 0) {
+            *out = newKey;
+            *outSz = inSz;
+            WMEMCPY(newKey, in, inSz);
+            *outType = (const byte*)IdToName(ret);
+            *outTypeSz = (word32)WSTRLEN((const char*)*outType);
+        }
     }
 
     wolfSSH_KEY_clean(key);

--- a/tests/api.c
+++ b/tests/api.c
@@ -876,6 +876,30 @@ static void test_wolfSSH_ReadKey(void)
     WFREE(key, NULL, DYNTYPE_FILE);
     WFREE(derKey, NULL, 0);
 
+    /* SSL DER Format, ssh-rsa, private, caller buffer too small.
+     * Exercises the DoAsn1Key error path that must not leak the key. */
+    derKey = NULL;
+    derKeySz = 0;
+    ret = ConvertHexToBin(serverKeyRsaDer, &derKey, &derKeySz,
+            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    AssertIntEQ(ret, 0);
+    keyCheck = (byte*)WMALLOC(derKeySz, NULL, DYNTYPE_FILE);
+    AssertNotNull(keyCheck);
+    key = keyCheck;
+    keySz = derKeySz - 1;
+    keyType = NULL;
+    keyTypeSz = 0;
+    ret = wolfSSH_ReadKey_buffer(derKey, derKeySz, WOLFSSH_FORMAT_ASN1,
+            &key, &keySz, &keyType, &keyTypeSz, NULL);
+    AssertIntEQ(ret, WS_BUFFER_E);
+    AssertTrue(key == keyCheck);
+    /* output params left untouched on the error path */
+    AssertIntEQ(keySz, derKeySz - 1);
+    AssertNull(keyType);
+    AssertIntEQ(keyTypeSz, 0);
+    WFREE(keyCheck, NULL, DYNTYPE_FILE);
+    WFREE(derKey, NULL, 0);
+
     /* OpenSSH Format, ssh-rsa, public, need alloc */
     key = NULL;
     keySz = 0;


### PR DESCRIPTION
## Description

`DoAsn1Key` (`src/ssh.c`) calls `IdentifyAsn1Key()`, which on success heap-allocates a `WS_KeySignature` and initializes an inner wolfCrypt key (`wc_InitRsaKey`/`wc_ecc_init`). That allocation is meant to be released at the end of the function via `wolfSSH_KEY_clean(key)` / `WFREE(key, ...)`.

In the `else if (ret > 0 && isPrivate)` branch, two early `return ret;` statements bypassed that cleanup:

- malloc-failure path (`WS_MEMORY_E`)
- caller-buffer-too-small path (`WS_BUFFER_E`)

Both run after `key` has been allocated, so each leaks the `WS_KeySignature` plus the `mp_int`/ECC internals owned by the embedded wolfCrypt key. The `*outSz < inSz` path is reachable from the public `wolfSSH_ReadKey_buffer` / `wolfSSH_ReadKey_buffer_ex` APIs whenever a caller passes a fixed `*out` buffer smaller than the DER private key.

Addressed by f_6513.

## Fix

Replaced the two early `return ret;` statements with fallthrough control flow so every error path reaches the existing `wolfSSH_KEY_clean(key)` / `WFREE(key, ...)` cleanup:

- malloc failure and buffer-too-small now set `ret` instead of returning.
- The success body is guarded with `if (ret > 0)`, which also preserves the positive key-type id needed by `IdToName(ret)`.
- The existing tail `if (*out == NULL) WFREE(newKey, ...)` remains correct for both error paths.

## Testing

Added a regression test in `tests/api.c` (`test_wolfSSH_ReadKey`) that drives the ASN.1/DER private-key error path with a caller-provided buffer one byte too small. Existing ASN.1 tests only used allocate-mode, leaving this path uncovered.

The test asserts:

- `ret == WS_BUFFER_E`
- caller buffer pointer is preserved (`key == keyCheck`)
- output params are left untouched on the error path (`keySz`, `keyType`, `keyTypeSz`)

The `WS_MEMORY_E` early-return path is fixed the same way but is not directly tested (it requires allocation-failure injection).

## Verification

- `./configure --enable-all` build + `tests/api.test`: pass.