### PR TITLE
fix: null_check hardening across wolfSSH

### DIFF
--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -857,6 +857,10 @@ static int config_parse_command_line(struct config* config,
         }
 
         command = (char*)WMALLOC(commandSz, NULL, 0);
+        if (command == NULL) {
+            fprintf(stderr, "Couldn't allocate command buffer.\n");
+            exit(EXIT_FAILURE);
+        }
         config->command = command;
         cursor = command;
 

--- a/src/agent.c
+++ b/src/agent.c
@@ -1680,7 +1680,7 @@ int wolfSSH_AGENT_worker(WOLFSSH* ssh)
     WLOG_ENTER();
 
     if (ssh == NULL)
-        ret = WS_SSH_NULL_E;
+        return WS_SSH_NULL_E;
 
     while (1) {
         if (ret == WS_SUCCESS) {


### PR DESCRIPTION
Two NULL-handling hardening fixes reported by Fenrir static analysis. Build-verified with `--enable-all` against wolfSSL built `--enable-all --enable-ssh` (make -j8, exit 0).

- **#3210** `apps/wolfssh/wolfssh.c` (`config_parse_command_line`) — the command-buffer `WMALLOC` return was unchecked, so a NULL `command` became a NULL `cursor` passed to `stpcpy` (crash). Now bails out with `fprintf(stderr, ...)` + `exit(EXIT_FAILURE)`, matching the existing error idiom in this same function.
- **#6694** `src/agent.c` (`wolfSSH_AGENT_worker`) — on a NULL session the code only set `ret = WS_SSH_NULL_E` then entered `while (1)`, which never breaks unless `ret == WS_SUCCESS`, causing an infinite busy loop. Now returns `WS_SSH_NULL_E` immediately.

Reported by Fenrir static analysis.