### PR TITLE
wolfterm: bound escBuf saves and clear esc state on OSC resume

### DIFF
--- a/src/wolfterm.c
+++ b/src/wolfterm.c
@@ -475,7 +475,8 @@ static int wolfSSH_DoControlSeq(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf, 
             numArgs = getArgs(buf, bufSz, &i, args);
             if (i >= bufSz) {
                 /* save left overs for next call */
-                if (bufSz - *idx > WOLFSSL_MAX_ESCBUF) {
+                if (bufSz - *idx >= WOLFSSL_MAX_ESCBUF) {
+                    WLOG(WS_LOG_ERROR, "escBuf state exceeds capacity");
                     return WS_FATAL_ERROR;
                 }
                 WMEMCPY(ssh->escBuf, buf + *idx, bufSz - *idx);
@@ -491,6 +492,10 @@ static int wolfSSH_DoControlSeq(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf, 
 
         if (i >= bufSz) {
             /* save left overs for next call */
+            if (bufSz - *idx >= WOLFSSL_MAX_ESCBUF) {
+                WLOG(WS_LOG_ERROR, "escBuf state exceeds capacity");
+                return WS_FATAL_ERROR;
+            }
             WMEMCPY(ssh->escBuf, buf + *idx, bufSz - *idx);
             ssh->escBufSz = bufSz - *idx;
             return WS_WANT_READ;
@@ -687,6 +692,7 @@ int wolfSSH_ConvertConsole(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf,
             if (ret == WS_WANT_READ) {
                 return ret;
             }
+            ssh->escState = WC_ESC_NONE;
             ssh->escBufSz = 0;
             break;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -3370,6 +3370,18 @@ static byte osc_trunc_str[] = { /* "ESC ] 0 ; title" with no BEL terminator */
 static byte osc_full[] = { /* well formed "ESC ] 0 ; hi BEL" */
     0x1B, 0x5D, 0x30, 0x3B, 0x68, 0x69, 0x07
 };
+static byte csi_open[] = { /* "ESC [" with no args yet, escBufSz left at 0 */
+    0x1B, 0x5B
+};
+static byte csi_args[] = { /* pure args "12" with no command char */
+    0x31, 0x32
+};
+static byte csi_cmd[] = { /* command char 'm' completes the sequence */
+    0x6D
+};
+static byte csi_inline[] = { /* "ESC [ 1 2" args run to end of one buffer */
+    0x1B, 0x5B, 0x31, 0x32
+};
 #endif /* USE_WINDOWS_API */
 
 
@@ -3416,6 +3428,29 @@ static void test_wolfSSH_ConvertConsole(void)
     /* a well formed OSC sequence still parses */
     AssertIntEQ(wolfSSH_ConvertConsole(ssh, stdoutHandle, osc_full,
                 sizeof(osc_full)), WS_SUCCESS);
+
+    /* a CSI sequence split so the first packet ends right after "ESC [" and
+     * the second carries only argument bytes must not read past the buffer
+     * while waiting for the command char */
+    AssertIntEQ(wolfSSH_ConvertConsole(ssh, stdoutHandle, csi_open,
+                sizeof(csi_open)), WS_WANT_READ);
+    AssertIntEQ(wolfSSH_ConvertConsole(ssh, stdoutHandle, csi_args,
+                sizeof(csi_args)), WS_WANT_READ);
+    /* the trailing command char completes the reassembled sequence */
+    AssertIntEQ(wolfSSH_ConvertConsole(ssh, stdoutHandle, csi_cmd,
+                sizeof(csi_cmd)), WS_SUCCESS);
+    /* after the split sequence completes the esc state must be cleared, so a
+     * following plain argument byte is printed rather than swallowed back into
+     * CSI parsing (which would return WS_WANT_READ) */
+    AssertIntEQ(wolfSSH_ConvertConsole(ssh, stdoutHandle, csi_args, 1),
+                WS_SUCCESS);
+
+    /* a single buffer whose CSI arguments run to the end with no command char
+     * must save the partial args and wait, then complete on the next byte */
+    AssertIntEQ(wolfSSH_ConvertConsole(ssh, stdoutHandle, csi_inline,
+                sizeof(csi_inline)), WS_WANT_READ);
+    AssertIntEQ(wolfSSH_ConvertConsole(ssh, stdoutHandle, csi_cmd,
+                sizeof(csi_cmd)), WS_SUCCESS);
 
     wolfSSH_free(ssh);
     wolfSSH_CTX_free(ctx);


### PR DESCRIPTION
## Overview

Hardens the `escBuf` partial-sequence reassembly in `wolfSSH_DoControlSeq` and
fixes an escape-state leak in the `wolfSSH_ConvertConsole` OSC resume path
(`src/wolfterm.c`). Windows-only console handling (`USE_WINDOWS_API`).

## Changes

1. **Tighten both `escBuf` save branches.** When a CSI sequence's arguments run
   to the end of a buffer with no command char, the partial bytes are stashed in
   `ssh->escBuf` for the next call. `escBuf` is `WOLFSSL_MAX_ESCBUF` bytes, so a
   save of exactly that length fills it with no room for continued state. Both
   save branches now reject `bufSz - *idx >= WOLFSSL_MAX_ESCBUF` before the
   `WMEMCPY` and log via `WLOG(WS_LOG_ERROR, ...)`, matching the boundary
   semantics of the resume check and keeping the two branches consistent.

2. **Guard the initial-parse CSI save branch.** The initial-parse path
   (`escState` was `WC_ESC_NONE`, buffer opens with `ESC [`) copied into `escBuf`
   with no capacity bound. In the default build `getArgs` caps the advance at
   `WOLFSSH_MAX_CONSOLE_ARGS` (16) < `WOLFSSL_MAX_ESCBUF` (19), so the copy was
   already safe; the guard is defense-in-depth for a custom
   `WOLFSSH_MAX_CONSOLE_ARGS > WOLFSSL_MAX_ESCBUF` build.

3. **Clear escape state on OSC resume completion.** When a split OSC sequence
   completes via the resume handler in `wolfSSH_ConvertConsole`, reset
   `escState = WC_ESC_NONE` (not just `escBufSz`). Without this, `escState`
   stayed `WS_ESC_OSC` and the next call re-entered OSC parsing on plain bytes
   instead of printing them.

## Testing

Extended `test_wolfSSH_ConvertConsole` in `tests/api.c`:

- **Split CSI across calls** (`ESC [` | `12` | `m`) — the continuation carries
  only argument bytes; verifies reassembly waits (`WS_WANT_READ`) and then
  completes (`WS_SUCCESS`) without reading past the buffer.
- **Trailing plain byte after completion** — a plain argument byte after the
  sequence finishes must be printed (`WS_SUCCESS`), not swallowed back into a
  new parse.
- **Single-buffer args-to-end** (`ESC [ 1 2`) — args run to the end of one
  buffer; verifies the partial save waits and completes on the next byte.

Verified on native Windows (Visual Studio Build Tools 2022, static Debug x64):

```
api-test EXITCODE=0
```

Local GCC preflight sweep (`--enable-all`, Zephyr defines, strncpy lint) clean.
