### PR TITLE
Drop incorrect const from ForceZero mem argument

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -99,7 +99,7 @@ STATIC INLINE void c32toa(word32 u32, byte* c)
 
 
 /* Make sure compiler doesn't skip */
-STATIC INLINE void ForceZero(const void* mem, word32 length)
+STATIC INLINE void ForceZero(void* mem, word32 length)
 {
     volatile byte* z = (volatile byte*)mem;
 

--- a/wolfssh/misc.h
+++ b/wolfssh/misc.h
@@ -42,7 +42,7 @@ WOLFSSH_LOCAL word32 min(word32 a, word32 b);
 
 WOLFSSH_LOCAL void ato32(const byte* c, word32* u32);
 WOLFSSH_LOCAL void c32toa(word32 u32, byte* c);
-WOLFSSH_LOCAL void ForceZero(const void* mem, word32 length);
+WOLFSSH_LOCAL void ForceZero(void* mem, word32 length);
 WOLFSSH_LOCAL int ConstantCompare(const byte* a, const byte* b, word32 length);
 
 


### PR DESCRIPTION
ForceZero writes zeros through mem, so const void* wasn't the right kind of pointer to take. It worked because of the casting later.