### PR TITLE
fix: validate DH GEX request bounds

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7254,6 +7254,16 @@ static int DoKexDhGexRequest(WOLFSSH* ssh,
     }
 
     if (ret == WS_SUCCESS) {
+        if (ssh->handshake->dhGexMinSz < WOLFSSH_DEFAULT_GEXDH_MIN ||
+            ssh->handshake->dhGexMaxSz > WOLFSSH_DEFAULT_GEXDH_MAX ||
+            ssh->handshake->dhGexMinSz > ssh->handshake->dhGexPreferredSz ||
+            ssh->handshake->dhGexPreferredSz > ssh->handshake->dhGexMaxSz) {
+            WLOG(WS_LOG_DEBUG, "Invalid DH GEX request parameters");
+            ret = WS_BAD_ARGUMENT;
+        }
+    }
+
+    if (ret == WS_SUCCESS) {
         WLOG(WS_LOG_INFO, "  min = %u, preferred = %u, max = %u",
                 ssh->handshake->dhGexMinSz,
                 ssh->handshake->dhGexPreferredSz,


### PR DESCRIPTION
## Summary

`DoKexDhGexRequest()` in `src/internal.c` reads three client-controlled values from the SSH_MSG_KEX_DH_GEX_REQUEST message — `dhGexMinSz`, `dhGexPreferredSz`, and `dhGexMaxSz` (via three `GetUint32` calls) — and then proceeds to `SendKexDhGexGroup()` without validating them. There is no check that the values satisfy `min <= preferred <= max` and no bounds check against the library's supported DH group sizes.

Per RFC 4419, these requested sizes are folded into the key-exchange hash `H` (`dhGexMinSz` is used when computing the exchange hash). Accepting nonsensical or out-of-range values invites protocol confusion and divergence of `H` between peers.

## Fix

Add a validation block after the three sizes are parsed and before proceeding. It rejects the request (aborts the handshake with `WS_BAD_ARGUMENT`) when:
- `dhGexMinSz < WOLFSSH_DEFAULT_GEXDH_MIN` (1024)
- `dhGexMaxSz > WOLFSSH_DEFAULT_GEXDH_MAX` (8192)
- `dhGexMinSz > dhGexPreferredSz`
- `dhGexPreferredSz > dhGexMaxSz`

The bound macros are the project's own existing defaults from `wolfssh/internal.h`. The request is **rejected** rather than clamped on purpose: because the requested values feed the RFC 4419 exchange hash `H`, silently clamping would make our `H` diverge from the client's and break the handshake in a harder-to-diagnose way.

## Verification

Built with `--enable-all` (`make`, exit 0) against a local wolfSSL install; the modified translation unit compiles cleanly. The affected path is live under `WOLFSSH_NO_DH_GEX_SHA256` not being defined.

Reported by static analysis (Fenrir finding 60).