### PR TITLE
Fix expected failing value for WFSEEK()

### DIFF
--- a/apps/wolfssh/common.c
+++ b/apps/wolfssh/common.c
@@ -89,7 +89,7 @@ static int load_der_file(const char* filename, byte** out, word32* outSz)
     if (ret != 0 || file == WBADFILE)
         return -1;
 
-    if (WFSEEK(NULL, file, 0, WSEEK_END) != 0) {
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
         WFCLOSE(NULL, file);
         return -1;
     }

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -291,7 +291,11 @@ static byte* getBufferFromFile(const char* fileName, word32* bufSz, void* heap,
             return NULL;
         }
     }
-    WFSEEK(NULL, file, 0, WSEEK_END);
+
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
+        WFCLOSE(NULL, file);
+        return NULL;
+    }
     fileSz = WFTELL(NULL, file);
     if (fileSz < 0) {
         WFCLOSE(NULL, file);

--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -274,7 +274,7 @@ static int load_der_file(const char* filename, byte** out, word32* outSz,
     if (ret != 0 || file == WBADFILE)
         return -1;
 
-    if (WFSEEK(NULL, file, 0, WSEEK_END) != 0) {
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
         WFCLOSE(NULL, file);
         return -1;
     }

--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -799,7 +799,10 @@ static int readKeyBlob(const char* filename, WOLFTPM2_KEYBLOB* key)
         rc = BUFFER_E; goto exit;
     }
     if (fp != WBADFILE) {
-        WFSEEK(NULL, fp, 0, WSEEK_END);
+        if (!WFSEEK_SUCCESS(WFSEEK(NULL, fp, 0, WSEEK_END))) {
+            printf("File seek failed\n");
+            rc = BUFFER_E; goto exit;
+        }
         fileSz = WFTELL(NULL, fp);
         WREWIND(NULL, fp);
 

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1730,6 +1730,7 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
     WFILE* file;
     word32 fileSz;
     word32 readSz;
+    long tmpSz;
 
     if (fileName == NULL) return 0;
 
@@ -1740,7 +1741,12 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
         return 0;
     }
 
-    fileSz = (word32)WFTELL(NULL, file);
+    tmpSz = WFTELL(NULL, file);
+    if (tmpSz < 0) {
+        WFCLOSE(NULL, file);
+        return 0;
+    }
+    fileSz = (word32)tmpSz;
     WREWIND(NULL, file);
 
     if (buf == NULL || fileSz > *bufSz) {
@@ -2565,6 +2571,11 @@ static char* LoadTpmSshKey(const char* keyFile, const char* username)
         return NULL;
     }
     length = WFTELL(NULL, file);
+    if (length < 0) {
+        fprintf(stderr, "TPM key file tell failed\n");
+        WFCLOSE(NULL, file);
+        return NULL;
+    }
     WREWIND(NULL, file);
 
     usernameLen = WSTRLEN(username);

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -1735,7 +1735,11 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
 
     if (WFOPEN(NULL, &file, fileName, "rb") != 0)
         return 0;
-    WFSEEK(NULL, file, 0, WSEEK_END);
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
+        WFCLOSE(NULL, file);
+        return 0;
+    }
+
     fileSz = (word32)WFTELL(NULL, file);
     WREWIND(NULL, file);
 
@@ -2555,7 +2559,11 @@ static char* LoadTpmSshKey(const char* keyFile, const char* username)
             "Failed to open TPM key file: %s\n", keyFile);
         return NULL;
     }
-    WFSEEK(NULL, file, 0, WSEEK_END);
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
+        fprintf(stderr, "TPM key file seek failed\n");
+        WFCLOSE(NULL, file);
+        return NULL;
+    }
     length = WFTELL(NULL, file);
     WREWIND(NULL, file);
 

