### PR TITLE
fix: security hardening across wolfSSH

### DIFF
--- a/apps/wolfsshd/configuration.c
+++ b/apps/wolfsshd/configuration.c
@@ -787,11 +787,20 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value, int depth)
                         /* Skip sub-directories */
                     #if defined(__QNX__) || defined(__QNXNTO__)
                         struct stat s;
+                        int qnxRet = WSNPRINTF(filepath, PATH_MAX, "%s/%s",
+                                path, dir->d_name);
 
-                        lstat(dir->d_name, &s);
-                        if (!S_ISDIR(s.st_mode))
+                        /* Full path is needed: lstat resolves relative to CWD,
+                         * not the include dir. On snprintf/lstat failure treat
+                         * as a non-directory so both passes agree. */
+                        if (qnxRet < 0 || qnxRet >= PATH_MAX ||
+                                lstat(filepath, &s) != 0 ||
+                                !S_ISDIR(s.st_mode))
                     #else
-                        if (dir->d_type != DT_DIR)
+                        /* Skip sub-directories and symlinks (CWE-61: a
+                         * symlink in the Include dir would otherwise be
+                         * followed by fopen and parsed as config). */
+                        if (dir->d_type != DT_DIR && dir->d_type != DT_LNK)
                     #endif
                         {
                             fileCount++;
@@ -819,11 +828,18 @@ static int HandleInclude(WOLFSSHD_CONFIG *conf, const char *value, int depth)
                             /* Skip sub-directories */
                         #if defined(__QNX__) || defined(__QNXNTO__)
                             struct stat s;
+                            int qnxRet = WSNPRINTF(filepath, PATH_MAX, "%s/%s",
+                                    path, dir->d_name);
 
-                            lstat(dir->d_name, &s);
-                            if (!S_ISDIR(s.st_mode))
+                            /* Full path is needed: lstat resolves relative to
+                             * CWD, not the include dir. On snprintf/lstat
+                             * failure treat as a non-directory so both passes
+                             * agree. */
+                            if (qnxRet < 0 || qnxRet >= PATH_MAX ||
+                                    lstat(filepath, &s) != 0 ||
+                                    !S_ISDIR(s.st_mode))
                         #else
-                            if (dir->d_type != DT_DIR)
+                            if (dir->d_type != DT_DIR && dir->d_type != DT_LNK)
                         #endif
                             {
                                 /* Duplicate the name; readdir() may reuse its

--- a/src/agent.c
+++ b/src/agent.c
@@ -383,7 +383,8 @@ static int PostLock(WOLFSSH_AGENT_CTX* agent,
 
     WMEMCPY(pp, passphrase, ppSz);
     pp[ppSz] = 0;
-    WLOG(WS_LOG_AGENT, "Locking with passphrase '%s'", pp);
+    WLOG(WS_LOG_AGENT, "Locking requested");
+    ForceZero(pp, sizeof(pp));
 
     return WS_SUCCESS;
 }
@@ -406,7 +407,8 @@ static int PostUnlock(WOLFSSH_AGENT_CTX* agent,
 
     WMEMCPY(pp, passphrase, ppSz);
     pp[ppSz] = 0;
-    WLOG(WS_LOG_AGENT, "Unlocking with passphrase '%s'", pp);
+    WLOG(WS_LOG_AGENT, "Unlocking requested");
+    ForceZero(pp, sizeof(pp));
 
     return WS_SUCCESS;
 }

--- a/src/internal.c
+++ b/src/internal.c
@@ -19705,8 +19705,10 @@ int wolfSSH_CleanPath(WOLFSSH* ssh, char* in, int inSz)
                 if (path[i] == WS_DELIM) {
                     int z;
 
-                    /* if next two chars are .. then delete */
-                    if (path[i+1] == '.' && path[i+2] == '.') {
+                    /* if next two chars are .. (and the component ends there)
+                     * then delete; guard against '..X' components */
+                    if (path[i+1] == '.' && path[i+2] == '.' &&
+                        (path[i+3] == WS_DELIM || path[i+3] == '\0')) {
                         enIdx = i + 3;
 
                         /* start at one char before / and retrace path */

--- a/src/wolfterm.c
+++ b/src/wolfterm.c
@@ -473,6 +473,9 @@ static int wolfSSH_DoControlSeq(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf, 
         }
         else {
             numArgs = getArgs(buf, bufSz, &i, args);
+            if (i >= bufSz) {
+                return WS_FATAL_ERROR;
+            }
             c = buf[i]; i++;
         }
     }
@@ -670,6 +673,7 @@ int wolfSSH_ConvertConsole(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf,
                 return ret;
             }
             ssh->escBufSz = 0;
+            ssh->escState = WC_ESC_NONE;
             break;
 
         case WS_ESC_OSC:
@@ -678,6 +682,7 @@ int wolfSSH_ConvertConsole(WOLFSSH* ssh, WOLFSSH_HANDLE handle, byte* buf,
                 return ret;
             }
             ssh->escBufSz = 0;
+            ssh->escState = WC_ESC_NONE;
             break;
 
         default:


### PR DESCRIPTION
Batch of security_sensitive findings from Fenrir static analysis. All fixes build-verified together against wolfSSL (--enable-all --enable-ssh) with `./configure --enable-all && make -j8` (exit 0); the QNX and Windows-only paths were source/syntax-analyzed (`gcc -D__QNX__ -fsyntax-only`).

- **#1684** `src/agent.c` — the agent `PostLock`/`PostUnlock` stubs logged the plaintext passphrase. Log only that a (un)lock was requested and `ForceZero` the stack buffer before return.
- **#4108** `apps/wolfsshd/configuration.c` — the QNX Include-dir filter called `lstat(dir->d_name, ...)`, which resolves relative to CWD, not the include dir. Build the full path with `WSNPRINTF` and treat snprintf/lstat failure as non-directory so the count pass and populate pass stay consistent.
- **#4794** `src/wolfterm.c` — reset `escState` to `WC_ESC_NONE` after the pre-loop CSI/OSC handling so a stale escape state is not carried into the next call, and bounds-guard the `buf[i]` read in `wolfSSH_DoControlSeq` (OOB read).
- **#5849** `apps/wolfsshd/configuration.c` — reject symlinks (`DT_LNK`) at both POSIX Include-dir filter sites (CWE-61) so a symlink in the Include dir is not followed by `fopen` and parsed as config.
- **#5852** `src/internal.c` — in `wolfSSH_CleanPath` parent-collapse, only match a `..` component that ends at a delimiter or NUL, guarding against `..X` components being mistaken for parent references.

Reported by Fenrir static analysis.