### PR TITLE
fix: send SSH_MSG_DISCONNECT on KEX failure

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5077,6 +5077,14 @@ static void SetPeerAlgoIds(HandshakeInfo* hs,
 }
 
 
+/* The KEXINIT negotiation failures DoKexInit() answers with a disconnect. */
+static int IsKexMatchError(int ret)
+{
+    return ret == WS_MATCH_KEX_ALGO_E || ret == WS_MATCH_KEY_ALGO_E ||
+        ret == WS_MATCH_ENC_ALGO_E || ret == WS_MATCH_MAC_ALGO_E;
+}
+
+
 static int DoKexInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
 {
     int ret = WS_SUCCESS;
@@ -5472,6 +5480,10 @@ static int DoKexInit(WOLFSSH* ssh, byte* buf, word32 len, word32* idx)
             if (ssh->error != 0)
                 ret = ssh->error;
         }
+    }
+    /* RFC 4253 7.1: no common algorithm means both sides disconnect. */
+    if (IsKexMatchError(ret)) {
+        (void)SendDisconnect(ssh, WOLFSSH_DISCONNECT_KEY_EXCHANGE_FAILED);
     }
     WLOG(WS_LOG_DEBUG, "Leaving DoKexInit(), ret = %d", ret);
     return ret;
@@ -11674,7 +11686,10 @@ static int DoPacket(WOLFSSH* ssh, byte* bufferConsumed)
         case MSGID_KEXINIT:
             WLOG(WS_LOG_DEBUG, "Decoding MSGID_KEXINIT");
             ret = DoKexInit(ssh, buf + idx, payloadSz, &payloadIdx);
-            if (ssh->isKeying &&
+            /* Don't answer a KEXINIT that failed to negotiate; DoKexInit()
+             * has already disconnected. A healthy rekey lands here as
+             * WS_REKEYING, so this cannot test for WS_SUCCESS. */
+            if (!IsKexMatchError(ret) && ssh->isKeying &&
                     ssh->connectState == CONNECT_SERVER_CHANNEL_REQUEST_DONE) {
                 if (ssh->handshake->kexId == ID_DH_GEX_SHA256) {
 #if !defined(WOLFSSH_NO_DH) && !defined(WOLFSSH_NO_DH_GEX_SHA256)


### PR DESCRIPTION
## Bug
`DoKexInit()` in `src/internal.c` sets `ret` to one of the negotiation-failure codes `WS_MATCH_KEX_ALGO_E` / `WS_MATCH_KEY_ALGO_E` / `WS_MATCH_ENC_ALGO_E` / `WS_MATCH_MAC_ALGO_E` when no common KEX / host-key / cipher / MAC algorithm can be negotiated, then returns. That code propagates unchanged through `DoPacket()` and `DoReceive()`, which set `ssh->error` and return `WS_FATAL_ERROR`. No `SSH_MSG_DISCONNECT` is ever sent on these paths, so the peer is dropped without notification.

RFC 4253 s7.1 covers exactly this case: when no algorithm satisfying all the conditions can be found, "the connection fails, and both sides MUST disconnect." wolfSSH already terminated the connection, so the MUST was met -- what was missing is the notification telling the peer why. The library already sends one best-effort with `(void)SendDisconnect(...)` for service-request/accept errors (internal.c:7703, 7735); the KEX negotiation paths were inconsistent with that pattern.

## Fix
Two changes, sharing one predicate:

1. At the single `DoKexInit()` exit point, send a best-effort `SSH_MSG_DISCONNECT` with reason `WOLFSSH_DISCONNECT_KEY_EXCHANGE_FAILED` (3) when `ret` is any of the four match-failure codes. Uses the same `(void)SendDisconnect` best-effort form as the existing call sites. `ret` is not overwritten for match errors -- the `SendKexInit`/`ssh->error` propagation block is gated on `ret == WS_SUCCESS`.

2. In `DoPacket()`, don't answer a KEXINIT that failed to negotiate. The `MSGID_KEXINIT` case ran its rekey response (`SendKexDhInit()` / `SendKexDhGexRequest()`) based only on `ssh->isKeying` and `ssh->connectState`, never consulting `ret`, so a post-auth rekey with a mismatch could emit a KEXDH packet immediately after the disconnect just sent.

Both sites test the same predicate through a shared helper:

```c
static int IsKexMatchError(int ret)
{
    return ret == WS_MATCH_KEX_ALGO_E || ret == WS_MATCH_KEY_ALGO_E ||
        ret == WS_MATCH_ENC_ALGO_E || ret == WS_MATCH_MAC_ALGO_E;
}
```

The second gate cannot be written as `ret == WS_SUCCESS`. A healthy client-side rekey returns `WS_REKEYING` (-1035) out of `DoKexInit()` -- a status, not an error, carried by the trailing `if (ssh->error != 0) ret = ssh->error;` that propagates a want-write from `SendKexInit()`. Gating on `WS_SUCCESS` suppresses every rekey response, not just failing ones, and fails the SCP rekey test at `tests/api.c:3030`.

## Verification
Built `--enable-all` against a full wolfSSL install. `make check`: 10 pass, 1 skip, 0 fail.

Behavior confirmed on the wire with a raw probe that completes the version exchange, sends a KEXINIT with one bogus name-list, and reads to EOF. Against `examples/echoserver`, for each of the four negotiation fields (kex, host key, cipher, MAC): master replies with its own KEXINIT and then closes silently; with this change it replies KEXINIT followed by `SSH_MSG_DISCONNECT` with reason 3. An OpenSSH client will not surface this -- it computes the algorithm intersection itself and aborts before reading the server's reply, which is why a raw probe was needed.

Regression coverage for the new disconnect side effect is deferred; `tests/regress.c` asserts the `WS_MATCH_*` return codes but does not yet capture the outbound packet.

Reported by static analysis (Fenrir finding 608). Severity Low -- the connection already terminated; this adds the reason code.