--- a/examples/tpmcertserver/tpmcertclient.c
+++ b/examples/tpmcertserver/tpmcertclient.c
@@ -72,18 +72,22 @@ static int TpmCcLoadFile(const char* file, byte* buf, word32* bufSz)
 {
     int ret = 0;
     WFILE* f;
-    word32 fileSz;
+    word32 fileSz = 0;
     word32 readSz;
 
     if (WFOPEN(NULL, &f, file, "rb") != 0) {
         ret = -1;
     }
     else {
-        WFSEEK(NULL, f, 0, WSEEK_END);
-        fileSz = (word32)WFTELL(NULL, f);
-        WREWIND(NULL, f);
+        if (!WFSEEK_SUCCESS(WFSEEK(NULL, f, 0, WSEEK_END))) {
+            ret = -1;
+        }
+        else {
+            fileSz = (word32)WFTELL(NULL, f);
+            WREWIND(NULL, f);
+        }
 
-        if (fileSz == 0 || fileSz > *bufSz) {
+        if (ret != 0 || fileSz == 0 || fileSz > *bufSz) {
             ret = -1;
         }
         else {

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
@@ -1665,7 +1665,10 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
 
     if (WFOPEN(NULL, &file, fileName, "rb") != 0)
         return 0;
-    WFSEEK(NULL, file, 0, WSEEK_END);
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
+        WFCLOSE(NULL, file);
+        return 0;
+    }
     fileSz = (word32)WFTELL(NULL, file);
     WREWIND(NULL, file);
 
@@ -2173,7 +2176,11 @@ static char* LoadTpmSshKey(const char* keyFile, const char* username)
             "Failed to open TPM key file: %s\n", keyFile);
         return NULL;
     }
-    WFSEEK(NULL, file, 0, WSEEK_END);
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
+        fprintf(stderr, "TPM key file seek failed\n");
+        WFCLOSE(NULL, file);
+        return NULL;
+    }
     length = WFTELL(NULL, file);
     WREWIND(NULL, file);
 

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
@@ -1660,6 +1660,7 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
     WFILE* file;
     word32 fileSz;
     word32 readSz;
+    long tmpSz;
 
     if (fileName == NULL) return 0;
 
@@ -1669,7 +1670,13 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
         WFCLOSE(NULL, file);
         return 0;
     }
-    fileSz = (word32)WFTELL(NULL, file);
+
+    tmpSz = WFTELL(NULL, file);
+    if (tmpSz < 0) {
+        WFCLOSE(NULL, file);
+        return 0;
+    }
+    fileSz = (word32)tmpSz;
     WREWIND(NULL, file);
 
     if (buf == NULL || fileSz > *bufSz) {
@@ -2182,6 +2189,11 @@ static char* LoadTpmSshKey(const char* keyFile, const char* username)
         return NULL;
     }
     length = WFTELL(NULL, file);
+    if (length < 0) {
+        fprintf(stderr, "TPM key file tell failed\n");
+        WFCLOSE(NULL, file);
+        return NULL;
+    }
     WREWIND(NULL, file);
 
     usernameLen = WSTRLEN(username);

