### PR TITLE
fix: guard sshd chroot steps after a failure

### DIFF
--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -559,12 +559,16 @@ static int SetupChroot(WOLFSSHD_CONFIG* usrConf)
                 "[SSHD] chdir to chroot path failed, %s", chrootPath);
             ret = WS_FATAL_ERROR;
         }
-        if (chroot(chrootPath) != 0) {
+        /* Only chroot() once the chdir() into the target succeeded, and only
+         * chdir("/") once inside the new root. Running a later step after an
+         * earlier failure could leave the process chrooted with a working
+         * directory outside the new root. */
+        if (ret == 1 && chroot(chrootPath) != 0) {
             wolfSSH_Log(WS_LOG_ERROR,
                 "[SSHD] chroot failed to path %s", chrootPath);
             ret = WS_FATAL_ERROR;
         }
-        if (chdir("/") != 0) {
+        if (ret == 1 && chdir("/") != 0) {
             wolfSSH_Log(WS_LOG_ERROR,
                 "[SSHD] chdir after chroot failed");
             ret = WS_FATAL_ERROR;


### PR DESCRIPTION
## Problem

`SetupChroot()` in `apps/wolfsshd/wolfsshd.c` performs the chroot sequence in three independent `if` blocks with a single `return` at the end:

```c
if (chdir(chrootPath) != 0) { ...; ret = WS_FATAL_ERROR; }
if (chroot(chrootPath) != 0) { ...; ret = WS_FATAL_ERROR; }
if (chdir("/")       != 0) { ...; ret = WS_FATAL_ERROR; }
```

Every step runs unconditionally, so `chroot()` executes even when the preceding `chdir(chrootPath)` failed. The secure idiom requires being *inside* the target directory before/at chroot; running `chroot()` after a failed `chdir` can leave the process chrooted with a working directory outside the new root. The caller does abort on the negative return, but `chroot()` has already run by then, so this is a defense-in-depth gap.

## Fix

Short-circuit the later steps on `ret > 0` (the no-failure state) so `chroot()` runs only after the `chdir()` into the target succeeds, and `chdir("/")` only after `chroot()` succeeds. `WS_FATAL_ERROR` is `-1001`, so `ret > 0` holds only while no step has failed.

Verified: wolfsshd builds cleanly (`--enable-sshd`) against wolfSSL `--enable-ssh` with the change. No behavioral change on the success path (all three steps still run and `ret` stays `1`); on failure the chain now stops at the first failed step.

Note: no automated test is added — `SetupChroot` is a static function whose failure path requires `root` plus a specifically failing `chdir`, which isn't exercisable in the wolfSSH test harness.

Reported by static analysis (Fenrir finding 58).