### PR TITLE
Address Coverity findings in wolfscp, wolfsftp, wolfssh, and wolfsshd

### DIFF
--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -402,6 +402,7 @@ static THREAD_RET readInput(void* in)
     int  bufSz = sizeof(buf);
     thread_args* args = (thread_args*)in;
     int ret = 0;
+    int err = 0;
     word32 sz = 0;
 #ifdef USE_WINDOWS_API
     HANDLE stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
@@ -420,15 +421,28 @@ static THREAD_RET readInput(void* in)
     #endif
         if (ret <= 0) {
             fprintf(stderr, "Error reading stdin\n");
-            return THREAD_RET_SUCCESS;
+            break;
         }
-        /* lock SSH structure access */
-        wc_LockMutex(&args->lock);
-        ret = wolfSSH_stream_send(args->ssh, buf, sz);
-        wc_UnLockMutex(&args->lock);
+        do {
+            /* lock SSH structure access */
+            wc_LockMutex(&args->lock);
+            ret = wolfSSH_stream_send(args->ssh, buf, sz);
+            err = (ret == WS_FATAL_ERROR) ?
+                wolfSSH_get_error(args->ssh) : ret;
+            wc_UnLockMutex(&args->lock);
+            if (err == WS_REKEYING) {
+                /* give readPeer() the lock to finish the rekey, then
+                 * send this buffer again */
+            #ifdef USE_WINDOWS_API
+                Sleep(1);
+            #else
+                usleep(1000);
+            #endif
+            }
+        } while (err == WS_REKEYING);
         if (ret <= 0) {
             fprintf(stderr, "Couldn't send data\n");
-            return THREAD_RET_SUCCESS;
+            break;
         }
     }
 #if !defined(WOLFSSH_NO_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)

--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -95,9 +95,16 @@ static void ShowUsage(char* appPath)
 
     printf("%s v%s linked with wolfSSL %s\n", appName,
         LIBWOLFSSH_VERSION_STRING, LIBWOLFSSL_VERSION_STRING);
-    printf("usage: %s [-E logfile] [-G] [-l login_name] [-N] [-p port] "
+    printf("usage: %s "
+#ifdef WOLFSSH_AGENT
+            "[-a] "
+#endif
+            "[-E logfile] [-G] [-l login_name] [-N] [-p port] "
             "[-V] destination\n",
             appName);
+#ifdef WOLFSSH_AGENT
+    printf("  -a  attempt to use SSH-AGENT\n");
+#endif
 }
 
 
@@ -726,6 +733,7 @@ struct config {
     char* command;
     word32 printConfig:1;
     word32 noCommand:1;
+    word32 useAgent:1;
     word16 port;
 };
 
