### PR TITLE
keyboard-interactive: send USERAUTH_FAILURE on response-count mismatch

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8223,12 +8223,10 @@ static int DoUserAuthInfoResponse(WOLFSSH* ssh,
     if ((ret == WS_SUCCESS) &&
         (ssh->kbAuth.promptCount != kb->responseCount)) {
         WLOG(WS_LOG_DEBUG, "DUARKB: Invalid number of responses received");
-        ret = WS_USER_AUTH_E;
-    }
-
-    if (ret == WS_SUCCESS && kb->responseCount > WOLFSSH_MAX_PROMPTS) {
-        WLOG(WS_LOG_DEBUG, "DUARKB: Received too many responses (%d), max: %d",
-             kb->responseCount, WOLFSSH_MAX_PROMPTS);
+        /* Answer with USERAUTH_FAILURE instead of tearing down the transport.
+         * Keeping ret non-success skips the allocation, parse, and callback
+         * below; past here responseCount equals the capped promptCount. */
+        authFailure = 1;
         ret = WS_USER_AUTH_E;
     }
 

--- a/tests/regress.c
+++ b/tests/regress.c
@@ -340,6 +340,103 @@ static void FreeChannelOpenHarness(ChannelOpenHarness* harness)
         wolfSSH_CTX_free(harness->ctx);
 }
 
+#ifdef WOLFSSH_KEYBOARD_INTERACTIVE
+/* Build a plaintext SSH_MSG_USERAUTH_INFO_RESPONSE. The wire response count is
+ * "responseCount"; "stringCount" "x" response strings are actually appended.
+ * The count-mismatch guard rejects before parsing the body, so a short body is
+ * sufficient to drive it. */
+static word32 BuildInfoResponsePacket(word32 responseCount, word32 stringCount,
+        byte* out, word32 outSz)
+{
+    byte payload[128];
+    word32 idx = 0;
+    word32 i;
+
+    idx = AppendUint32(payload, sizeof(payload), idx, responseCount);
+    for (i = 0; i < stringCount; i++) {
+        idx = AppendString(payload, sizeof(payload), idx, "x");
+    }
+
+    return WrapPacket(MSGID_USERAUTH_INFO_RESPONSE, payload, idx, out, outSz);
+}
+
+/* Place the server mid keyboard-interactive auth, expecting an INFO_RESPONSE
+ * for "promptCount" prompts. */
+static void InitKbInfoResponseHarness(ChannelOpenHarness* harness,
+        byte* in, word32 inSz, word32 promptCount)
+{
+    InitChannelOpenHarness(harness, in, inSz);
+    harness->ssh->acceptState = ACCEPT_CLIENT_USERAUTH_REQUEST_DONE;
+    harness->ssh->authId = ID_USERAUTH_KEYBOARD;
+    harness->ssh->kbAuth.promptCount = promptCount;
+}
+
+/* Post-condition for a rejected INFO_RESPONSE: the transport survives and the
+ * server's reply is a USERAUTH_FAILURE rather than a teardown. */
+static void AssertKbInfoResponseSentFailure(const ChannelOpenHarness* harness,
+        int ret)
+{
+    AssertIntEQ(ret, WS_SUCCESS);
+    AssertIntEQ(harness->io.inOff, harness->io.inSz);
+    AssertTrue(harness->io.outSz > 0);
+    AssertIntEQ(ParseMsgId(harness->io.out, harness->io.outSz),
+            MSGID_USERAUTH_FAILURE);
+}
+
+/* A response count that disagrees with the server's prompt count must yield a
+ * USERAUTH_FAILURE, not a transport teardown (RFC 4256). */
+static void TestKbInfoResponseCountMismatchSendsFailure(void)
+{
+    ChannelOpenHarness harness;
+    byte in[128];
+    word32 inSz;
+    int ret;
+
+    /* Server expects 1 response; client sends 2. */
+    inSz = BuildInfoResponsePacket(2, 2, in, sizeof(in));
+    InitKbInfoResponseHarness(&harness, in, inSz, 1);
+
+    ret = DoReceive(harness.ssh);
+
+    AssertKbInfoResponseSentFailure(&harness, ret);
+
+    FreeChannelOpenHarness(&harness);
+}
+
+/* A rejected INFO_RESPONSE must leave packet framing intact: the next packet on
+ * the surviving connection still parses and draws its own failure. */
+static void TestKbInfoResponseMismatchKeepsFraming(void)
+{
+    ChannelOpenHarness harness;
+    byte in[256];
+    word32 inSz, nextSz, firstOutSz;
+    int ret;
+
+    /* Two back-to-back responses, both disagreeing with a prompt count of 1. */
+    inSz = BuildInfoResponsePacket(2, 2, in, sizeof(in));
+    nextSz = BuildInfoResponsePacket(3, 3, in + inSz,
+            (word32)sizeof(in) - inSz);
+    InitKbInfoResponseHarness(&harness, in, inSz + nextSz, 1);
+
+    ret = DoReceive(harness.ssh);
+    AssertIntEQ(ret, WS_SUCCESS);
+    AssertTrue(harness.io.outSz > 0);
+    AssertIntEQ(ParseMsgId(harness.io.out, harness.io.outSz),
+            MSGID_USERAUTH_FAILURE);
+    firstOutSz = harness.io.outSz;
+
+    ret = DoReceive(harness.ssh);
+    AssertIntEQ(ret, WS_SUCCESS);
+    AssertIntEQ(harness.io.inOff, harness.io.inSz);
+    AssertTrue(harness.io.outSz > firstOutSz);
+    AssertIntEQ(ParseMsgId(harness.io.out + firstOutSz,
+            harness.io.outSz - firstOutSz), MSGID_USERAUTH_FAILURE);
+
+    FreeChannelOpenHarness(&harness);
+}
+
+#endif /* WOLFSSH_KEYBOARD_INTERACTIVE */
+
 /* Needs server, client, key files, and one covered host-key algorithm. */
 #if !defined(NO_WOLFSSH_SERVER) && !defined(NO_WOLFSSH_CLIENT) && \
     !defined(NO_FILESYSTEM) && \
