### PR TITLE
fix: correct DoChannelData dataSz bounds check

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11090,7 +11090,7 @@ static int DoChannelData(WOLFSSH* ssh,
 
     /* Validate dataSz */
     if (ret == WS_SUCCESS) {
-        if (len < begin) {
+        if (dataSz > len - begin) {
             ret = WS_RECV_OVERFLOW_E;
         }
     }


### PR DESCRIPTION
## Bug

In `DoChannelData()` (src/internal.c), the "Validate dataSz" block checks `if (len < begin)` after `GetSize()` has already returned `WS_SUCCESS`. That condition is provably always false: `GetSize`/`GetUint32` only advance `begin` when the requested bytes fit, guaranteeing `begin <= len` on success. So the check is dead code and never validates the payload length against the remaining buffer.

## Fix

Replace the dead check with the meaningful one that the surrounding code already relies on:

```c
    /* Validate dataSz */
    if (ret == WS_SUCCESS) {
        if (dataSz > len - begin) {
            ret = WS_RECV_OVERFLOW_E;
        }
    }
```

`len - begin` cannot underflow because `GetSize` guarantees `begin <= len` on success. This makes the actual payload-length safety invariant explicit for auditors, matching the existing combined pattern used at src/internal.c:7554 (`if ((len < begin) || (strSz > len - begin))`). No behavioral change on valid input — pure defense-in-depth / readability.

This is a LOW severity finding: the following `*idx = begin + dataSz` is already safe on valid input (no word32 overflow), so this is not an exploitable overflow.

## Build verification

Recompiled the full wolfSSH library (including src/internal.c) against a prebuilt wolfSSL (`--enable-all --enable-ssh`) on Ubuntu 24.04, `make` exit 0.

Reported by static analysis (Fenrir finding 247).