### PR TITLE
Test SearchForPubKey authorized_keys no-match rejection

### DIFF
--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -783,9 +783,15 @@ int wolfSSHD_OpenSecureFile(const char* path, WUID_T ownerUid,
 #endif
 }
 
+#if defined(WOLFSSHD_UNIT_TEST) && !defined(_WIN32)
+int SearchForPubKey(const char* path, const char* authKeysFile,
+                    const WS_UserAuthData_PublicKey* pubKeyCtx,
+                    WUID_T uid, int strictModes)
+#else
 static int SearchForPubKey(const char* path, const char* authKeysFile,
                            const WS_UserAuthData_PublicKey* pubKeyCtx,
                            WUID_T uid, int strictModes)
+#endif
 {
     int ret = WSSHD_AUTH_SUCCESS;
     char authKeysPath[MAX_PATH_SZ];

--- a/apps/wolfsshd/auth.h
+++ b/apps/wolfsshd/auth.h
@@ -93,6 +93,9 @@ extern int (*wsshd_setreuid_cb)(WUID_T, WUID_T);
 int wolfSSHD_GetUserGroupNames(void* heap, const char* usr, WGID_T primaryGid,
         char*** outNames, word32* outCount);
 void wolfSSHD_FreeUserGroupNames(void* heap, char** names, word32 count);
+int SearchForPubKey(const char* path, const char* authKeysFile,
+                    const WS_UserAuthData_PublicKey* pubKeyCtx,
+                    WUID_T uid, int strictModes);
 #endif
 #if defined(WOLFSSH_HAVE_LIBCRYPT) || defined(WOLFSSH_HAVE_LIBLOGIN)
 int CheckPasswordHashUnix(const char* input, char* stored);

--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -1408,6 +1408,126 @@ static int test_CheckAuthKeysLine(void)
 
     return ret;
 }
+
+#ifndef _WIN32
+/* Drive SearchForPubKey against a temp authorized_keys file to cover the
+ * "no line matched -> WSSHD_AUTH_FAILURE" gate: the authorized key kills a
+ * condition inversion, the unauthorized key kills a deletion of the gate. */
+static int test_SearchForPubKey(void)
+{
+    int ret = WS_SUCCESS;
+    static const char keyAStr[] = "wolfssh-auth-key-test-A-AAAAAAA";
+    static const char keyBStr[] = "wolfssh-auth-key-test-B-BBBBBBB";
+    const byte* keyA = (const byte*)keyAStr;
+    const byte* keyB = (const byte*)keyBStr;
+    const word32 keySz = (word32)(sizeof(keyAStr) - 1);
+    char base[] = "/tmp/wolfsshd_pkXXXXXX";
+    char keysPath[64] = "";
+    char missPath[64] = "";
+    char line[256];
+    WS_UserAuthData_PublicKey pubKeyCtx;
+    WUID_T uid = getuid();
+    FILE* f = NULL;
+    int rc;
+
+    if (mkdtemp(base) == NULL) {
+        Log("    mkdtemp failed.\n");
+        ret = WS_FATAL_ERROR;
+    }
+
+    if (ret == WS_SUCCESS) {
+        snprintf(keysPath, sizeof(keysPath), "%s/authorized_keys", base);
+        snprintf(missPath, sizeof(missPath), "%s/absent_keys", base);
+        ret = BuildAuthKeysLine(keyA, keySz, line, sizeof(line));
+    }
+
+    if (ret == WS_SUCCESS) {
+        f = fopen(keysPath, "w");
+        if (f == NULL) {
+            Log("    fopen of authorized_keys failed.\n");
+            ret = WS_FATAL_ERROR;
+        }
+        else {
+            fputs(line, f);
+            fputs("\n", f);
+            fclose(f);
+        }
+    }
+
+    /* Force 0600 so the StrictModes secure-open is not tripped by a permissive
+     * umask leaving the file group or world writable. */
+    if (ret == WS_SUCCESS && chmod(keysPath, S_IRUSR | S_IWUSR) != 0) {
+        Log("    chmod of authorized_keys failed.\n");
+        ret = WS_FATAL_ERROR;
+    }
+
+    WMEMSET(&pubKeyCtx, 0, sizeof(pubKeyCtx));
+    pubKeyCtx.publicKeySz = keySz;
+
+    /* StrictModes disabled so the check stays hermetic (no ownership gate). */
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: authorized key is accepted.");
+        pubKeyCtx.publicKey = keyA;
+        rc = SearchForPubKey(base, keysPath, &pubKeyCtx, uid, 0);
+        if (rc == WSSHD_AUTH_SUCCESS) {
+            Log(" PASSED.\n");
+        }
+        else {
+            Log(" FAILED (rc=%d).\n", rc);
+            ret = WS_FATAL_ERROR;
+        }
+    }
+
+    /* The temp file is user-owned with safe perms, so the StrictModes
+     * secure-open branch must also accept the authorized key. */
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: authorized key accepted under StrictModes.");
+        pubKeyCtx.publicKey = keyA;
+        rc = SearchForPubKey(base, keysPath, &pubKeyCtx, uid, 1);
+        if (rc == WSSHD_AUTH_SUCCESS) {
+            Log(" PASSED.\n");
+        }
+        else {
+            Log(" FAILED (rc=%d).\n", rc);
+            ret = WS_FATAL_ERROR;
+        }
+    }
+
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: unauthorized key is rejected.");
+        pubKeyCtx.publicKey = keyB;
+        rc = SearchForPubKey(base, keysPath, &pubKeyCtx, uid, 0);
+        if (rc == WSSHD_AUTH_FAILURE) {
+            Log(" PASSED.\n");
+        }
+        else {
+            Log(" FAILED (rc=%d).\n", rc);
+            ret = WS_FATAL_ERROR;
+        }
+    }
+
+    /* A missing authorized_keys file is an error, not a silent accept. */
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: missing keys file returns an error.");
+        pubKeyCtx.publicKey = keyA;
+        rc = SearchForPubKey(base, missPath, &pubKeyCtx, uid, 0);
+        if (rc < 0) {
+            Log(" PASSED.\n");
+        }
+        else {
+            Log(" FAILED (rc=%d).\n", rc);
+            ret = WS_FATAL_ERROR;
+        }
+    }
+
+    if (keysPath[0] != '\0') {
+        unlink(keysPath);
+    }
+    rmdir(base);
+
+    return ret;
+}
+#endif /* !_WIN32 */
 #endif /* WOLFSSL_BASE64_ENCODE */
 
 #ifndef _WIN32