@@ -5097,6 +5194,10 @@ int main(int argc, char** argv)
     TestSecondSessionChannelRejected();
     TestUsernameChangeDisconnects();
     TestSameUserRetryAllowed();
+#ifdef WOLFSSH_KEYBOARD_INTERACTIVE
+    TestKbInfoResponseCountMismatchSendsFailure();
+    TestKbInfoResponseMismatchKeepsFraming();
+#endif
 #ifdef WOLFSSH_FWD
     TestDirectTcpipRejectSendsOpenFail();
     TestDirectTcpipNoFwdCbSendsOpenFail();


### PR DESCRIPTION
### Problem

`DoUserAuthInfoResponse()` tore down the transport instead of sending an
`SSH_MSG_USERAUTH_FAILURE` when a keyboard-interactive `INFO_RESPONSE` carried a
`responseCount` that did not match the server's pending `promptCount`.

The guard set `ret = WS_USER_AUTH_E`, but the failure-response gate only sends a
message when `authFailure || partialSuccess` is set, so nothing was emitted;
`DoReceive()` converts `WS_USER_AUTH_E` to `WS_FATAL_ERROR` and the connection
dies. RFC 4256 requires the server to answer every `INFO_RESPONSE` with
`SUCCESS`, `FAILURE`, or another `INFO_REQUEST`. Impact is limited to
malformed/malicious clients, but the response is non-conformant.

Addressed by f_6514.

### Fix (`src/internal.c`)

Set `authFailure` in the mismatch guard so the existing gate sends
`SSH_MSG_USERAUTH_FAILURE` and the connection survives; the client may retry.
`ret` stays non-success so the response allocation, parse, and user-auth callback
are skipped on a protocol-violating message.

Two removals came out of review:

- The adjacent `responseCount > WOLFSSH_MAX_PROMPTS` guard was dead code. The
  mismatch check forces `responseCount == promptCount`, and `promptCount` is
  capped at `WOLFSSH_MAX_PROMPTS` by both of its writers
  (`SendUserAuthKeyboardRequest()` server-side, `DoUserAuthInfoRequest()`
  client-side), so the allocation below is bounded transitively.
- An `*idx = len` line on the failure path was an unobservable no-op:
  `DoReceive()` calls `ShrinkBuffer(&ssh->inputBuffer, 1)` on every consumed
  packet, and `forcedFree = 1` zeroes `length`/`idx`, so a short payload index
  never reaches the next packet.

Net change is one functional line plus a comment.

### Tests (`tests/regress.c`)

Both use the in-memory packet harness, feeding crafted packets into `DoReceive()`
and inspecting the bytes the server writes back:

- `TestKbInfoResponseCountMismatchSendsFailure` — `responseCount` 2 vs
  `promptCount` 1; asserts `WS_SUCCESS` and a `MSGID_USERAUTH_FAILURE` reply.
- `TestKbInfoResponseMismatchKeepsFraming` — two back-to-back malformed
  responses; asserts the second packet still parses and draws its own failure,
  covering parser state after a rejected response.

### Verification

- `make check`: 10 passed, 1 skipped (external), 0 failed.
- Clean under `-Werror` across 6 gcc-13 configs; lint clean.
- Negative controls: reverting `authFailure = 1` aborts the first test with
  `-1001`; the framing test fails only when `*idx = len` is absent *and*
  `ShrinkBuffer()` is forced non-free, confirming it detects real desync.