### PR TITLE
test: add BuildNameList and AEAD tamper tests

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -19901,6 +19901,12 @@ int wolfSSH_TestDoReceive(WOLFSSH* ssh)
     return DoReceive(ssh);
 }
 
+int wolfSSH_TestBuildNameList(char* buf, word32 bufSz,
+        const byte* src, word32 srcSz)
+{
+    return BuildNameList(buf, bufSz, src, srcSz);
+}
+
 int wolfSSH_TestDoUserAuthBanner(WOLFSSH* ssh, byte* buf, word32 len,
         word32* idx)
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -2724,6 +2724,47 @@ static void test_wolfSSH_SFTP_SetDefaultPath(void) { ; }
 #endif /* WOLFSSH_SFTP && !NO_WOLFSSH_CLIENT && !SINGLE_THREADED */
 
 
+#ifdef WOLFSSH_TEST_INTERNAL
+static void test_wolfSSH_BuildNameList(void)
+{
+    /* Fixed, valid IDs; oracle = comma-joined IdToName() per RFC 4253 7.1 */
+    const byte ids[] = { ID_ECDH_SHA2_NISTP256, ID_AES128_CTR,
+                         ID_HMAC_SHA2_256 };
+    const word32 n = (word32)(sizeof(ids) / sizeof(ids[0]));
+    char expected[256];
+    char buf[256];
+    word32 i;
+    int sizeMode, writeMode;
+    size_t expLen;
+
+    expected[0] = '\0';
+    for (i = 0; i < n; i++) {
+        if (i > 0)
+            strcat(expected, ",");
+        strcat(expected, IdToName(ids[i]));  /* independent oracle */
+    }
+    expLen = strlen(expected);
+
+    sizeMode  = wolfSSH_TestBuildNameList(NULL, 0, ids, n);
+    writeMode = wolfSSH_TestBuildNameList(buf, sizeof(buf), ids, n);
+
+    AssertIntEQ(sizeMode,  (int)expLen);        /* size mode == oracle */
+    AssertIntEQ(writeMode, (int)expLen);        /* write mode == oracle */
+    AssertIntEQ(strcmp(buf, expected), 0);      /* content == oracle    */
+    AssertIntNE(buf[writeMode - 1], ',');       /* no trailing comma    */
+    AssertIntNE(buf[writeMode - 1], '\0');      /* last char is a name  */
+
+    /* Undersized buffer must be rejected with a negative error, not
+     * overflow. BuildNameList sets idx = WS_BUFFER_E then returns idx - 1,
+     * so the exact code is implementation detail; the safety property is
+     * that the call fails rather than writing past the buffer. */
+    AssertIntLT(wolfSSH_TestBuildNameList(buf, 1, ids, n), 0);
+}
+#else
+static void test_wolfSSH_BuildNameList(void) { ; }
+#endif
+
+
 #if defined(WOLFSSH_SCP) && !defined(NO_WOLFSSH_CLIENT) && \
     !defined(SINGLE_THREADED) && !defined(NO_FILESYSTEM) && \
     !defined(WOLFSSH_SCP_USER_CALLBACKS) && !defined(WOLFSSH_ZEPHYR)
@@ -3866,6 +3907,8 @@ int wolfSSH_ApiTest(int argc, char** argv)
     test_wolfSSH_SCP_ReKey_NonBlock();
     test_wolfSSH_SCP_ReKey_ToServer();
     test_wolfSSH_SCP_ReKey_ToServer_NonBlock();
+
+    test_wolfSSH_BuildNameList();
 
     /* SFTP tests */
     test_wolfSSH_SFTP_SendReadPacket();

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -37,6 +37,7 @@
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/integer.h>
 #include <wolfssl/wolfcrypt/hmac.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
 #ifndef WOLFSSH_NO_RSA
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/asn.h>
@@ -1014,6 +1015,127 @@ done:
     return result;
 }
 #endif /* WOLFSSH_TEST_INTERNAL && any HMAC SHA variant enabled */
