### PR TITLE
fix: CountNameList undercounts leading-comma name-lists

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4312,10 +4312,6 @@ static word32 CountNameList(const byte* buf, word32 len)
                 count++;
             }
         }
-        /* remove leading comma */
-        if (count > 0 && buf[0] == ',') {
-            count--;
-        }
         /* remove trailing comma */
         if (count > 0 && buf[len-1] == ',') {
             count--;


### PR DESCRIPTION
## Bug

`CountNameList()` (src/internal.c) sizes the allocation that `GetNameListRaw()`
then fills. It discounts *both* a leading and a trailing comma, but
`GetNameListRaw()` only strips a trailing comma — it still emits the empty
leading token (the `idListIdx == 0` first-token case). For a name-list with a
leading comma such as `,ssh-rsa`, `CountNameList()` returns 1 while
`GetNameListRaw()` needs 2 slots, so the fill hits the capacity guard and
returns `WS_BUFFER_E`.

The visible effect is in `DoExtInfoServerSigAlgs()`, which sizes the
`server-sig-algs` buffer from `CountNameList()`: a peer advertising a
leading-comma / empty-first-element name-list is spuriously rejected and the
connection fails. No memory-safety impact — the capacity guard fails closed.

## Fix

Drop the leading-comma discount in `CountNameList()`. `GetNameListRaw()` keeps
that first token, so the count must include it. Over-counting an empty leading
element is harmless: `GetNameListRaw()` caps writes at the capacity and rewrites
the caller's size to the actual filled count.

## Verification

Built `--enable-all` against wolfSSL master; compiles clean. Traced `,ssh-rsa`,
`ssh-rsa,ssh-dss` (normal, unaffected), and `,,ssh-rsa` (harmless over-alloc)
by hand against `GetNameListRaw`.

Reported by static analysis (Fenrir finding F-6817). Distinct from the
trailing-comma name-list issue tracked separately.