### PR TITLE
Fix incorrect argument being passed to wc_InitDecodedCert.

### DIFF
--- a/src/certman.c
+++ b/src/certman.c
@@ -369,7 +369,7 @@ int wolfSSH_CERTMAN_VerifyCerts_buffer(WOLFSSH_CERTMAN* cm,
     if (ret == WS_SUCCESS) {
         DecodedCert decoded;
 
-        wc_InitDecodedCert(&decoded, certLoc[0], certLen[0], cm->cm);
+        wc_InitDecodedCert(&decoded, certLoc[0], certLen[0], cm->heap);
         ret = wc_ParseCert(&decoded, WOLFSSL_FILETYPE_ASN1, 0, cm->cm);
 
         if (ret == 0) {


### PR DESCRIPTION
Should be the heap rather than the CM.

Thanks to Asif Nadaf for the report.