### PR TITLE
fix: missing WMALLOC NULL checks in sftpclient rm/rename

### DIFF
--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1092,6 +1092,10 @@ static int doCmds(func_args* args)
             if (pt[0] != '/') {
                 int maxSz = (int)WSTRLEN(workingDir) + sz + 2;
                 f = (char*)WMALLOC(maxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                if (f == NULL) {
+                    err_msg("Error malloc'ing");
+                    return -1;
+                }
 
                 f[0] = '\0';
                 WSTRNCAT(f, workingDir, maxSz);
@@ -1180,6 +1184,11 @@ static int doCmds(func_args* args)
             if (to[0] != '/') {
                 int maxSz = (int)WSTRLEN(workingDir) + toSz + 2;
                 fTo = (char*)WMALLOC(maxSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                if (fTo == NULL) {
+                    err_msg("Error malloc'ing");
+                    WFREE(f, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                    return -1;
+                }
 
                 fTo[0] = '\0';
                 WSTRNCAT(fTo, workingDir, maxSz);


### PR DESCRIPTION
## Bug

In the sftp client example's `doCmds()`, the `rm` and `rename` handlers call
`WMALLOC` and then dereference the result without a NULL check:

- `rm`: `f = WMALLOC(...)` then `f[0] = '\0'` (no check).
- `rename`: the first buffer `f` is checked, but the second, `fTo = WMALLOC(...)`,
  is dereferenced (`fTo[0] = '\0'`) without one.

The allocations use the system heap (`NULL` ctx), so on allocation failure the
result is a real NULL and the write is a NULL dereference / crash. Sibling
handlers (e.g. `mkdir`, and `rename`'s first buffer) already guard.

## Fix

Add the same `if (... == NULL)` guard the sibling handlers use. For `rename`'s
second allocation, free the already-allocated `f` before returning.

## Verification

Built `--enable-all` against wolfSSL master; compiles clean.

Reported by static analysis (Fenrir finding F-6973).