+
+
+#if defined(WOLFSSH_TEST_INTERNAL) && !defined(WOLFSSH_NO_AES_GCM)
+/* Verify DoReceive rejects a tampered AES-256-GCM packet, returning
+ * WS_FATAL_ERROR with ssh->error == AES_GCM_AUTH_E. The valid ciphertext and
+ * tag are produced by a SEPARATE Aes context (independent oracle), never
+ * ssh->decryptCipher, so the test is not self-referential. One ciphertext byte
+ * is flipped before delivery; the AEAD auth check must reject it. */
+static int test_DoReceive_AeadTamperFailure(void)
+{
+    WOLFSSH_CTX* ctx = NULL;
+    WOLFSSH* ssh = NULL;
+    int ret;
+    int result = 0;
+    int encReady = 0;
+    Aes enc;
+    byte key[AES_256_KEY_SIZE];
+    byte iv[AEAD_NONCE_SZ];
+    byte pt[16];
+    byte ct[16];
+    byte tag[AES_BLOCK_SIZE];
+    byte lenField[UINT32_SZ];
+    byte pkt[UINT32_SZ + 16 + AES_BLOCK_SIZE];
+    word32 curSz = 16;
+    word32 totalLen = UINT32_SZ + 16 + AES_BLOCK_SIZE;
+
+    ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_CLIENT, NULL);
+    if (ctx == NULL)
+        return -300;
+    ssh = wolfSSH_new(ctx);
+    if (ssh == NULL) {
+        wolfSSH_CTX_free(ctx);
+        return -301;
+    }
+
+    WMEMSET(key, 0xA5, sizeof(key));
+    WMEMSET(iv, 0x5A, sizeof(iv));
+
+    /* Plaintext = MSG_IGNORE carrying an empty string. Contents past what
+     * triggers decrypt are irrelevant: the auth reject fires before DoPacket. */
+    WMEMSET(pt, 0, sizeof(pt));
+    pt[0] = 4;              /* padding_length */
+    pt[1] = MSGID_IGNORE;   /* pt[2..5] = uint32 string len 0; rest padding */
+
+    /* AAD = 4-byte big-endian packet_length field (== curSz). */
+    lenField[0] = (byte)(curSz >> 24);
+    lenField[1] = (byte)(curSz >> 16);
+    lenField[2] = (byte)(curSz >> 8);
+    lenField[3] = (byte)(curSz);
+
+    /* Independent oracle: encrypt with a SEPARATE Aes context. */
+    ret = wc_AesInit(&enc, ssh->ctx->heap, INVALID_DEVID);
+    if (ret != 0) {
+        result = -302;
+        goto done;
+    }
+    encReady = 1;
+    ret = wc_AesGcmSetKey(&enc, key, sizeof(key));
+    if (ret == 0)
+        ret = wc_AesGcmEncrypt(&enc, ct, pt, curSz, iv, sizeof(iv),
+                tag, sizeof(tag), lenField, UINT32_SZ);
+    if (ret != 0) {
+        result = -303;
+        goto done;
+    }
+
+    /* Set up ssh receive state to match DecryptAead's expectations. */
+    ssh->peerEncryptId = ID_AES256_GCM;
+    ssh->peerAeadMode = 1;
+    ssh->peerBlockSz = AES_BLOCK_SIZE;
+    ssh->peerMacSz = AES_BLOCK_SIZE;   /* GCM tag size, per SetPeerAlgoIds */
+    WMEMCPY(ssh->peerKeys.iv, iv, sizeof(iv));
+    ssh->peerKeys.ivSz = AEAD_NONCE_SZ;
+    ret = wc_AesInit(&ssh->decryptCipher.aes, ssh->ctx->heap, INVALID_DEVID);
+    if (ret == 0)
+        ret = wc_AesGcmSetKey(&ssh->decryptCipher.aes, key, sizeof(key));
+    if (ret != 0) {
+        result = -304;
+        goto done;
+    }
+    ssh->decryptCipher.cipherType = ID_AES256_GCM;
+    ssh->decryptCipher.isInit = 1;   /* let wolfSSH_free clean it up */
+    ssh->peerSeq = 0;
+    ssh->curSz = 0;
+    ssh->processReplyState = PROCESS_INIT;
+    ssh->error = 0;
+
+    /* Assemble wire packet [lenField][ct][tag], then tamper one byte. */
+    WMEMCPY(pkt, lenField, UINT32_SZ);
+    WMEMCPY(pkt + UINT32_SZ, ct, curSz);
+    WMEMCPY(pkt + UINT32_SZ + curSz, tag, sizeof(tag));
+    pkt[UINT32_SZ] ^= 0x01;   /* flip a ciphertext byte */
+
+    ShrinkBuffer(&ssh->inputBuffer, 1);
+    ret = GrowBuffer(&ssh->inputBuffer, totalLen);
+    if (ret != WS_SUCCESS) {
+        result = -305;
+        goto done;
+    }
+    WMEMCPY(ssh->inputBuffer.buffer, pkt, totalLen);
+    ssh->inputBuffer.length = totalLen;
+    ssh->inputBuffer.idx = 0;
+
+    ret = wolfSSH_TestDoReceive(ssh);
+    if (ret != WS_FATAL_ERROR) {
+        result = -306;
+        goto done;
+    }
+    if (ssh->error != AES_GCM_AUTH_E) {
+        result = -307;
+        goto done;
+    }
+
+done:
+    if (encReady)
+        wc_AesFree(&enc);
+    wolfSSH_free(ssh);
+    wolfSSH_CTX_free(ctx);
+    return result;
+}
+#endif /* WOLFSSH_TEST_INTERNAL && !WOLFSSH_NO_AES_GCM */
 
 
 #ifdef WOLFSSH_TEST_INTERNAL