@@ -1923,6 +2043,9 @@ const TEST_CASE testCases[] = {
 #endif
 #ifdef WOLFSSL_BASE64_ENCODE
     TEST_DECL(test_CheckAuthKeysLine),
+#endif
+#if defined(WOLFSSL_BASE64_ENCODE) && !defined(_WIN32)
+    TEST_DECL(test_SearchForPubKey),
 #endif
 #ifndef _WIN32
     TEST_DECL(test_GetUserGroupNames),


### PR DESCRIPTION
## Overview

Adds a negative-path unit test for `SearchForPubKey`, the authorized_keys authorization gate for default (non-certificate) wolfsshd builds. Finding 6814 was a **test-coverage gap**, not a live bug: the gate that converts "no authorized_keys line matched" into an authentication failure was untested, so a deletion or condition-inversion of it could ship undetected.

## Background

`SearchForPubKey` (`apps/wolfsshd/auth.c`) reads a user's authorized_keys file and calls `CheckAuthKeysLine` for each line. `foundKey` is set only when a line matches; the final gate

```c
if (ret == WSSHD_AUTH_SUCCESS && !foundKey) {
    ret = WSSHD_AUTH_FAILURE;
}
```

is the sole line that turns an all-mismatch file into a rejection. It had no coverage:

- `SearchForPubKey` was `static` and not exported through the `WOLFSSHD_UNIT_TEST` block.
- `test_CheckAuthKeysLine` exercises a single line in isolation, never the `foundKey` aggregation.
- The integration suite (`run_all_sshd_tests.sh`) is positive-only — it always presents an authorized key — so it cannot kill a mutation of this gate.

A deletion of the `if` block, or inverting `!foundKey` to `foundKey`, would make `SearchForPubKey` return success for a key that is **not** in authorized_keys, propagating up as `WOLFSSH_USERAUTH_SUCCESS` — a public-key auth bypass.

## Changes

- **`apps/wolfsshd/auth.c`** — expose `SearchForPubKey` (non-`static`) under `#if defined(WOLFSSHD_UNIT_TEST) && !defined(_WIN32)`, mirroring the existing `CheckAuthKeysLine` / `wsshd_setre*_cb` unit-test hooks. No production behavior change.
- **`apps/wolfsshd/auth.h`** — add the prototype inside the existing `WOLFSSHD_UNIT_TEST` / `#ifndef _WIN32` block.
- **`apps/wolfsshd/test/test_configuration.c`** — add `test_SearchForPubKey`, driving the real function against a `mkdtemp` temp authorized_keys file across four scenarios:
  - authorized key accepted (StrictModes off)
  - authorized key accepted (StrictModes on) — covers the `wolfSSHD_OpenSecureFile` dispatch branch
  - valid-but-unauthorized key rejected → `WSSHD_AUTH_FAILURE`
  - missing keys file → error (`rc < 0`, the `WS_BAD_FILE_E` path)

  Registered under `#if defined(WOLFSSL_BASE64_ENCODE) && !defined(_WIN32)`.

## Mutation coverage

The negative controls were confirmed by hand-mutating the gate and observing the test fail:

- `!foundKey` → `foundKey` (inversion): the authorized-key scenario fails.
- gate deleted entirely: the unauthorized-key scenario fails (`rc == WSSHD_AUTH_SUCCESS` leaks through).

Both mutations are now killed; the gate was then restored to its correct form.

## Testing

- `apps/wolfsshd/test/test_configuration` — all four scenarios pass, full suite exits 0.