### PR TITLE
Add PermitRootLogin prohibit-password and forced-commands-only

### DIFF
--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -387,13 +387,13 @@ static int ExtractSalt(char* hash, char** salt, int saltSz)
 
 #if defined(WOLFSSH_HAVE_LIBCRYPT) || defined(WOLFSSH_HAVE_LIBLOGIN)
 #ifdef WOLFSSHD_UNIT_TEST
-int CheckPasswordHashUnix(const char* input, char* stored)
+int CheckPasswordHashUnix(const char* input, const char* stored)
 #else
-static int CheckPasswordHashUnix(const char* input, char* stored)
+static int CheckPasswordHashUnix(const char* input, const char* stored)
 #endif
 {
     int ret = WSSHD_AUTH_SUCCESS;
-    char* hashedInput;
+    char* hashedInput = NULL;
     word32 hashedInputSz = 0, storedSz = 0;
 
     if (input == NULL || stored == NULL) {
@@ -1760,42 +1760,75 @@ static int CheckPublicKeyWIN(const char* usr,
 }
 #endif /* _WIN32*/
 
-/* return WOLFSSH_USERAUTH_SUCCESS on success */
-static int DoCheckUser(const char* usr, WOLFSSHD_AUTH* auth)
+/* Returns 1 if 'usr' is root-equivalent for PermitRootLogin (any uid 0
+ * account, or the literal name "root"; name-only on Windows). Shared by
+ * DoCheckUser and RequestAuthentication so all enforcement points agree. */
+static int IsRootUser(const char* usr)
 {
-    int ret = WOLFSSH_USERAUTH_SUCCESS;
-    int rc;
     int isRoot = 0;
-    WOLFSSHD_CONFIG* usrConf;
 #ifndef _WIN32
     struct passwd* pwInfo;
-#endif
 
-    wolfSSH_Log(WS_LOG_INFO, "[SSHD] Checking user name %s", usr);
-
-#ifndef _WIN32
-    /* PermitRootLogin covers every uid 0 account (so an alias like "toor"
-     * cannot bypass it) and the literal name "root", so a transient getpwnam
-     * failure cannot skip the check for root. */
     pwInfo = getpwnam(usr);
     if ((pwInfo != NULL && pwInfo->pw_uid == 0) || XSTRCMP(usr, "root") == 0) {
         isRoot = 1;
     }
 #else
-    /* No uid 0 on Windows and no logon token yet at this pre-auth stage, so
-     * fall back to the literal name; a token based Administrators membership
-     * check would belong after authentication. */
     if (XSTRCMP(usr, "root") == 0) {
         isRoot = 1;
     }
 #endif
+    return isRoot;
+}
+
+/* Returns 1 if root login is denied outright, i.e. PermitRootLogin no.
+ * Used by DoCheckUser. */
+WOLFSSHD_STATIC int IsRootLoginDenied(int isRoot, WOLFSSHD_CONFIG* usrConf)
+{
+    return (isRoot == 1 &&
+            wolfSSHD_ConfigGetPermitRoot(usrConf) == WOLFSSHD_PERMIT_ROOT_NO);
+}
+
+/* Returns 1 if root password authentication is blocked, i.e.
+ * PermitRootLogin prohibit-password or forced-commands-only. Used by
+ * RequestAuthentication for WOLFSSH_USERAUTH_PASSWORD. */
+WOLFSSHD_STATIC int IsRootPasswordAuthBlocked(int isRoot,
+        WOLFSSHD_CONFIG* usrConf)
+{
+    return (isRoot == 1 &&
+            (wolfSSHD_ConfigGetPermitRoot(usrConf) ==
+                 WOLFSSHD_PERMIT_ROOT_PROHIBIT_PW ||
+             wolfSSHD_ConfigGetPermitRoot(usrConf) ==
+                 WOLFSSHD_PERMIT_ROOT_FORCED_CMD));
+}
+
+/* Returns 1 if root public key login is missing the ForceCommand required by
+ * PermitRootLogin forced-commands-only. Used by RequestAuthentication for
+ * WOLFSSH_USERAUTH_PUBLICKEY. */
+WOLFSSHD_STATIC int IsRootPubKeyForcedCmdMissing(int isRoot,
+        WOLFSSHD_CONFIG* usrConf)
+{
+    return (isRoot == 1 &&
+            wolfSSHD_ConfigGetPermitRoot(usrConf) ==
+                WOLFSSHD_PERMIT_ROOT_FORCED_CMD &&
+            wolfSSHD_ConfigGetForcedCmd(usrConf) == NULL);
+}
+
+/* return WOLFSSH_USERAUTH_SUCCESS on success */
+static int DoCheckUser(const char* usr, WOLFSSHD_AUTH* auth, int isRoot)
+{
+    int ret = WOLFSSH_USERAUTH_SUCCESS;
+    int rc;
+    WOLFSSHD_CONFIG* usrConf;
+
+    wolfSSH_Log(WS_LOG_INFO, "[SSHD] Checking user name %s", usr);
 
     if (isRoot == 1) {
         /* Resolve per-user config so a Match override is honored; a NULL
          * result is unresolvable, so fail closed and reject. */
         usrConf = wolfSSHD_AuthGetUserConf(auth, usr, NULL, NULL, NULL, NULL,
                                            NULL);
-        if (usrConf == NULL || wolfSSHD_ConfigGetPermitRoot(usrConf) == 0) {
+        if (usrConf == NULL || IsRootLoginDenied(isRoot, usrConf)) {
             wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Login as root not permitted");
             ret = WOLFSSH_USERAUTH_REJECTED;
         }
@@ -1934,6 +1967,7 @@ static int RequestAuthentication(WS_UserAuthData* authData,
 {
     int ret;
     int rc;
+    int isRoot;
     const char* usr;
     WOLFSSHD_CONFIG* usrConf = NULL;
 
@@ -1948,7 +1982,9 @@ static int RequestAuthentication(WS_UserAuthData* authData,
     }
 
     usr = (const char*)authData->username;
-    ret = DoCheckUser(usr, authCtx);
+    isRoot = IsRootUser(usr);
+    ret = DoCheckUser(usr, authCtx, isRoot);
+
     /* temporarily elevate permissions */
     if (ret == WOLFSSH_USERAUTH_SUCCESS &&
             wolfSSHD_AuthRaisePermissions(authCtx) != WS_SUCCESS) {
@@ -1983,10 +2019,15 @@ static int RequestAuthentication(WS_UserAuthData* authData,
 
     if (ret == WOLFSSH_USERAUTH_SUCCESS &&
         authData->type == WOLFSSH_USERAUTH_PASSWORD) {
-
         if (wolfSSHD_ConfigGetPwAuth(usrConf) != 1) {
             wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Password authentication not "
                         "allowed by configuration!");
+            ret = WOLFSSH_USERAUTH_REJECTED;
+        }
+        else if (IsRootPasswordAuthBlocked(isRoot, usrConf)) {
+            /* prohibit-password and forced-commands-only both block this. */
+            wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Password authentication for "
+                        "root not allowed by configuration!");
             ret = WOLFSSH_USERAUTH_REJECTED;
         }
         /* Check if password is valid for this user. */
@@ -2000,6 +2041,7 @@ static int RequestAuthentication(WS_UserAuthData* authData,
         else {
             rc = authCtx->checkPasswordCb(usr, authData->sf.password.password,
                                      authData->sf.password.passwordSz, authCtx);
+
             if (rc == WSSHD_AUTH_SUCCESS) {
                 wolfSSH_Log(WS_LOG_INFO, "[SSHD] Password ok.");
             }
@@ -2027,6 +2069,15 @@ static int RequestAuthentication(WS_UserAuthData* authData,
         wolfSSHD_ConfigGetPubKeyAuth(usrConf) != 1) {
         wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Public key authentication not "
                     "allowed by configuration!");
+        ret = WOLFSSH_USERAUTH_REJECTED;
+    }
+
+    if (ret == WOLFSSH_USERAUTH_SUCCESS &&
+        authData->type == WOLFSSH_USERAUTH_PUBLICKEY &&
+        IsRootPubKeyForcedCmdMissing(isRoot, usrConf)) {
+        /* forced-commands-only requires a forced command for root pubkey. */
+        wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Public key login for root requires "
+                    "a forced command by configuration!");
         ret = WOLFSSH_USERAUTH_REJECTED;
     }
 
@@ -2258,7 +2309,7 @@ int DefaultUserAuthTypes(WOLFSSH* ssh, void* ctx)
     int   ret = 0;
 
     if (ssh == NULL || ctx == NULL)
-        return WS_BAD_ARGUMENT;
+        return 0;
     authCtx = (WOLFSSHD_AUTH*)ctx;
 
     /* get configuration for user */
@@ -2266,7 +2317,7 @@ int DefaultUserAuthTypes(WOLFSSH* ssh, void* ctx)
     usrConf = wolfSSHD_AuthGetUserConf(authCtx, usr, NULL, NULL,
             NULL, NULL, NULL);
     if (usrConf == NULL) {
-        ret = WS_BAD_ARGUMENT;
+        ret = 0;
     }
     else {
         ret = wolfSSHD_GetUserAuthTypes(usrConf);

--- a/apps/wolfsshd/auth.h
+++ b/apps/wolfsshd/auth.h
@@ -119,7 +119,7 @@ int SearchForPubKey(const char* path, const char* authKeysFile,
                     WUID_T uid, int strictModes);
 #endif
 #if defined(WOLFSSH_HAVE_LIBCRYPT) || defined(WOLFSSH_HAVE_LIBLOGIN)
-int CheckPasswordHashUnix(const char* input, char* stored);
+int CheckPasswordHashUnix(const char* input, const char* stored);
 #endif
 int CheckAuthKeysLine(char* line, word32 lineSz, const byte* key,
                       word32 keySz);
@@ -128,6 +128,9 @@ int ResolveAuthKeysPath(const char* homeDir, const char* pattern,
 int CAKeysFileDiffers(const char* a, const char* b);
 int MatchUPNToUser(const char* usr, const char* name, int nameSz,
                    const char* allowList);
+int IsRootLoginDenied(int isRoot, WOLFSSHD_CONFIG* usrConf);
+int IsRootPasswordAuthBlocked(int isRoot, WOLFSSHD_CONFIG* usrConf);
+int IsRootPubKeyForcedCmdMissing(int isRoot, WOLFSSHD_CONFIG* usrConf);
 int wolfSSHD_GetUserAuthTypes(const WOLFSSHD_CONFIG* usrConf);
 #if defined(WOLFSSH_OSSH_CERTS) && !defined(_WIN32)
 int OsshPrefixMatch(const byte* a, const byte* b, int bits, int len);

--- a/apps/wolfsshd/configuration.c
+++ b/apps/wolfsshd/configuration.c
@@ -100,7 +100,7 @@ struct WOLFSSHD_CONFIG {
     byte usePrivilegeSeparation:2;
     byte passwordAuth:1;
     byte pubKeyAuth:1;
-    byte permitRootLogin:1;
+    byte permitRootLogin:2;
     byte permitEmptyPasswords:1;
     byte authKeysFileSet:1; /* if not set then no explicit authorized keys */
     byte strictModes:1; /* enforce file permission/ownership checks */
@@ -555,10 +555,20 @@ static int HandlePermitRoot(WOLFSSHD_CONFIG* conf, const char* value)
 
     if (ret == WS_SUCCESS) {
         if (WSTRCMP(value, "no") == 0) {
-            conf->permitRootLogin = 0;
+            conf->permitRootLogin = WOLFSSHD_PERMIT_ROOT_NO;
         }
         else if (WSTRCMP(value, "yes") == 0) {
-            conf->permitRootLogin = 1;
+            conf->permitRootLogin = WOLFSSHD_PERMIT_ROOT_YES;
+        }
+        else if (WSTRCMP(value, "prohibit-password") == 0 ||
+                 WSTRCMP(value, "without-password") == 0) {
+            conf->permitRootLogin = WOLFSSHD_PERMIT_ROOT_PROHIBIT_PW;
+        }
+        else if (WSTRCMP(value, "forced-commands-only") == 0) {
+            wolfSSH_Log(WS_LOG_WARN, "[SSHD] PermitRootLogin "
+                        "forced-commands-only: authorized_keys command= "
+                        "restrictions not enforced");
+            conf->permitRootLogin = WOLFSSHD_PERMIT_ROOT_FORCED_CMD;
         }
         else {
             ret = WS_BAD_ARGUMENT;

--- a/apps/wolfsshd/configuration.h
+++ b/apps/wolfsshd/configuration.h
@@ -43,6 +43,14 @@ typedef struct WOLFSSHD_CONFIG WOLFSSHD_CONFIG;
     #define MAX_PATH_SZ 80
 #endif
 
+/* 0 so that root login is default off after struct memset'd on init */
+#define WOLFSSHD_PERMIT_ROOT_NO           0
+#define WOLFSSHD_PERMIT_ROOT_YES          1
+#define WOLFSSHD_PERMIT_ROOT_PROHIBIT_PW  2
+/* Prohibits passwords; pubkey logins require a configured ForceCommand
+ * (ignores authorized_keys command="..." restrictions). */
+#define WOLFSSHD_PERMIT_ROOT_FORCED_CMD   3
+
 WOLFSSHD_CONFIG* wolfSSHD_ConfigNew(void* heap);
 void wolfSSHD_ConfigFree(WOLFSSHD_CONFIG* conf);
 int wolfSSHD_ConfigLoad(WOLFSSHD_CONFIG* conf, const char* filename);

--- a/apps/wolfsshd/test/run_all_sshd_tests.sh
+++ b/apps/wolfsshd/test/run_all_sshd_tests.sh
@@ -396,12 +396,14 @@ else
         run_test "sshd_window_full_test.sh"
         run_test "sshd_empty_password_test.sh"
         run_test "sshd_permitroot_test.sh"
+        run_test "sshd_permitroot_prohibit_password.sh"
+        run_test "sshd_permitroot_forced_cmd.sh"
         run_strictmodes_negative_test
         run_test "sshd_login_grace_test.sh"
         run_test "sshd_privdrop_fail_test.sh"
     else
         printf "Skipping tests that need to setup local SSHD\n"
-        SKIPPED=$((SKIPPED+7))
+        SKIPPED=$((SKIPPED+9))
     fi
 
     # these tests run with X509 sshd-config loaded

--- a/apps/wolfsshd/test/sshd_permitroot_forced_cmd.sh
+++ b/apps/wolfsshd/test/sshd_permitroot_forced_cmd.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Test for PermitRootLogin forced-commands-only enforcement.
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "expecting host and port as arguments"
+    echo "$0 127.0.0.1 22222"
+    exit 1
+fi
+
+TEST_HOST="$1"
+TEST_PORT="$2"
+USER="root"
+PWD=`pwd`
+
+source ./start_sshd.sh
+
+# Build an authorized_keys file for "root" so we can test root public-key
+# auth both with and without a ForceCommand configured.
+cat ../../../keys/hansel-*.pub > authorized_keys_test_forced_cmd
+sed -i.bak "s/hansel/root/" ./authorized_keys_test_forced_cmd
+
+TEST_CLIENT="../../../examples/client/client"
+
+cleanup() {
+    stop_wolfsshd
+    rm -f authorized_keys_test_forced_cmd authorized_keys_test_forced_cmd.bak \
+        sshd_config_test_forced_cmd sshd_config_test_forced_cmd_with_cmd
+}
+trap cleanup EXIT
+
+### Scenario 1: forced-commands-only with no ForceCommand configured -- both
+### root password auth and root pubkey auth must be rejected.
+cat <<EOF > sshd_config_test_forced_cmd
+Port $TEST_PORT
+Protocol 2
+LoginGraceTime 600
+PermitRootLogin forced-commands-only
+PasswordAuthentication yes
+AuthorizedKeysFile $PWD/authorized_keys_test_forced_cmd
+StrictModes no
+UsePrivilegeSeparation no
+UseDNS no
+HostKey $PWD/../../../keys/server-key.pem
+EOF
+
+sudo rm -f ./log.txt
+
+start_wolfsshd "sshd_config_test_forced_cmd"
+if [ -z "$PID" ]; then
+    echo "Failed to start wolfsshd"
+    exit 1
+fi
+
+timeout 10 $TEST_CLIENT -u "$USER" -P "somepassword" -c 'true' \
+    -h "$TEST_HOST" -p "$TEST_PORT" > /dev/null 2>&1
+PASS_RESULT=$?
+
+if [ "$PASS_RESULT" = 0 ]; then
+    echo "FAIL: root password login unexpectedly succeeded under forced-commands-only"
+    exit 1
+fi
+
+timeout 10 $TEST_CLIENT -u "$USER" -c 'true' \
+    -i $PWD/../../../keys/hansel-key-ecc.der -j $PWD/../../../keys/hansel-key-ecc.pub \
+    -h "$TEST_HOST" -p "$TEST_PORT" > /dev/null 2>&1
+NOCMD_PUBKEY_RESULT=$?
+
+if [ "$NOCMD_PUBKEY_RESULT" = 0 ]; then
+    echo "FAIL: root pubkey login without a ForceCommand unexpectedly succeeded"
+    exit 1
+fi
+
+# Let wolfsshd flush the log before we stop it.
+sleep 1
+
+if ! sudo grep -q "Password authentication for root not allowed by configuration!" ./log.txt; then
+    echo "FAIL: forced-commands-only did not reject root password login as expected"
+    echo "----- log.txt -----"
+    sudo cat ./log.txt
+    exit 1
+fi
+
+if ! sudo grep -q "Public key login for root requires a forced command by configuration!" ./log.txt; then
+    echo "FAIL: forced-commands-only did not reject root pubkey login without a ForceCommand"
+    echo "----- log.txt -----"
+    sudo cat ./log.txt
+    exit 1
+fi
+
+stop_wolfsshd
+
+### Scenario 2: forced-commands-only WITH a ForceCommand configured -- root
+### pubkey login must now be permitted.
+cat <<EOF > sshd_config_test_forced_cmd_with_cmd
+Port $TEST_PORT
+Protocol 2
+LoginGraceTime 600
+PermitRootLogin forced-commands-only
+ForceCommand true
+PasswordAuthentication yes
+AuthorizedKeysFile $PWD/authorized_keys_test_forced_cmd
+StrictModes no
+UsePrivilegeSeparation no
+UseDNS no
+HostKey $PWD/../../../keys/server-key.pem
+EOF
+
+sudo rm -f ./log.txt
+
+start_wolfsshd "sshd_config_test_forced_cmd_with_cmd"
+if [ -z "$PID" ]; then
+    echo "Failed to start wolfsshd"
+    exit 1
+fi
+
+timeout 10 $TEST_CLIENT -u "$USER" -c 'true' \
+    -i $PWD/../../../keys/hansel-key-ecc.der -j $PWD/../../../keys/hansel-key-ecc.pub \
+    -h "$TEST_HOST" -p "$TEST_PORT" > /dev/null 2>&1
+WITHCMD_PUBKEY_RESULT=$?
+
+if [ "$WITHCMD_PUBKEY_RESULT" != 0 ]; then
+    echo "FAIL: root pubkey login with a ForceCommand configured was rejected"
+    echo "----- log.txt -----"
+    sudo cat ./log.txt
+    exit 1
+fi
+
+exit 0

--- a/apps/wolfsshd/test/sshd_permitroot_prohibit_password.sh
+++ b/apps/wolfsshd/test/sshd_permitroot_prohibit_password.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Test for PermitRootLogin prohibit-password enforcement.
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "expecting host and port as arguments"
+    echo "$0 127.0.0.1 22222"
+    exit 1
+fi
+
+TEST_HOST="$1"
+TEST_PORT="$2"
+USER="root"
+PWD=`pwd`
+
+source ./start_sshd.sh
+
+# Build an authorized_keys file for "root" so we can confirm root public-key
+# auth is still permitted under prohibit-password, while root password auth
+# is rejected.
+cat ../../../keys/hansel-*.pub > authorized_keys_test_prohibit_pw
+sed -i.bak "s/hansel/root/" ./authorized_keys_test_prohibit_pw
+
+cat <<EOF > sshd_config_test_prohibit_pw
+Port $TEST_PORT
+Protocol 2
+LoginGraceTime 600
+PermitRootLogin prohibit-password
+PasswordAuthentication yes
+AuthorizedKeysFile $PWD/authorized_keys_test_prohibit_pw
+StrictModes no
+UsePrivilegeSeparation no
+UseDNS no
+HostKey $PWD/../../../keys/server-key.pem
+EOF
+
+# Fresh log so we only see this run's output.
+sudo rm -f ./log.txt
+
+cleanup() {
+    stop_wolfsshd
+    rm -f authorized_keys_test_prohibit_pw authorized_keys_test_prohibit_pw.bak \
+        sshd_config_test_prohibit_pw
+}
+trap cleanup EXIT
+
+start_wolfsshd "sshd_config_test_prohibit_pw"
+if [ -z "$PID" ]; then
+    echo "Failed to start wolfsshd"
+    exit 1
+fi
+
+TEST_CLIENT="../../../examples/client/client"
+
+# Attempt password login as root, which should be rejected
+timeout 10 $TEST_CLIENT -u "$USER" -P "somepassword" -c 'true' \
+    -h "$TEST_HOST" -p "$TEST_PORT" > /dev/null 2>&1
+PASS_RESULT=$?
+
+if [ "$PASS_RESULT" = 0 ]; then
+    echo "FAIL: root password login unexpectedly succeeded"
+    exit 1
+fi
+
+# Attempt public-key login as root, which should still be permitted under
+# prohibit-password (only password auth is restricted for root).
+timeout 10 $TEST_CLIENT -u "$USER" -c 'true' \
+    -i $PWD/../../../keys/hansel-key-ecc.der -j $PWD/../../../keys/hansel-key-ecc.pub \
+    -h "$TEST_HOST" -p "$TEST_PORT" > /dev/null 2>&1
+PUBKEY_RESULT=$?
+
+# Let wolfsshd flush the log before we stop it.
+sleep 1
+
+# log.txt is owned by root (wolfsshd ran via sudo); use sudo to read it.
+if ! sudo grep -q "Password authentication for root not allowed by configuration!" ./log.txt; then
+    echo "FAIL: PermitRootLogin prohibit-password bypass detected or message changed"
+    echo "----- log.txt -----"
+    sudo cat ./log.txt
+    exit 1
+fi
+
+if [ "$PUBKEY_RESULT" != 0 ]; then
+    echo "FAIL: root public-key login was rejected under PermitRootLogin prohibit-password"
+    echo "----- log.txt -----"
+    sudo cat ./log.txt
+    exit 1
+fi
+
+exit 0

--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -23,6 +23,7 @@
 #endif
 
 #include <wolfssh/ssh.h>
+#include <wolfssh/internal.h>
 #include <wolfssl/wolfcrypt/coding.h>
 #include <configuration.h>
 #include <auth.h>
@@ -230,6 +231,44 @@ static int test_ConfigDefaults(void)
     return ret;
 }
 
+/* Pins PermitRootLogin prohibit-password/without-password parsing. */
+static int test_PermitRootProhibitPassword(void)
+{
+    int ret = WS_SUCCESS;
+    WOLFSSHD_CONFIG* conf;
+
+#define PCL(s) ParseConfigLine(&conf, s, (int)WSTRLEN(s), 0)
+    conf = wolfSSHD_ConfigNew(NULL);
+    if (conf == NULL)
+        ret = WS_MEMORY_E;
+
+    if (ret == WS_SUCCESS) ret = PCL("PermitRootLogin prohibit-password");
+    if (ret == WS_SUCCESS) {
+        if (wolfSSHD_ConfigGetPermitRoot(conf) !=
+                WOLFSSHD_PERMIT_ROOT_PROHIBIT_PW)
+            ret = WS_FATAL_ERROR;
+    }
+
+    if (ret == WS_SUCCESS) ret = PCL("PermitRootLogin without-password");
+    if (ret == WS_SUCCESS) {
+        if (wolfSSHD_ConfigGetPermitRoot(conf) !=
+                WOLFSSHD_PERMIT_ROOT_PROHIBIT_PW)
+            ret = WS_FATAL_ERROR;
+    }
+
+    if (ret == WS_SUCCESS) ret = PCL("PermitRootLogin forced-commands-only");
+    if (ret == WS_SUCCESS) {
+        if (wolfSSHD_ConfigGetPermitRoot(conf) !=
+                WOLFSSHD_PERMIT_ROOT_FORCED_CMD)
+            ret = WS_FATAL_ERROR;
+    }
+#undef PCL
+
+    if (conf != NULL)
+        wolfSSHD_ConfigFree(conf);
+    return ret;
+}
+
 static int test_ParseConfigLine(void)
 {
     int ret = WS_SUCCESS;
@@ -277,6 +316,17 @@ static int test_ParseConfigLine(void)
         {"Pubkey auth no", "PubkeyAuthentication no", 0},
         {"Pubkey auth yes", "PubkeyAuthentication yes", 0},
         {"Pubkey auth invalid", "PubkeyAuthentication wolfsshd", 1},
+
+        /* Permit root login tests. */
+        {"Permit root login no", "PermitRootLogin no", 0},
+        {"Permit root login yes", "PermitRootLogin yes", 0},
+        {"Permit root login prohibit-password",
+            "PermitRootLogin prohibit-password", 0},
+        {"Permit root login without-password",
+            "PermitRootLogin without-password", 0},
+        {"Permit root login forced-commands-only",
+            "PermitRootLogin forced-commands-only", 0},
+        {"Permit root login invalid", "PermitRootLogin wolfsshd", 1},
 
         /* StrictModes tests. */
         {"Strict modes no", "StrictModes no", 0},
@@ -471,27 +521,16 @@ static int test_ConfigCopy(void)
     return ret;
 }
 
-/* Verifies that a Match block override of the auth-relevant settings is the
- * value returned by wolfSSHD_GetUserConf, and that it differs from the global
- * node. RequestAuthentication and DoCheckUser resolve the per-user config via
- * wolfSSHD_AuthGetUserConf (a wrapper around wolfSSHD_GetUserConf) before
- * consulting PwAuth, PermitEmptyPw, PermitRootLogin and AuthKeysFileSet, so
- * this locks in that resolution: a regression that reverts to the global node
- * would be caught here.
+/* Verifies a Match block override is returned by wolfSSHD_GetUserConf and
+ * differs from the global node; RequestAuthentication/DoCheckUser depend on
+ * this resolution for PwAuth, PermitEmptyPw, PermitRootLogin, and
+ * AuthKeysFileSet.
  *
- * Coverage note: the new fail-closed branches in DoCheckUser and
- * RequestAuthentication (rejecting auth when wolfSSHD_AuthGetUserConf returns
- * NULL, and the Match-aware PermitRootLogin check) are not exercised directly.
- * Those paths require a populated WOLFSSHD_AUTH context (opaque to this test)
- * plus real system users, group lookups, callbacks, and privilege raising, so
- * they are validated here only at the config-resolution layer they depend on.
- * The auth-boundary enforcement itself (a tightened Match node is honored, and
- * a NULL per-user config rejects rather than falls through to the global node)
- * is covered by manual/integration testing of wolfsshd against an sshd_config
- * containing a Match block that disables password auth and PermitRootLogin.
- * On Unix the PermitRootLogin check now resolves the account and gates on
- * uid 0 (not the literal name "root"), so a non-"root" uid 0 alias is also
- * rejected; that behavior is covered by sshd_permitroot_test.sh. */
+ * Not covered here: the fail-closed NULL-config branches and the Match-aware
+ * PermitRootLogin modes (prohibit-password, forced-commands-only) need a
+ * real WOLFSSHD_AUTH context and system users, so they're covered instead by
+ * sshd_permitroot_test.sh, sshd_permitroot_prohibit_password.sh, and
+ * sshd_permitroot_forced_cmd.sh. */
 static int test_GetUserConfMatchOverride(void)
 {
     int ret = WS_SUCCESS;
@@ -1342,12 +1381,13 @@ static int test_CheckPasswordHashUnix(void)
         }
     }
 
-    /* (a) empty input + empty stored hash -> SUCCESS (pins the empty branch). */
     if (ret == WS_SUCCESS) {
-        char emptyStored[2];
-        emptyStored[0] = 0;
-        Log("    Testing scenario: empty password + empty stored hash authenticates.");
-        rc = CheckPasswordHashUnix("", emptyStored);
+        char empty[1];
+
+        empty[0] = '\0';
+
+        Log("    Empty password + empty stored: ");
+        rc = CheckPasswordHashUnix(empty, empty);
         if (rc == WSSHD_AUTH_SUCCESS) {
             Log(" PASSED.\n");
         }
@@ -1357,10 +1397,13 @@ static int test_CheckPasswordHashUnix(void)
         }
     }
 
-    /* (b) empty input + real $6$ hash -> FAILURE (kills the && -> || mutant). */
     if (ret == WS_SUCCESS) {
-        Log("    Testing scenario: empty password + real hash is rejected.");
-        rc = CheckPasswordHashUnix("", stored);
+        char empty[1];
+
+        empty[0] = '\0';
+
+        Log("    Empty password vs real hash: ");
+        rc = CheckPasswordHashUnix(empty, stored);
         if (rc == WSSHD_AUTH_FAILURE) {
             Log(" PASSED.\n");
         }
@@ -1370,13 +1413,18 @@ static int test_CheckPasswordHashUnix(void)
         }
     }
 
-    /* (c) non-empty input + empty stored hash -> FAILURE. */
     if (ret == WS_SUCCESS) {
-        char emptyStored[2];
-        emptyStored[0] = 0;
-        Log("    Testing scenario: non-empty password + empty stored hash is rejected.");
+        char emptyStored[1];
+
+        emptyStored[0] = '\0';
+
+        /* A hardened libxcrypt may reject the degenerate salt outright
+         * (crypt() returns NULL -> WS_FATAL_ERROR) rather than proceeding
+         * to a mismatched comparison (WSSHD_AUTH_FAILURE); either is a
+         * correct "not authenticated" outcome. */
+        Log("    Non-empty password vs empty stored: ");
         rc = CheckPasswordHashUnix(correct, emptyStored);
-        if (rc == WSSHD_AUTH_FAILURE) {
+        if (rc == WSSHD_AUTH_FAILURE || rc == WS_FATAL_ERROR) {
             Log(" PASSED.\n");
         }
         else {
@@ -1385,14 +1433,13 @@ static int test_CheckPasswordHashUnix(void)
         }
     }
 
-    /* (d) locked account (stored[0]=='*') -> FAILURE (pins the '*' guard). */
     if (ret == WS_SUCCESS) {
-        char lockedStored[3];
-        lockedStored[0] = '*';
-        lockedStored[1] = 0;
-        Log("    Testing scenario: locked account is rejected.");
-        rc = CheckPasswordHashUnix(correct, lockedStored);
-        if (rc == WSSHD_AUTH_FAILURE) {
+        char locked[] = "*";
+
+        /* Same NULL-tolerant reasoning as the empty-salt case above. */
+        Log("    Locked account (stored[0] == '*'): ");
+        rc = CheckPasswordHashUnix(correct, locked);
+        if (rc == WSSHD_AUTH_FAILURE || rc == WS_FATAL_ERROR) {
             Log(" PASSED.\n");
         }
         else {
@@ -1400,6 +1447,91 @@ static int test_CheckPasswordHashUnix(void)
             ret = WS_FATAL_ERROR;
         }
     }
+
+    if (ret == WS_SUCCESS) {
+        char lockedWithSalt[130];
+
+        /* A locked ('!') account with a valid hash must still fail auth, even if salt-reuse lets crypt() match. */
+        lockedWithSalt[0] = '!';
+        WMEMCPY(lockedWithSalt + 1, stored, WSTRLEN(stored) + 1);
+
+        /* Same NULL-tolerant reasoning as the empty-salt case above. */
+        Log("    Locked account with reusable '!' salt: ");
+        rc = CheckPasswordHashUnix(correct, lockedWithSalt);
+        if (rc == WSSHD_AUTH_FAILURE || rc == WS_FATAL_ERROR) {
+            Log(" PASSED.\n");
+        }
+        else {
+            Log(" FAILED.\n");
+            ret = WS_FATAL_ERROR;
+        }
+    }
+
+    return ret;
+}
+
+static int test_DefaultUserAuth_OOBRead(void)
+{
+    int ret = WS_SUCCESS;
+    WOLFSSHD_CONFIG* conf;
+    WOLFSSHD_AUTH* authCtx;
+    WS_UserAuthData authData;
+    char* passwordHeap;
+    word32 passwordSz = 16;
+    int rc;
+    /* Privilege separation off so RequestAuthentication's unconditional
+     * wolfSSHD_AuthReducePermissions() -> exit(1) on failure never fires:
+     * SetDefaultUserID then uses this process's own uid/gid, making the
+     * permission drop a no-op regardless of whether an 'sshd' account
+     * exists on the test machine. */
+    static const char line[] = "UsePrivilegeSeparation no";
+
+    conf = wolfSSHD_ConfigNew(NULL);
+    if (conf == NULL) return WS_MEMORY_E;
+
+    if (ParseConfigLine(&conf, line, (int)WSTRLEN(line), 0) != WS_SUCCESS) {
+        wolfSSHD_ConfigFree(conf);
+        return WS_FATAL_ERROR;
+    }
+
+    authCtx = wolfSSHD_AuthCreateUser(NULL, conf);
+    if (authCtx == NULL) {
+        wolfSSHD_ConfigFree(conf);
+        Log("    Skipping test: wolfSSHD_AuthCreateUser failed (likely missing 'sshd' user).\n");
+        return WS_SUCCESS;
+    }
+
+    passwordHeap = (char*)WMALLOC(passwordSz, NULL, DYNTYPE_STRING);
+    if (passwordHeap != NULL) {
+        WMEMSET(passwordHeap, 'A', passwordSz);
+
+        WMEMSET(&authData, 0, sizeof(authData));
+        authData.type = WOLFSSH_USERAUTH_PASSWORD;
+        authData.username = (const byte*)"nonexistent_test_user_xyz";
+        authData.usernameSz = (word32)WSTRLEN((const char*)authData.username);
+        authData.sf.password.password = (const byte*)passwordHeap;
+        authData.sf.password.passwordSz = passwordSz;
+
+        Log("    Testing scenario: DefaultUserAuth with non-NUL-terminated password (OOB read check).");
+        rc = DefaultUserAuth(WOLFSSH_USERAUTH_PASSWORD, &authData, authCtx);
+        if (rc == WOLFSSH_USERAUTH_INVALID_USER ||
+                rc == WOLFSSH_USERAUTH_FAILURE ||
+                rc == WOLFSSH_USERAUTH_REJECTED) {
+            Log(" PASSED.\n");
+        }
+        else {
+            Log(" FAILED.\n");
+            ret = WS_FATAL_ERROR;
+        }
+
+        WFREE(passwordHeap, NULL, DYNTYPE_STRING);
+    }
+    else {
+        ret = WS_MEMORY_E;
+    }
+
+    wolfSSHD_AuthFreeUser(authCtx);
+    wolfSSHD_ConfigFree(conf);
 
     return ret;
 }
@@ -2332,6 +2464,108 @@ static int test_CAKeysFileDiffers(void)
     return ret;
 }
 
+/* Locks in the enforcement decisions RequestAuthentication and DoCheckUser
+ * make for each PermitRootLogin mode, without needing a live sshd (the
+ * Match-aware end-to-end behavior is covered separately by
+ * sshd_permitroot_test.sh, sshd_permitroot_prohibit_password.sh, and
+ * sshd_permitroot_forced_cmd.sh). */
+static int test_PermitRootLoginModes(void)
+{
+    int ret = WS_SUCCESS;
+    WOLFSSHD_CONFIG* conf;
+    WOLFSSHD_CONFIG* head;
+
+#define PCL(s) ParseConfigLine(&conf, s, (int)WSTRLEN(s), 0)
+
+    /* PermitRootLogin no: root is denied outright, and never reaches the
+     * password/pubkey checks since DoCheckUser rejects first. */
+    Log("    Testing scenario: PermitRootLogin no.");
+    head = wolfSSHD_ConfigNew(NULL);
+    conf = head;
+    if (conf == NULL || PCL("PermitRootLogin no") != WS_SUCCESS) {
+        ret = WS_FATAL_ERROR;
+    }
+    else if (IsRootLoginDenied(1, conf) != 1 ||
+             IsRootLoginDenied(0, conf) != 0) {
+        ret = WS_FATAL_ERROR;
+    }
+    Log((ret == WS_SUCCESS) ? " PASSED.\n" : " FAILED.\n");
+    wolfSSHD_ConfigFree(head);
+
+    /* PermitRootLogin yes: nothing is blocked for root. */
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: PermitRootLogin yes.");
+        head = wolfSSHD_ConfigNew(NULL);
+        conf = head;
+        if (conf == NULL || PCL("PermitRootLogin yes") != WS_SUCCESS) {
+            ret = WS_FATAL_ERROR;
+        }
+        else if (IsRootLoginDenied(1, conf) != 0 ||
+                 IsRootPasswordAuthBlocked(1, conf) != 0 ||
+                 IsRootPubKeyForcedCmdMissing(1, conf) != 0) {
+            ret = WS_FATAL_ERROR;
+        }
+        Log((ret == WS_SUCCESS) ? " PASSED.\n" : " FAILED.\n");
+        wolfSSHD_ConfigFree(head);
+    }
+
+    /* PermitRootLogin prohibit-password: password auth blocked, pubkey auth
+     * is not required to carry a forced command. */
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: PermitRootLogin prohibit-password.");
+        head = wolfSSHD_ConfigNew(NULL);
+        conf = head;
+        if (conf == NULL ||
+                PCL("PermitRootLogin prohibit-password") != WS_SUCCESS) {
+            ret = WS_FATAL_ERROR;
+        }
+        else if (IsRootLoginDenied(1, conf) != 0 ||
+                 IsRootPasswordAuthBlocked(1, conf) != 1 ||
+                 IsRootPasswordAuthBlocked(0, conf) != 0 ||
+                 IsRootPubKeyForcedCmdMissing(1, conf) != 0) {
+            ret = WS_FATAL_ERROR;
+        }
+        Log((ret == WS_SUCCESS) ? " PASSED.\n" : " FAILED.\n");
+        wolfSSHD_ConfigFree(head);
+    }
+
+    /* PermitRootLogin forced-commands-only: password auth blocked; pubkey
+     * auth requires a ForceCommand, and passes once one is configured. */
+    if (ret == WS_SUCCESS) {
+        Log("    Testing scenario: PermitRootLogin forced-commands-only, "
+            "no ForceCommand.");
+        head = wolfSSHD_ConfigNew(NULL);
+        conf = head;
+        if (conf == NULL ||
+                PCL("PermitRootLogin forced-commands-only") != WS_SUCCESS) {
+            ret = WS_FATAL_ERROR;
+        }
+        else if (IsRootPasswordAuthBlocked(1, conf) != 1 ||
+                 IsRootPubKeyForcedCmdMissing(1, conf) != 1 ||
+                 IsRootPubKeyForcedCmdMissing(0, conf) != 0) {
+            ret = WS_FATAL_ERROR;
+        }
+        Log((ret == WS_SUCCESS) ? " PASSED.\n" : " FAILED.\n");
+
+        if (ret == WS_SUCCESS) {
+            Log("    Testing scenario: PermitRootLogin "
+                "forced-commands-only, with ForceCommand.");
+            if (PCL("ForceCommand internal-sftp") != WS_SUCCESS) {
+                ret = WS_FATAL_ERROR;
+            }
+            else if (IsRootPubKeyForcedCmdMissing(1, conf) != 0) {
+                ret = WS_FATAL_ERROR;
+            }
+            Log((ret == WS_SUCCESS) ? " PASSED.\n" : " FAILED.\n");
+        }
+        wolfSSHD_ConfigFree(head);
+    }
+
+#undef PCL
+
+    return ret;
+}
+
 /* Parses an AuthorizedUPNDomains line and confirms the stored value is returned
  * by the getter, locking in the new config option's plumbing. */
 static int test_ConfigParseAuthorizedUPNDomains(void)
@@ -2507,6 +2741,23 @@ static int test_GetUserAuthTypes(void)
         }
 
         wolfSSHD_ConfigFree(conf);
+    }
+
+    return ret;
+}
+
+/* Ensures DefaultUserAuthTypes returns a safe 0 (no auth methods) on NULL args instead of corrupting the bitmask with an error code. */
+static int test_DefaultUserAuthTypesNullArgs(void)
+{
+    int ret = WS_SUCCESS;
+
+    Log("    Testing scenario: DefaultUserAuthTypes with NULL ssh and ctx.");
+    if (DefaultUserAuthTypes(NULL, NULL) != 0) {
+        Log(" FAILED.\n");
+        ret = WS_FATAL_ERROR;
+    }
+    else {
+        Log(" PASSED.\n");
     }
 
     return ret;
@@ -3724,6 +3975,7 @@ static int test_ResolveAuthKeysPath(void)
 
 const TEST_CASE testCases[] = {
     TEST_DECL(test_ConfigDefaults),
+    TEST_DECL(test_PermitRootProhibitPassword),
     TEST_DECL(test_ParseConfigLine),
     TEST_DECL(test_ConfigCopy),
     TEST_DECL(test_GetUserConfMatchOverride),
@@ -3736,10 +3988,12 @@ const TEST_CASE testCases[] = {
     TEST_DECL(test_GetUserConfMatchGroupAnd),
     TEST_DECL(test_GetUserConfMatchSecondaryGroup),
     TEST_DECL(test_CAKeysFileDiffers),
+    TEST_DECL(test_PermitRootLoginModes),
     TEST_DECL(test_ConfigParseAuthorizedUPNDomains),
     TEST_DECL(test_MatchUPNToUser),
     TEST_DECL(test_IncludeRecursionBound),
     TEST_DECL(test_GetUserAuthTypes),
+    TEST_DECL(test_DefaultUserAuthTypesNullArgs),
     TEST_DECL(test_ConfigSetAuthKeysFile),
     TEST_DECL(test_ResolveAuthKeysPath),
     TEST_DECL(test_ConfigFree),
@@ -3770,6 +4024,7 @@ const TEST_CASE testCases[] = {
 #endif
 #if defined(WOLFSSH_HAVE_LIBCRYPT) || defined(WOLFSSH_HAVE_LIBLOGIN)
     TEST_DECL(test_CheckPasswordHashUnix),
+    TEST_DECL(test_DefaultUserAuth_OOBRead),
 #endif
 #if defined(WOLFSSH_OSSH_CERTS) && !defined(_WIN32)
     TEST_DECL(test_OsshPrefixMatch),

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -2094,6 +2094,47 @@ static int UserAuthResult(byte result,
     return ret;
 }
 
+#if defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)
+/* Returns 1 if root's forced-commands-only ForceCommand isn't
+ * "internal-sftp": SFTP/SCP never honor ForceCommand (only SHELL_Subsystem
+ * does), so this blocks the confinement bypass. No-op on Windows
+ * (pPasswd is NULL there). */
+static int IsRootTransferBlocked(WPASSWD* pPasswd, WOLFSSHD_CONFIG* usrConf)
+{
+#ifdef _WIN32
+    (void)pPasswd;
+    (void)usrConf;
+    return 0;
+#else
+    char* forcedCmd;
+
+    if (pPasswd == NULL || pPasswd->pw_uid != 0) {
+        return 0;
+    }
+    if (wolfSSHD_ConfigGetPermitRoot(usrConf) !=
+            WOLFSSHD_PERMIT_ROOT_FORCED_CMD) {
+        return 0;
+    }
+
+    forcedCmd = wolfSSHD_ConfigGetForcedCmd(usrConf);
+    return (forcedCmd == NULL || WSTRCMP(forcedCmd, "internal-sftp") != 0);
+#endif
+}
+
+/* Logs and returns 1 if 'what' (e.g. "SFTP subsystem", "SCP session") is
+ * blocked for root by IsRootTransferBlocked(); 0 otherwise. */
+static int RejectRootTransfer(WPASSWD* pPasswd, WOLFSSHD_CONFIG* usrConf,
+        const char* what)
+{
+    if (IsRootTransferBlocked(pPasswd, usrConf)) {
+        wolfSSH_Log(WS_LOG_ERROR, "[SSHD] %s for root requires ForceCommand "
+            "internal-sftp under forced-commands-only", what);
+        return 1;
+    }
+    return 0;
+}
+#endif /* WOLFSSH_SFTP || WOLFSSH_SCP */
+
 /* handle wolfSSH accept and directing to correct subsystem */
 #ifdef _WIN32
 static DWORD HandleConnection(void* arg)
@@ -2281,7 +2322,14 @@ static void* HandleConnection(void* arg)
                     switch (ret) {
                         case WS_SFTP_COMPLETE:
                         #ifdef WOLFSSH_SFTP
-                            ret = SFTP_Subsystem(conn, ssh, pPasswd, usrConf);
+                            if (RejectRootTransfer(pPasswd, usrConf,
+                                    "SFTP subsystem")) {
+                                ret = WS_FATAL_ERROR;
+                            }
+                            else {
+                                ret = SFTP_Subsystem(conn, ssh, pPasswd,
+                                        usrConf);
+                            }
                         #else
                             err_sys("SFTP not compiled in. Please use "
                                     "--enable-sftp");
@@ -2299,7 +2347,13 @@ static void* HandleConnection(void* arg)
                                     wolfSSH_GetUsername(ssh));
                                 ret = WS_FATAL_ERROR;
                             }
+                            else if (RejectRootTransfer(pPasswd, usrConf,
+                                    "SCP session")) {
+                                ret = WS_FATAL_ERROR;
+                            }
                             else {
+                                /* Intentional: SCP grants no more than the
+                                 * SFTP access already permitted above. */
                                 ret = SCP_Subsystem(conn, ssh, pPasswd,
                                         usrConf);
                             }
@@ -2341,7 +2395,13 @@ static void* HandleConnection(void* arg)
                                 "denying SCP", wolfSSH_GetUsername(ssh));
                             ret = WS_FATAL_ERROR;
                         }
+                        else if (RejectRootTransfer(pPasswd, usrConf,
+                                "SCP session")) {
+                            ret = WS_FATAL_ERROR;
+                        }
                         else {
+                            /* Intentional: SCP grants no more than the
+                             * SFTP access already permitted above. */
                             ret = SCP_Subsystem(conn, ssh, pPasswd, usrConf);
                         }
                     #else


### PR DESCRIPTION
Expanded PermitRootLogin configuration to fully support OpenSSH settings prohibit-password (including legacy without-password) and forced-commands-only.

Added additional test coverage for this new feature.