@@ -7635,6 +7757,13 @@ int wolfSSH_UnitTest(int argc, char** argv)
      !defined(WOLFSSH_NO_HMAC_SHA2_512))
     unitResult = test_DoReceive_VerifyMacFailure();
     printf("DoReceiveVerifyMac: %s\n",
+            (unitResult == 0 ? "SUCCESS" : "FAILED"));
+    testResult = testResult || unitResult;
+#endif
+
+#if defined(WOLFSSH_TEST_INTERNAL) && !defined(WOLFSSH_NO_AES_GCM)
+    unitResult = test_DoReceive_AeadTamperFailure();
+    printf("DoReceiveAeadTamper: %s\n",
             (unitResult == 0 ? "SUCCESS" : "FAILED"));
     testResult = testResult || unitResult;
 #endif

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -1544,6 +1544,8 @@ enum WS_MessageIdLimits {
     WOLFSSH_API int wolfSSH_TestScpExtractFileName(const char* filePath,
             char* fileName, word32 fileNameSz);
 #endif /* WOLFSSH_SCP && !WOLFSSH_SCP_USER_CALLBACKS */
+    WOLFSSH_API int wolfSSH_TestBuildNameList(char* buf, word32 bufSz,
+            const byte* src, word32 srcSz);
 #endif /* WOLFSSH_TEST_INTERNAL */
 
 /* dynamic memory types */


### PR DESCRIPTION
Adds two unit tests closing gaps found by Fenrir static analysis (test_gap theme). Additive/test-only; follows the existing `WOLFSSH_TEST_INTERNAL` wrapper idiom. Build-verified on Ubuntu 24.04 against wolfSSL `--enable-all --enable-ssh`; both `tests/api.test` and `tests/unit.test` pass.

- **#3452** `src/internal.c` `BuildNameList` had no direct coverage. Adds a `WOLFSSH_TEST_INTERNAL` wrapper `wolfSSH_TestBuildNameList` (internal.h + internal.c) and `tests/api.c` `test_wolfSSH_BuildNameList`. Oracle is a comma-joined `IdToName()` name-list built independently per RFC 4253 s7.1, checking size mode, write mode, exact content, no trailing comma, and undersized-buffer rejection (negative error, no overflow).

- **#6703** `tests/unit.c` had no AEAD authentication-failure test. Adds `test_DoReceive_AeadTamperFailure` for AES-256-GCM: a separate `Aes` context produces the valid ciphertext/tag (independent oracle, never `ssh->decryptCipher`), one ciphertext byte is flipped, and `DoReceive` must return `WS_FATAL_ERROR` with `ssh->error == AES_GCM_AUTH_E`.

Reported by Fenrir static analysis.