@@ -783,8 +791,18 @@ static int config_parse_command_line(struct config* config,
 {
     int ch;
 
-    while ((ch = mygetopt(argc, argv, "E:Gl:Np:V")) != -1) {
+    while ((ch = mygetopt(argc, argv,
+#ifdef WOLFSSH_AGENT
+                "a"
+#endif
+                "E:Gl:Np:V")) != -1) {
         switch (ch) {
+        #ifdef WOLFSSH_AGENT
+            case 'a':
+                config->useAgent = 1;
+                break;
+        #endif
+
             case 'E':
                 config->logFile = myoptarg;
                 break;
@@ -887,6 +905,9 @@ static int config_print(struct config* config)
         printf("pubKeyFile %s\n",
                 config->pubKeyFile ? config->pubKeyFile : "none");
         printf("noCommand %s\n", config->noCommand ? "true" : "false");
+    #ifdef WOLFSSH_AGENT
+        printf("useAgent %s\n", config->useAgent ? "true" : "false");
+    #endif
         printf("logfile %s\n", config->logFile ? config->logFile : "default");
         printf("command %s\n", config->command ? config->command : "none");
     }
@@ -949,6 +970,10 @@ static THREAD_RETURN WOLFSSH_THREAD wolfSSH_Client(void* args)
     config_parse_command_line(&config,
             ((func_args*)args)->argc, ((func_args*)args)->argv);
     config_print(&config);
+
+#ifdef WOLFSSH_AGENT
+    useAgent = (byte)config.useAgent;
+#endif
 
     if (config.user == NULL)
         err_sys("client requires a username parameter.");

--- a/apps/wolfssh/wolfssh.c
+++ b/apps/wolfssh/wolfssh.c
@@ -119,7 +119,6 @@ static int NonBlockSSH_connect(WOLFSSH* ssh)
     int ret;
     int error;
     SOCKET_T sockfd;
-    int select_ret = 0;
 
     ret = wolfSSH_connect(ssh);
     error = wolfSSH_get_error(ssh);
@@ -128,23 +127,13 @@ static int NonBlockSSH_connect(WOLFSSH* ssh)
     while (ret != WS_SUCCESS &&
             (error == WS_WANT_READ || error == WS_WANT_WRITE))
     {
-        select_ret = tcp_select(sockfd, 1);
+        /* tcp_select only throttles the loop, always retry. On want write
+         * there may be pending data to send, and on want read a test case
+         * may have forced the want read with no more data coming in. */
+        (void)tcp_select(sockfd, 1);
 
-        /* Continue in want write cases even if did not select on socket
-         * because there could be pending data to be written. Added continue
-         * on want write for test cases where a forced want read was introduced
-         * and the socket will not be receiving more data. */
-        if (error == WS_WANT_WRITE || error == WS_WANT_READ ||
-            select_ret == WS_SELECT_RECV_READY ||
-            select_ret == WS_SELECT_ERROR_READY)
-        {
-            ret = wolfSSH_connect(ssh);
-            error = wolfSSH_get_error(ssh);
-        }
-        else if (select_ret == WS_SELECT_TIMEOUT)
-            error = WS_WANT_READ;
-        else
-            error = WS_FATAL_ERROR;
+        ret = wolfSSH_connect(ssh);
+        error = wolfSSH_get_error(ssh);
     }
 
     return ret;

--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -2088,20 +2088,22 @@ static int RequestAuthentication(WS_UserAuthData* authData,
         authData->type == WOLFSSH_USERAUTH_PUBLICKEY) {
         /* compare user name to UPN in certificate */
         if (authData->sf.publicKey.isCert) {
-            DecodedCert* dCert;
         #ifdef WOLFSSH_SMALL_STACK
+            DecodedCert* dCert;
+
             dCert = (DecodedCert*)WMALLOC(sizeof(DecodedCert), NULL,
                 DYNTYPE_CERT);
-        #else
-            DecodedCert sdCert;
-            dCert = &sdCert;
-        #endif
-
             if (dCert == NULL) {
                 wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Error creating cert struct");
                 ret = WOLFSSH_USERAUTH_INVALID_PUBLICKEY;
             }
-            else {
+        #else
+            DecodedCert sdCert;
+            DecodedCert* dCert = &sdCert;
+        #endif
+
+            /* ret is still success unless the allocation above failed */
+            if (ret == WOLFSSH_USERAUTH_SUCCESS) {
                 wc_InitDecodedCert(dCert, authData->sf.publicKey.publicKey,
                         authData->sf.publicKey.publicKeySz, NULL);
                 if (wc_ParseCert(dCert, CERT_TYPE, NO_VERIFY, NULL) != 0) {

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1388,6 +1388,26 @@ static int SHELL_IsPty(WOLFSSH* ssh)
     return ret;
 }
 
+/* set a descriptor to non blocking, returns 0 on success and -1 on failure */
+static int SHELL_SetNonBlocking(int fd)
+{
+    int flags;
+
+    flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) {
+        wolfSSH_Log(WS_LOG_ERROR, "[SSHD] fcntl get failed");
+        return -1;
+    }
+
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        wolfSSH_Log(WS_LOG_ERROR, "[SSHD] fcntl set failed");
+        return -1;
+    }
+
+    return 0;
+}
+
+
 /* handles creating a new shell env. and maintains SSH connection for incoming
  * user input as well as output of the shell.
  * return WS_SUCCESS on success */
@@ -2007,18 +2027,20 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
     if (!ptyReq || forcedCmd) {
         int readSz;
 
-        fcntl(stdoutPipe[0], F_SETFL, fcntl(stdoutPipe[0], F_GETFL)
-            | O_NONBLOCK);
-        readSz = (int)read(stdoutPipe[0], shellBuffer, sizeof shellBuffer);
-        if (readSz > 0) {
-            wolfSSH_ChannelIdSend(ssh, shellChannelId, shellBuffer, readSz);
+        /* when the pipe can not be made non blocking skip the drain, a
+         * blocking read here could hang the connection process */
+        if (SHELL_SetNonBlocking(stdoutPipe[0]) == 0) {
+            readSz = (int)read(stdoutPipe[0], shellBuffer, sizeof shellBuffer);
+            if (readSz > 0) {
+                wolfSSH_ChannelIdSend(ssh, shellChannelId, shellBuffer, readSz);
+            }
         }
 
-        fcntl(stderrPipe[0], F_SETFL, fcntl(stderrPipe[0], F_GETFL)
-            | O_NONBLOCK);
-        readSz = (int)read(stderrPipe[0], shellBuffer, sizeof shellBuffer);
-        if (readSz > 0) {
-            wolfSSH_extended_data_send(ssh, shellBuffer, readSz);
+        if (SHELL_SetNonBlocking(stderrPipe[0]) == 0) {
+            readSz = (int)read(stderrPipe[0], shellBuffer, sizeof shellBuffer);
+            if (readSz > 0) {
+                wolfSSH_extended_data_send(ssh, shellBuffer, readSz);
+            }
         }
 
         close(stdoutPipe[0]);

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -1408,6 +1408,88 @@ static int SHELL_SetNonBlocking(int fd)
 }
 
 
+#ifndef WOLFSSHD_SHELL_FLUSH_TRIES
+    #define WOLFSSHD_SHELL_FLUSH_TRIES 10
+#endif
+#ifndef WOLFSSHD_SHELL_FLUSH_WAIT_US
+    #define WOLFSSHD_SHELL_FLUSH_WAIT_US 50000
+#endif
+
+/* Send out the last of a shell's output once the child has been reaped. The
+ * SSH socket is non blocking, so retry a bounded number of times on a full
+ * window, a rekey or a would block. 'ext' selects the extended (stderr) data
+ * stream. Returns 0 on success and -1 when the data could not all be sent. */
+static int SHELL_FlushOut(WOLFSSH* ssh, WS_SOCKET_T sshFd, word32 channelId,
+    byte* buf, int sz, int ext)
+{
+    int tries = 0;
+
+    while (sz > 0 && tries < WOLFSSHD_SHELL_FLUSH_TRIES) {
+        int cnt_w;
+
+        if (ext) {
+            cnt_w = wolfSSH_extended_data_send(ssh, buf, sz);
+        }
+        else {
+            cnt_w = wolfSSH_ChannelIdSend(ssh, channelId, buf, sz);
+        }
+
+        if (cnt_w == WS_WINDOW_FULL || cnt_w == WS_REKEYING ||
+                cnt_w == WS_WANT_WRITE) {
+            fd_set fds;
+            struct timeval to;
+
+            FD_ZERO(&fds);
+            FD_SET(sshFd, &fds);
+            to.tv_sec  = 0;
+            to.tv_usec = WOLFSSHD_SHELL_FLUSH_WAIT_US;
+            if (cnt_w == WS_WANT_WRITE) {
+                select((int)sshFd + 1, NULL, &fds, NULL, &to);
+            }
+            else {
+                /* waiting on the peer's window adjust or kex packets */
+                select((int)sshFd + 1, &fds, NULL, NULL, &to);
+            }
+
+            /* process what came in, otherwise the window never opens and
+             * the rekey never finishes, and the send can not progress */
+            if (wolfSSH_worker(ssh, NULL) < 0) {
+                int err = wolfSSH_get_error(ssh);
+
+                if (err != WS_WANT_READ && err != WS_WANT_WRITE &&
+                        err != WS_CHAN_RXD && err != WS_REKEYING) {
+                    wolfSSH_Log(WS_LOG_ERROR,
+                        "[SSHD] Issue draining connection on final flush");
+                    return -1;
+                }
+            }
+            tries++;
+            continue;
+        }
+
+        if (cnt_w < 0) {
+            wolfSSH_Log(WS_LOG_ERROR,
+                "[SSHD] Issue sending final shell output");
+            return -1;
+        }
+
+        sz -= cnt_w;
+        if (sz > 0) {
+            WMEMMOVE(buf, buf + cnt_w, sz);
+            tries++;
+        }
+    }
+
+    if (sz > 0) {
+        wolfSSH_Log(WS_LOG_ERROR, "[SSHD] Unable to send all of the final "
+            "shell output, %d bytes dropped", sz);
+        return -1;
+    }
+
+    return 0;
+}
+
+
 /* handles creating a new shell env. and maintains SSH connection for incoming
  * user input as well as output of the shell.
  * return WS_SUCCESS on success */
@@ -2032,14 +2114,16 @@ static int SHELL_Subsystem(WOLFSSHD_CONNECTION* conn, WOLFSSH* ssh,
         if (SHELL_SetNonBlocking(stdoutPipe[0]) == 0) {
             readSz = (int)read(stdoutPipe[0], shellBuffer, sizeof shellBuffer);
             if (readSz > 0) {
-                wolfSSH_ChannelIdSend(ssh, shellChannelId, shellBuffer, readSz);
+                SHELL_FlushOut(ssh, sshFd, shellChannelId, shellBuffer, readSz,
+                    0);
             }
         }
 
         if (SHELL_SetNonBlocking(stderrPipe[0]) == 0) {
             readSz = (int)read(stderrPipe[0], shellBuffer, sizeof shellBuffer);
             if (readSz > 0) {
-                wolfSSH_extended_data_send(ssh, shellBuffer, readSz);
+                SHELL_FlushOut(ssh, sshFd, shellChannelId, shellBuffer, readSz,
+                    1);
             }
         }
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -149,7 +149,6 @@ static int NonBlockSSH_connect(WOLFSSH* ssh)
     int ret;
     int error;
     SOCKET_T sockfd;
-    int select_ret = 0;
 
     ret = wolfSSH_connect(ssh);
     error = wolfSSH_get_error(ssh);
@@ -163,23 +162,13 @@ static int NonBlockSSH_connect(WOLFSSH* ssh)
         else if (error == WS_WANT_WRITE)
             printf("... client would write block\n");
 
-        select_ret = tcp_select(sockfd, 1);
+        /* tcp_select only throttles the loop, always retry. On want write
+         * there may be pending data to send, and on want read a test case
+         * may have forced the want read with no more data coming in. */
+        (void)tcp_select(sockfd, 1);
 
-        /* Continue in want write cases even if did not select on socket
-         * because there could be pending data to be written. Added continue
-         * on want write for test cases where a forced want read was introduced
-         * and the socket will not be receiving more data. */
-        if (error == WS_WANT_WRITE || error == WS_WANT_READ ||
-            select_ret == WS_SELECT_RECV_READY ||
-            select_ret == WS_SELECT_ERROR_READY)
-        {
-            ret = wolfSSH_connect(ssh);
-            error = wolfSSH_get_error(ssh);
-        }
-        else if (select_ret == WS_SELECT_TIMEOUT)
-            error = WS_WANT_READ;
-        else
-            error = WS_FATAL_ERROR;
+        ret = wolfSSH_connect(ssh);
+        error = wolfSSH_get_error(ssh);
     }
 
     return ret;

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -368,6 +368,7 @@ static THREAD_RET readInput(void* in)
     int  bufSz = sizeof(buf);
     thread_args* args = (thread_args*)in;
     int ret = 0;
+    int err = 0;
     word32 sz = 0;
 #ifdef USE_WINDOWS_API
     HANDLE stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
@@ -386,18 +387,28 @@ static THREAD_RET readInput(void* in)
     #endif
         if (ret <= 0) {
             fprintf(stderr, "Error reading stdin\n");
-            return THREAD_RET_SUCCESS;
+            break;
         }
-        /* lock SSH structure access */
-        wc_LockMutex(&args->lock);
-        ret = wolfSSH_stream_send(args->ssh, buf, sz);
-        wc_UnLockMutex(&args->lock);
-        if (ret <= 0) {
-            if (ret == WS_REKEYING) {
-                continue;
+        do {
+            /* lock SSH structure access */
+            wc_LockMutex(&args->lock);
+            ret = wolfSSH_stream_send(args->ssh, buf, sz);
+            err = (ret == WS_FATAL_ERROR) ?
+                wolfSSH_get_error(args->ssh) : ret;
+            wc_UnLockMutex(&args->lock);
+            if (err == WS_REKEYING) {
+                /* give readPeer() the lock to finish the rekey, then
+                 * send this buffer again */
+            #ifdef USE_WINDOWS_API
+                Sleep(1);
+            #else
+                usleep(1000);
+            #endif
             }
+        } while (err == WS_REKEYING);
+        if (ret <= 0) {
             fprintf(stderr, "Couldn't send data\n");
-            return THREAD_RET_SUCCESS;
+            break;
         }
     }
 #if !defined(WOLFSSH_NO_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -3103,13 +3103,15 @@ static int ScpProcessEntry(WOLFSSH* ssh, char* fileName, word64* mTime,
     #else
         dNameLen   = (int)WSTRLEN(sendCtx->entry->d_name);
     #endif
-        if ((dirNameLen + 1 + dNameLen) > DEFAULT_SCP_FILE_NAME_SZ) {
+        /* need room for the separator and the terminating null */
+        if ((dirNameLen + 1 + dNameLen) >= DEFAULT_SCP_FILE_NAME_SZ) {
             WLOG(WS_LOG_ERROR, "scp: dir name length too long, abort");
             ret = WS_SCP_ABORT;
 
         } else {
             WSTRNCPY(filePath, sendCtx->dirName,
                      DEFAULT_SCP_FILE_NAME_SZ);
+            filePath[DEFAULT_SCP_FILE_NAME_SZ - 1] = '\0';
             WSTRNCAT(filePath, "/", DEFAULT_SCP_FILE_NAME_SZ);
 
         #ifdef WOLFSSL_NUCLEUS

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -3503,9 +3503,6 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
                 }
             }
 
-            if (ret != WS_BAD_ARGUMENT && sendCtx == NULL)
-                ret = WS_BAD_ARGUMENT;
-
             if (ret == WS_SUCCESS) {
                 ret = ScpProcessEntry(ssh, fileName,
                         mTime, aTime, fileMode, totalFileSz, buf,

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -10095,6 +10095,9 @@ int wolfSSH_SFTP_Put(WOLFSSH* ssh, char* from, char* to, byte resume,
                         return WS_FATAL_ERROR;
                     }
                     WLOG(WS_LOG_SFTP, "Error getting handle");
+                    /* handleSz still holds the request buffer size, the
+                     * remote file was never opened */
+                    state->handleSz = 0;
                     state->state = STATE_PUT_CLOSE_LOCAL;
                     continue;
                 }

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -10053,7 +10053,15 @@ int wolfSSH_SFTP_Put(WOLFSSH* ssh, char* from, char* to, byte resume,
                 #if SIZEOF_OFF_T == 8
                     offset = (((word64)state->pOfst[1]) << 32) | offset;
                 #endif
-                    WFSEEK(ssh->fs, state->fl, offset, 0);
+                    if (WFSEEK(ssh->fs, state->fl, offset, 0) != 0) {
+                        WLOG(WS_LOG_SFTP, "Unable to seek input file");
+                        ssh->error = WS_BAD_FILE_E;
+                        ret = WS_FATAL_ERROR;
+                        /* no remote handle to close yet */
+                        state->handleSz = 0;
+                        state->state = STATE_PUT_CLOSE_LOCAL;
+                        continue;
+                    }
                 }
             #else /* USE_WINDOWS_API */
                 state->fileHandle = WS_CreateFileA(from, GENERIC_READ,

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -1561,8 +1561,15 @@ static int wolfSSH_SFTP_RecvRealPath(WOLFSSH* ssh, int reqId, byte* data,
         return WS_MEMORY_E;
     }
 
-    SFTP_SetHeader(ssh, reqId, WOLFSSH_FTP_NAME,
-            outSz - WOLFSSH_SFTP_HEADER, out);
+    if (SFTP_SetHeader(ssh, reqId, WOLFSSH_FTP_NAME,
+                outSz - WOLFSSH_SFTP_HEADER, out) != WS_SUCCESS) {
+        /* only free "out" when it was allocated here, otherwise it is the
+         * state buffer owned by "ssh" */
+        if (outSz > (word32)maxSz) {
+            WFREE(out, ssh->ctx->heap, DYNTYPE_BUFFER);
+        }
+        return WS_BUFFER_E;
+    }
     lidx += WOLFSSH_SFTP_HEADER;
 
     /* set number of files */


### PR DESCRIPTION
- wolfscp: remove dead sendCtx null re-check — FindNextDirEntry() already returns WS_BAD_ARGUMENT for a NULL ctx, so the second check is unreachable. (CID-572848)
- wolfscp: fix path length check and terminate filePath — the guard allowed the joined path to exactly fill the buffer, leaving no room for the null; also terminate filePath after the WSTRNCPY of dirName. (CID-572864)
- wolfsftp: check SFTP_SetHeader in RecvRealPath — ignored return; free the output buffer on error only when allocated locally, not when borrowed from the receive state.  (CID-572923)
- wolfsftp: check the resume seek in wolfSSH_SFTP_Put — a failed WFSEEK() left the local file at offset 0 while the remote write resumed at the offset, silently corrupting the upload. (CID-572932)
- apps/wolfssh: wire up the -a agent option — useAgent was never set, making both agent setup blocks dead code; adds the option to match examples/client. (CID-572857)
- apps/wolfssh, examples/client: retry readInput sends over a rekey — a rekey surfaces as WS_FATAL_ERROR with WS_REKEYING from wolfSSH_get_error(), so the old test never matched; resend the same buffer, and break out of the loop so the ECC cache cleanup is reachable.  (CID-572833)
- examples/client: drop dead select_ret tests in NonBlockSSH_connect — the loop condition already guarantees want-read/want-write, so the select_ret arms were unreachable; same change in apps/wolfssh. (CID-572884)
- wolfsshd: check fcntl results in the pipe drain — check both fcntl calls and skip the drain read on a pipe that could not be made non-blocking, so the read cannot hang the connection process. (CID-572931)
- wolfsshd: retry the final shell output flush — the post-waitpid drain ignored the send return, dropping the tail of command output on a full window, rekey, or would-block; retry bounded and log on failure. (CID-572907)
- wolfsshd: drop dead dCert NULL check — without WOLFSSH_SMALL_STACK, dCert is a stack address and can't be NULL; keep the check only for the small-stack build where the WMALLOC can fail. (CID-573006)