### PR TITLE
fix: buffer write hardening across wolfSSH

### DIFF
--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -563,7 +563,7 @@ static THREAD_RET readPeer(void* in)
                 buf[bufSz - 1] = '\0';
 
             #ifdef USE_WINDOWS_API
-                if (WriteFile(stdoutHandle, buf, bufSz, &writtn, NULL) == FALSE) {
+                if (WriteFile(stdoutHandle, buf, (DWORD)ret, &writtn, NULL) == FALSE) {
                     err_sys("Failed to write to stdout handle");
                 }
             #else

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -546,7 +546,7 @@ static THREAD_RET readPeer(void* in)
                 buf[bufSz - 1] = '\0';
 
             #ifdef USE_WINDOWS_API
-                if (WriteFile(stdoutHandle, buf, bufSz, &writtn, NULL) == FALSE) {
+                if (WriteFile(stdoutHandle, buf, (DWORD)ret, &writtn, NULL) == FALSE) {
                     err_sys("Failed to write to stdout handle");
                 }
             #else

--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -519,6 +519,8 @@ int ClientUserAuth(byte authType,
     else if (authType == WOLFSSH_USERAUTH_PASSWORD) {
         if (defaultPassword != NULL) {
             passwordSz = (word32)strlen(defaultPassword);
+            if (passwordSz > (word32)sizeof(userPassword))
+                passwordSz = (word32)sizeof(userPassword);
             memcpy(userPassword, defaultPassword, passwordSz);
         }
 #ifdef WOLFSSH_TERM

--- a/examples/portfwd/portfwd.c
+++ b/examples/portfwd/portfwd.c
@@ -172,6 +172,8 @@ static int wsUserAuth(byte authType,
     (void)authType;
     if (defaultPassword != NULL) {
         passwordSz = (word32)strlen(defaultPassword);
+        if (passwordSz > (word32)sizeof(userPassword))
+            passwordSz = (word32)sizeof(userPassword);
         memcpy(userPassword, defaultPassword, passwordSz);
     }
     else {

--- a/src/wolfterm.c
+++ b/src/wolfterm.c
@@ -737,7 +737,7 @@ int wolfSSH_ConvertConsole(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf,
 
                 case 'D':
                     /* linefeed */
-                    if (WS_WRITECONSOLE(handle, "\n", sizeof("\n"), &wrt, NULL)
+                    if (WS_WRITECONSOLE(handle, "\n", sizeof("\n") - 1, &wrt, NULL)
                         == 0) {
                         WLOG(WS_LOG_DEBUG, "Error writing newline to handle");
                         return WS_FATAL_ERROR;
@@ -745,7 +745,7 @@ int wolfSSH_ConvertConsole(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf,
                     break;
 
                 case 'E': /* newline */
-                    if (WS_WRITECONSOLE(handle, "\n", sizeof("\n"), &wrt, NULL)
+                    if (WS_WRITECONSOLE(handle, "\n", sizeof("\n") - 1, &wrt, NULL)
                             == 0) {
                         WLOG(WS_LOG_DEBUG, "Error writing newline to handle");
                         return WS_FATAL_ERROR;


### PR DESCRIPTION
Buffer-write hardening across wolfSSH. Three independent fixes reported by Fenrir static analysis, batched into one PR. Build-verified on Ubuntu 24.04 against wolfSSL `--enable-all --enable-ssh` (`./configure --enable-all && make -j8`, exit 0).

- **#3446** — `examples/portfwd/portfwd.c` and `examples/client/common.c`: clamp `passwordSz` to `sizeof(userPassword)` (256) before the `memcpy`. Without the clamp, a `defaultPassword` longer than 256 bytes overflows the fixed `userPassword` buffer. `userPassword` is a raw password buffer whose length travels in `password.passwordSz`, so clamping without a NUL terminator is correct.
- **#4105** — `examples/client/client.c` and `apps/wolfssh/wolfssh.c`: in `readPeer()`'s Windows branch, `WriteFile` now writes `(DWORD)ret` (bytes actually read) instead of the full `bufSz`, matching the POSIX `write(STDOUT_FILENO, buf, ret)` sibling. Prevents emitting stale buffer tail on short reads.
- **#4106** — `src/wolfterm.c` cases `'D'` and `'E'`: `WS_WRITECONSOLE` now writes `sizeof("\n") - 1` (1 byte) instead of `sizeof("\n")` (2 bytes), dropping the stray trailing NUL from the console output.

The #4105 and #4106 sites are under `USE_WINDOWS_API` (not compiled on Linux); they are source-verified against the working POSIX path. The #3446 sites are compiled and covered by the successful Linux build.

Reported by Fenrir static analysis.