--- a/src/port.c
+++ b/src/port.c
@@ -129,10 +129,10 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
         int wPwrite(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)
         {
-            int ret;
+            int ret = -1;
 
-            ret = (int)WFSEEK(NULL, &fd, shortOffset[0], SYS_FS_SEEK_SET);
-            if (ret != -1) {
+            if (WFSEEK_SUCCESS(WFSEEK(
+                               NULL, &fd, shortOffset[0], SYS_FS_SEEK_SET))) {
                 ret = (int)WFWRITE(NULL, buf, 1, sz, &fd);
             }
 
@@ -142,10 +142,10 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
         int wPread(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)
         {
-            int ret;
+            int ret = -1;
 
-            ret = (int)WFSEEK(NULL, &fd, shortOffset[0], SYS_FS_SEEK_SET);
-            if (ret != -1)
+            if (WFSEEK_SUCCESS(WFSEEK(
+                               NULL, &fd, shortOffset[0], SYS_FS_SEEK_SET)))
                 ret = (int)WFREAD(NULL, buf, 1, sz, &fd);
 
             return ret;

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -2410,7 +2410,7 @@ int wolfSSH_ReadKey_file(const char* name,
     if (ret != 0 || file == WBADFILE) return WS_BAD_FILE_E;
 #endif
 
-    if (WFSEEK(NULL, file, 0, WSEEK_END) != 0) {
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
         WFCLOSE(NULL, file);
         return WS_BAD_FILE_E;
     }

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -2686,6 +2686,8 @@ int wsScpRecvCallback(WOLFSSH* ssh, int state, const char* basePath,
 
 static int _GetFileSize(void* fs, WFILE* fp, word32* fileSz)
 {
+    long tmpSz;
+
     WOLFSSH_UNUSED(fs);
 
     if (fp == NULL || fileSz == NULL)
@@ -2693,7 +2695,11 @@ static int _GetFileSize(void* fs, WFILE* fp, word32* fileSz)
 
     /* get file size */
     if (WFSEEK_SUCCESS(WFSEEK(fs, fp, 0, WSEEK_END))) {
-        *fileSz = (word32)WFTELL(fs, fp);
+        tmpSz = WFTELL(fs, fp);
+        if (tmpSz < 0) {
+            return WS_BAD_FILE_E;
+        }
+        *fileSz = (word32)tmpSz;
         WREWIND(fs, fp);
 
         return WS_SUCCESS;
@@ -3184,8 +3190,14 @@ static int ScpProcessEntry(WOLFSSH* ssh, char* fileName, word64* mTime,
             if (ret == WS_SUCCESS) {
                 ret = _GetFileSize(ssh->fs, sendCtx->fp, totalFileSz);
 
-                if (ret == WS_SUCCESS)
+                if (ret != WS_SUCCESS) {
+                    WLOG(WS_LOG_ERROR, "scp: unable to get file size, abort");
+                    wolfSSH_SetScpErrorMsg(ssh, "unable to get file size");
+                    ret = WS_SCP_ABORT;
+                }
+                else {
                     ret = (word32)WFREAD(ssh->fs, buf, 1, bufSz, sendCtx->fp);
+                }
             }
 
             /* keep fp open if no errors and transfer will continue */
@@ -3358,8 +3370,13 @@ int wsScpSendCallback(WOLFSSH* ssh, int state, const char* peerRequest,
             #endif
             }
 
-            if (ret == WS_SUCCESS)
+            if (ret == WS_SUCCESS) {
                 ret = _GetFileSize(ssh->fs, sendCtx->fp, totalFileSz);
+                if (ret != WS_SUCCESS) {
+                    WLOG(WS_LOG_ERROR, "scp: unable to get file size, abort");
+                    wolfSSH_SetScpErrorMsg(ssh, "unable to get file size");
+                }
+            }
 
             if (ret == WS_SUCCESS)
                 ret = GetFileStats(ssh->fs, sendCtx, peerRequest, mTime, aTime, fileMode);

--- a/src/wolfscp.c
+++ b/src/wolfscp.c
@@ -2692,11 +2692,13 @@ static int _GetFileSize(void* fs, WFILE* fp, word32* fileSz)
         return WS_BAD_ARGUMENT;
 
     /* get file size */
-    WFSEEK(fs, fp, 0, WSEEK_END);
-    *fileSz = (word32)WFTELL(fs, fp);
-    WREWIND(fs, fp);
+    if (WFSEEK_SUCCESS(WFSEEK(fs, fp, 0, WSEEK_END))) {
+        *fileSz = (word32)WFTELL(fs, fp);
+        WREWIND(fs, fp);
 
-    return WS_SUCCESS;
+        return WS_SUCCESS;
+    }
+    return WS_BAD_FILE_E;
 }
 
 static int GetFileStats(void *fs, ScpSendCtx* ctx, const char* fileName,

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -10053,7 +10053,8 @@ int wolfSSH_SFTP_Put(WOLFSSH* ssh, char* from, char* to, byte resume,
                 #if SIZEOF_OFF_T == 8
                     offset = (((word64)state->pOfst[1]) << 32) | offset;
                 #endif
-                    if (WFSEEK(ssh->fs, state->fl, offset, 0) != 0) {
+                    if (!WFSEEK_SUCCESS(WFSEEK(
+                                        ssh->fs, state->fl, offset, 0))) {
                         WLOG(WS_LOG_SFTP, "Unable to seek input file");
                         ssh->error = WS_BAD_FILE_E;
                         ret = WS_FATAL_ERROR;

--- a/tests/auth.c
+++ b/tests/auth.c
@@ -174,6 +174,7 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
     WFILE* file;
     word32 fileSz;
     word32 readSz;
+    long tmpSz;
 
     if (fileName == NULL) return 0;
 
@@ -183,7 +184,12 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
         WFCLOSE(NULL, file);
         return 0;
     }
-    fileSz = (word32)WFTELL(NULL, file);
+    tmpSz = WFTELL(NULL, file);
+    if (tmpSz < 0) {
+        WFCLOSE(NULL, file);
+        return 0;
+    }
+    fileSz = (word32)tmpSz;
     WREWIND(NULL, file);
 
     if (buf == NULL || fileSz > *bufSz) {

--- a/tests/auth.c
+++ b/tests/auth.c
@@ -179,7 +179,10 @@ static int load_file(const char* fileName, byte* buf, word32* bufSz)
 
     if (WFOPEN(NULL, &file, fileName, "rb") != 0)
         return 0;
-    WFSEEK(NULL, file, 0, WSEEK_END);
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
+        WFCLOSE(NULL, file);
+        return 0;
+    }
     fileSz = (word32)WFTELL(NULL, file);
     WREWIND(NULL, file);
 

--- a/tests/regress.c
+++ b/tests/regress.c
@@ -472,7 +472,10 @@ static word32 LoadFileBuffer(const char* path, byte* buf, word32 bufSz)
     if (WFOPEN(NULL, &file, path, "rb") != 0 || file == WBADFILE) {
         return 0;
     }
-    WFSEEK(NULL, file, 0, WSEEK_END);
+    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
+        WFCLOSE(NULL, file);
+        return 0;
+    }
     fileSz = WFTELL(NULL, file);
     WREWIND(NULL, file);
 

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -124,6 +124,7 @@ extern "C" {
     #define WREWIND(fs,s)       NU_Seek(*(s), 0, PSEEK_SET)
     #define WSEEK_END           PSEEK_END
     #define WBADFILE            NULL
+    #define WFSEEK_SUCCESS(r)   ((int)(r) >= 0)
 
     #define WS_DELIM '\\'
     #define WOLFSSH_O_RDWR   PO_RDWR
@@ -440,6 +441,7 @@ extern "C" {
     #define WSETTIME(fs,f,a,m) (0)
     #define WFSETTIME(fs,fd,a,m) (0)
     #define WCHDIR(fs,b)        SYS_FS_DirectryChange((b))
+    #define WFSEEK_SUCCESS(r)   ((int)(r) >= 0)
 
 #else
     #include <stdlib.h>
@@ -1622,6 +1624,15 @@ extern "C" {
  * 0 when symlinks are not a concern (no-symlink filesystems, opt-out builds). */
 #ifndef WOLFSSH_O_NOFOLLOW
     #define WOLFSSH_O_NOFOLLOW 0
+#endif
+
+/* Catch-all so callers can test a seek result unconditionally.  Ports whose
+ * seek returns the new file position rather than a 0/-1 status define their
+ * own WFSEEK_SUCCESS() in the port block above; see Nucleus and MPLAB
+ * Harmony.  Any definition must evaluate its argument exactly once, as
+ * callers pass the WFSEEK() call in directly. */
+#ifndef WFSEEK_SUCCESS
+    #define WFSEEK_SUCCESS(r)   ((r) == 0)
 #endif
 
 /* wIsSymlink lives in the always-compiled port.c, but its filesystem


### PR DESCRIPTION
Adds on to #1139. Adds `WFSEEK_SUCCESS()` to `wolfssh/port.h`, fixes issue where checking the return value of `WFSEEK()` against 0 may fail erroneously due to Nucleus (`NU_Seek()`) and MPLAB Harmony (`SYS_FS_FileSeek()`) returning the new file position and only signaling failure with a negative value.

Fixed existing checks that misread the return value (already tested the result, but with `!= 0` or `!= -1`):
- `src/ssh.c` — `wolfSSH_ReadKey_file()`
- `src/wolfsftp.c` — resume seek in `wolfSSH_SFTP_Put()`
- `src/port.c` — `wPwrite()` / `wPread()` (Harmony)
- `apps/wolfssh/common.c`, `examples/client/common.c` — `load_der_file()`

Added checks where the result was discarded
- `src/wolfscp.c` — `_GetFileSize()`
- `apps/wolfsshd/wolfsshd.c` — `getBufferFromFile()`
- `examples/echoserver/echoserver.c` and the ESP-IDF copy — `load_file()`, `LoadTpmSshKey()`
- `examples/client/common.c` — `readKeyBlob()`
- `examples/tpmcertserver/tpmcertclient.c` — `TpmCcLoadFile()`
- `tests/auth.c`, `tests/regress.c` — file loaders

`WFTELL()` negative-return guards - can return `-1`, and several callers cast straight to `word32`, turning an error into a 4 GB size
