### PR TITLE
fix: correctness hardening across wolfSSH

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -319,7 +319,7 @@ static void *global_req(void *ctx)
             return NULL;
         }
 
-        wolfSSH_stream_read(threadCtx->ssh, buf, 0);
+        ret = wolfSSH_stream_read(threadCtx->ssh, buf, 0);
         if (ret != WS_SUCCESS)
         {
             printf("wolfSSH_stream_read Failed.\n");

--- a/src/log.c
+++ b/src/log.c
@@ -49,7 +49,7 @@
 #endif
 
 
-#ifndef WOLFSSL_NO_DEFAULT_LOGGING_CB
+#ifndef WOLFSSH_NO_DEFAULT_LOGGING_CB
     static void DefaultLoggingCb(enum wolfSSH_LogLevel level,
             const char *const msgStr);
     static wolfSSH_LoggingCb logFunction = DefaultLoggingCb;

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -9652,7 +9652,7 @@ int wolfSSH_SFTP_Get(WOLFSSH* ssh, char* from,
             #elif defined(USE_WINDOWS_API)
                     {
                         DWORD desiredAccess = GENERIC_WRITE;
-                        if (state->gOfst > 0)
+                        if (state->gOfst[0] > 0 || state->gOfst[1] > 0)
                             desiredAccess |= FILE_APPEND_DATA;
                         state->fileHandle = WS_CreateFileA(to, desiredAccess,
                             (FILE_SHARE_DELETE | FILE_SHARE_READ |


### PR DESCRIPTION
Three low-risk correctness fixes flagged by Fenrir static analysis. Build-verified together with `./configure --with-wolfssl=... --enable-all && make -j8` (exit 0).

- **#4582** `src/log.c:52` — the default-logging-cb guard used `WOLFSSL_NO_DEFAULT_LOGGING_CB`, but the body gate (line 104) and the `#else`/`#endif` comments use `WOLFSSH_NO_DEFAULT_LOGGING_CB`. Defining the documented `WOLFSSH_` macro left the guard active, referencing a compiled-out `DefaultLoggingCb`. Aligned the guard to `WOLFSSH_NO_DEFAULT_LOGGING_CB` so it sets `logFunction = NULL`.
- **#4583** `examples/echoserver/echoserver.c:322` (`global_req`) — the return of `wolfSSH_stream_read` was discarded, so the following `if (ret != WS_SUCCESS)` tested the stale `ret` from the earlier `wolfSSH_global_request`. Captured the read's result into `ret`.
- **#6268** `src/wolfsftp.c:9655` (Windows `STATE_GET_OPEN_LOCAL` branch) — `gOfst` is a 2-word array, so `state->gOfst > 0` is always true. Changed to `state->gOfst[0] > 0 || state->gOfst[1] > 0`, matching the MPLAB and POSIX branches.

Reported by Fenrir static analysis.