### PR TITLE
internal: allow PEM private-key decode without WOLFSSH_CERTS

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2954,17 +2954,29 @@ int wolfSSH_ProcessBuffer(WOLFSSH_CTX* ctx,
         WMEMCPY(der, in, inSz);
         derSz = inSz;
     }
-    #ifdef WOLFSSH_CERTS
     else if (format == WOLFSSH_FORMAT_PEM) {
         /* The der size will be smaller than the pem size. */
         der = (byte*)WMALLOC(inSz, heap, dynamicType);
         if (der == NULL)
             return WS_MEMORY_E;
 
-        if (type == BUFTYPE_PRIVKEY)
+        if (type == BUFTYPE_PRIVKEY) {
+            /* Private-key PEM decoding does not depend on WOLFSSH_CERTS;
+             * gating it there rejected PEM private keys (e.g. a PKCS#8 ML-DSA
+             * host key) unless wolfSSH was built with certificate support. */
             ret = wc_KeyPemToDer(in, inSz, der, inSz, NULL);
-        else
+        }
+    #ifdef WOLFSSH_CERTS
+        else {
             ret = wc_CertPemToDer(in, inSz, der, inSz, wcType);
+        }
+    #else
+        else {
+            /* Certificate/CA PEM decoding still requires WOLFSSH_CERTS. */
+            WFREE(der, heap, dynamicType);
+            return WS_UNIMPLEMENTED_E;
+        }
+    #endif /* WOLFSSH_CERTS */
         if (ret < 0) {
             if (type == BUFTYPE_PRIVKEY) {
                 /* wc_KeyPemToDer may have written partial key material;
@@ -2976,7 +2988,6 @@ int wolfSSH_ProcessBuffer(WOLFSSH_CTX* ctx,
         }
         derSz = (word32)ret;
     }
-    #endif /* WOLFSSH_CERTS */
     else {
         return WS_UNIMPLEMENTED_E;
     }


### PR DESCRIPTION
In `wolfSSH_ProcessBuffer()` (`src/internal.c`) the entire `WOLFSSH_FORMAT_PEM` branch — including the **private-key** path — sits inside `#ifdef WOLFSSH_CERTS`. A caller doing `wolfSSH_CTX_UsePrivateKey_buffer(..., WOLFSSH_FORMAT_PEM)` on a build without certificate support therefore gets `WS_UNIMPLEMENTED_E`, even though decoding a PEM private key has nothing to do with certificates.

This moves the private-key PEM path (`wc_KeyPemToDer`) out of the guard. The certificate PEM path (`wc_CertPemToDer`) stays guarded, and a certificate/CA PEM buffer on a build without `WOLFSSH_CERTS` still returns `WS_UNIMPLEMENTED_E` as before.

### Testing

`wolfSSH_CTX_UsePrivateKey_buffer(ctx, pem, sz, WOLFSSH_FORMAT_PEM)` on an ML-DSA-65 PKCS#8 PEM key, patch toggled in each configuration:

| Build | Before | After |
|---|---|---|
| default (no `--enable-certs`) | `-1017` (`WS_UNIMPLEMENTED_E`) | `0` |
| `--enable-certs` | `0` | `0` (no regression) |

Both configurations build warning-free.

Independent of #1118 — that one fixes `wolfsshd` by feeding the library the format it accepts; this makes the library API consistent for any caller. No ordering dependency between them.

Suggested ChangeLog entry: "`wolfSSH_ProcessBuffer()` now decodes PEM private keys without requiring `WOLFSSH_CERTS`."