### PR TITLE
Fix DEADCODE and TOCTOU defects reported by Coverity

### DIFF
--- a/apps/wolfsshd/test/test_configuration.c
+++ b/apps/wolfsshd/test/test_configuration.c
@@ -2747,6 +2747,9 @@ static int test_ConfigSavePID(void)
     void (*prevXfsz)(int);
 #endif
 
+    /* Every path below lives in this directory, which mkdtemp() creates mode
+     * 0700. No other user can traverse it, so none of the path-based checks
+     * here can be raced. */
     if (mkdtemp(base) == NULL) {
         Log("    mkdtemp failed.\n");
         ret = WS_FATAL_ERROR;
@@ -2773,15 +2776,16 @@ static int test_ConfigSavePID(void)
         ret = pidSave(conf, pidPath);
     }
     if (ret == WS_SUCCESS) {
-        if (stat(pidPath, &st) != 0) {
+        /* fstat() the open handle instead of stat()ing the path a second
+         * time, so the mode asserted below belongs to the same file the PID
+         * was read from. */
+        f = fopen(pidPath, "r");
+        if (f == NULL || fstat(fileno(f), &st) != 0) {
+            Log("    Could not open or stat %s.\n", pidPath);
             ret = WS_FATAL_ERROR;
         }
         else {
-            f = fopen(pidPath, "r");
-            rd = (f != NULL) ? fscanf(f, "%ld", &pid) : 0;
-            if (f != NULL) {
-                fclose(f);
-            }
+            rd = fscanf(f, "%ld", &pid);
             ret = smExpect("normal PID file written with our PID",
                 (rd == 1 && pid == (long)getpid()) ? WS_SUCCESS
                                                     : WS_FATAL_ERROR, 1);
@@ -2790,6 +2794,9 @@ static int test_ConfigSavePID(void)
                     (st.st_mode & (S_IWGRP | S_IWOTH)) ? WS_FATAL_ERROR
                                                         : WS_SUCCESS, 1);
             }
+        }
+        if (f != NULL) {
+            fclose(f);
         }
     }
 
@@ -2897,15 +2904,13 @@ static int test_ConfigSavePID(void)
     }
     if (ret == WS_SUCCESS) {
         pid = -1;
-        if (stat(stale, &st) != 0) {
+        f = fopen(stale, "r");
+        if (f == NULL || fstat(fileno(f), &st) != 0) {
+            Log("    Could not open or stat %s.\n", stale);
             ret = WS_FATAL_ERROR;
         }
         else {
-            f = fopen(stale, "r");
-            rd = (f != NULL) ? fscanf(f, "%ld", &pid) : 0;
-            if (f != NULL) {
-                fclose(f);
-            }
+            rd = fscanf(f, "%ld", &pid);
             ret = smExpect("existing PID file rewritten with our PID",
                 (rd == 1 && pid == (long)getpid()) ? WS_SUCCESS
                                                     : WS_FATAL_ERROR, 1);
@@ -2915,6 +2920,9 @@ static int test_ConfigSavePID(void)
                     (st.st_mode & (S_IWGRP | S_IWOTH)) ? WS_FATAL_ERROR
                                                         : WS_SUCCESS, 1);
             }
+        }
+        if (f != NULL) {
+            fclose(f);
         }
     }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -3113,20 +3113,18 @@ int CheckAlgoList(const char* list, byte type)
                 byte id = NameToIdType(name, nameSz, &tokenType);
 
                 if (id == ID_NONE) {
-                    int noneOk = 0;
-
                     /* "none" names the null cipher/MAC, not a host key. It
                      * disables the transport, so it needs the build flag. */
 #ifdef WOLFSSH_ALLOW_NONE_CIPHER
-                    if (type == TYPE_CIPHER || type == TYPE_MAC) {
-                        noneOk = 1;
-                    }
-#endif
-                    if (!noneOk) {
+                    if (type != TYPE_CIPHER && type != TYPE_MAC) {
                         ret = WS_INVALID_ALGO_ID;
                         break;
                     }
                     usableCount++;
+#else
+                    ret = WS_INVALID_ALGO_ID;
+                    break;
+#endif
                 }
                 else if (id != ID_UNKNOWN) {
                     /* Wrong category is a caller mistake, not a build


### PR DESCRIPTION
Coverity flagged two new defects:

- CheckAlgoList() rejected "none" via a noneOk flag that was only ever set
  inside the WOLFSSH_ALLOW_NONE_CIPHER guard, so usableCount++ was
  unreachable in the default build. The whole ID_NONE arm now lives under
  the guard. Behavior is unchanged in both builds.
- test_ConfigSavePID() stat()ed the PID path and then fopen()ed it.
  Scenarios 1 and 5 now fopen() once and fstat() that handle, so the mode
  asserted is the mode of the file the PID was read from. A failed open is
  a logged error rather than an indirect rd == 0.

The FIFO lstat() and the failPath existence test keep their path-based
checks: neither has a descriptor to stat, and mkdtemp() gives the test a
0700 directory.

Issues: CID-651701, CID-651702
