### PR TITLE
Fix ssh->fs reference in Nucleus/Harmony SFTP_GetAttributes helpers

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -4960,13 +4960,14 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
     int ret;
 
     WOLFSSH_UNUSED(heap);
+    /* WSTAT/WLSTAT discard the fs handle on Nucleus, so fs stays unused. */
     WOLFSSH_UNUSED(fs);
 
     if (noFollow) {
-        ret = WLSTAT(ssh->fs, fileName, &stats);
+        ret = WLSTAT(fs, fileName, &stats);
     }
     else {
-        ret = WSTAT(ssh->fs, fileName, &stats);
+        ret = WSTAT(fs, fileName, &stats);
     }
 
     WMEMSET(atr, 0, sizeof(WS_SFTP_FILEATRB));
@@ -5530,11 +5531,15 @@ static int SFTP_GetAttributesStat(WS_SFTP_FILEATRB* atr, WSTAT_T* stats)
 }
 
 
-static int SFTP_GetAttributesHelper(WS_SFTP_FILEATRB* atr, const char* fName)
+static int SFTP_GetAttributesHelper(void* fs, WS_SFTP_FILEATRB* atr,
+        const char* fName)
 {
     WSTAT_T stats;
     SYS_FS_RESULT res;
     char buffer[255];
+
+    /* WSTAT discards the fs handle on Harmony, so fs stays unused. */
+    WOLFSSH_UNUSED(fs);
 
     WMEMSET(atr, 0, sizeof(WS_SFTP_FILEATRB));
     WMEMSET(buffer, 0, sizeof(buffer));
@@ -5554,7 +5559,7 @@ static int SFTP_GetAttributesHelper(WS_SFTP_FILEATRB* atr, const char* fName)
         }
     }
 
-    if (WSTAT(ssh->fs, fName, &stats) != 0) {
+    if (WSTAT(fs, fName, &stats) != 0) {
         WLOG(WS_LOG_SFTP, "Issue with WSTAT call");
         return WS_BAD_FILE_E;
     }
@@ -5571,9 +5576,8 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
         WS_SFTP_FILEATRB* atr, byte noFollow, void* heap)
 {
     WOLFSSH_UNUSED(heap);
-    WOLFSSH_UNUSED(fs);
 
-    return SFTP_GetAttributesHelper(atr, fileName);
+    return SFTP_GetAttributesHelper(fs, atr, fileName);
 }
 
 
@@ -5587,9 +5591,8 @@ static int SFTP_GetAttributes(void* fs, const char* fileName,
 static int SFTP_GetAttributes_Handle(WOLFSSH* ssh, WFD fd,
         char* name, WS_SFTP_FILEATRB* atr)
 {
-    WOLFSSH_UNUSED(ssh);
     WOLFSSH_UNUSED(fd);
-    return SFTP_GetAttributesHelper(atr, name);
+    return SFTP_GetAttributesHelper(ssh->fs, atr, name);
 }
 #endif /* !NO_WOLFSSH_SERVER */
 


### PR DESCRIPTION
## Overview

Fixes two copy/paste-style defects in `src/wolfsftp.c` where SFTP attribute
helpers referenced `ssh->fs` in a `WSTAT`/`WLSTAT` call, but the enclosing
function has no `ssh` variable in scope — only the filesystem handle the caller
already holds.

- **6691** — Nucleus (`WOLFSSL_NUCLEUS`) `SFTP_GetAttributes`
- **6692** — Harmony (`MICROCHIP_MPLAB_HARMONY`) `SFTP_GetAttributesHelper`

## Changes

**Nucleus `SFTP_GetAttributes` (6691)** — `fs` is already a parameter; use it:

```c
    if (noFollow) {
        ret = WLSTAT(fs, fileName, &stats);
    }
    else {
        ret = WSTAT(fs, fileName, &stats);
    }
```

**Harmony `SFTP_GetAttributesHelper` (6692)** — the helper had no `fs` in scope,
so thread it through from both callers:

- Added `void* fs` as the first parameter; `WSTAT(fs, ...)`.
- `SFTP_GetAttributes(void* fs, ...)` forwards `fs`.
- `SFTP_GetAttributes_Handle(WOLFSSH* ssh, ...)` forwards `ssh->fs` (this
  function has `ssh`, not `fs`, in scope — `ssh->fs` is the correct in-scope
  access).

`WOLFSSH_UNUSED(fs)` is kept where the macro drops the handle, each with a short
comment explaining why `fs` still counts as unused despite appearing in the
`WSTAT`/`WLSTAT` call.