### PR TITLE
Adopt the certificate loading APIs in the examples and apps

### DIFF
--- a/apps/wolfssh/common.c
+++ b/apps/wolfssh/common.c
@@ -45,7 +45,9 @@ static byte userPublicKeyBuf[512];
 static byte* userPublicKey = userPublicKeyBuf;
 static const byte* userPublicKeyType = NULL;
 static byte userPassword[256];
+#if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
 static const byte* userPrivateKeyType = NULL;
+#endif
 static byte userPublicKeyAlloc = 0;
 static word32 userPublicKeySz = 0;
 static byte pubKeyLoaded = 0; /* was a public key loaded */
@@ -54,18 +56,9 @@ static byte* userPrivateKey = userPrivateKeyBuf;
 static byte userPrivateKeyAlloc = 0;
 static word32 userPublicKeyTypeSz = 0;
 static word32 userPrivateKeySz = sizeof(userPrivateKeyBuf);
+#if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
 static word32 userPrivateKeyTypeSz = 0;
 static byte isPrivate = 0;
-
-
-#ifdef WOLFSSH_CERTS
-#if 0
-/* compiled in for using RSA certificates instead of ECC certificate */
-static const byte publicKeyType[] = "x509v3-ssh-rsa";
-static const byte privateKeyType[] = "ssh-rsa";
-#else
-static const byte publicKeyType[] = "x509v3-ecdsa-sha2-nistp256";
-#endif
 #endif
 
 
@@ -75,10 +68,12 @@ static inline void ato32(const byte* c, word32* u32)
 }
 
 
-static int load_der_file(const char* filename, byte** out, word32* outSz)
+/* Reads the text file filename into a nul terminated buffer, so callers can
+ * treat it as a C string. The caller frees out. Returns 0 on success. */
+static int load_text_file(const char* filename, char** out, word32* outSz)
 {
     WFILE* file;
-    byte* in;
+    char* in;
     long inSz;
     int ret;
 
@@ -101,28 +96,25 @@ static int load_der_file(const char* filename, byte** out, word32* outSz)
         return -1;
     }
 
-    in = (byte*)WMALLOC(inSz, NULL, 0);
+    in = (char*)WMALLOC(inSz + 1, NULL, 0);
     if (in == NULL) {
         WFCLOSE(NULL, file);
         return -1;
     }
 
     ret = (int)WFREAD(NULL, in, 1, inSz, file);
-    if (ret <= 0 || ret != inSz) {
-        ret = -1;
-        WFREE(in, NULL, 0);
-        in = 0;
-        inSz = 0;
-    }
-    else
-        ret = 0;
+    WFCLOSE(NULL, file);
 
+    if (ret <= 0 || (long)ret != inSz) {
+        WFREE(in, NULL, 0);
+        return -1;
+    }
+
+    in[inSz] = '\0';
     *out = in;
     *outSz = (word32)inSz;
 
-    WFCLOSE(NULL, file);
-
-    return ret;
+    return 0;
 }
 
 
@@ -358,7 +350,7 @@ int ClientPublicKeyCheck(const byte* pubKey, word32 pubKeySz, void* ctx)
 
     if (ret == 0) {
         sz = 0;
-        ret = load_der_file(knownHostsName, (byte**)&knownHosts, &sz);
+        ret = load_text_file(knownHostsName, &knownHosts, &sz);
     }
 
     if (ret == 0) {
@@ -370,11 +362,6 @@ int ClientPublicKeyCheck(const byte* pubKey, word32 pubKeySz, void* ctx)
     }
 
     if (ret == 0) {
-        /* load_der_file() loads exactly what's in the file. Since it is
-         * NL terminated lines of known host data, and the last line ends
-         * in a NL, overwrite that with a nul to terminate the new string. */
-        knownHosts[sz - 1] = 0;
-
         encodedKey = (char*)WMALLOC(WOLFSSH_CLIENT_ENCKEY_SIZE_ESTIMATE
                 + WOLFSSH_CLIENT_PUBKEYTYPE_SIZE_ESTIMATE
                 + WOLFSSH_CLIENT_FINGERPRINT_SIZE_ESTIMATE, NULL, 0);
@@ -739,24 +726,30 @@ int ClientSetEcho(int type)
 int ClientUseCert(const char* certName)
 {
     int ret = 0;
+#if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+        !defined(WOLFSSH_USER_FILESYSTEM)
+    byte flavor = WOLFSSH_CERT_FLAVOR_UNKNOWN;
+#endif
 
     if (certName != NULL) {
-    #ifdef WOLFSSH_CERTS
-        ret = load_der_file(certName, &userPublicKey, &userPublicKeySz);
-        if (ret == 0) {
-            userPublicKeyType = publicKeyType;
-            userPublicKeyTypeSz = (word32)WSTRLEN((const char*)publicKeyType);
+    #if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+            !defined(WOLFSSH_USER_FILESYSTEM)
+        /* Form comes from the file, algorithm name from the certificate. */
+        ret = wolfSSH_ReadCert_file(certName, &userPublicKey, &userPublicKeySz,
+                &userPublicKeyType, &userPublicKeyTypeSz, &flavor, NULL);
+        if (ret == WS_SUCCESS) {
             pubKeyLoaded = 1;
             userPublicKeyAlloc = 1;
         }
         else {
+            /* Out params are cleared on failure; restore the static buf. */
             userPublicKey = userPublicKeyBuf;
             userPublicKeySz = 0;
             userPublicKeyType = NULL;
             userPublicKeyAlloc = 0;
         }
     #else
-        fprintf(stderr, "Certificate support not compiled in");
+        fprintf(stderr, "Certificate file support not compiled in\n");
         ret = WS_NOT_COMPILED;
     #endif
     }
@@ -771,6 +764,7 @@ int ClientSetPrivateKey(const char* privKeyName)
 {
     int ret;
 
+#if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
     userPrivateKeyAlloc = 0;
     userPrivateKey = NULL; /* create new buffer based on parsed input */
     ret = wolfSSH_ReadKey_file(privKeyName,
@@ -786,6 +780,11 @@ int ClientSetPrivateKey(const char* privKeyName)
         userPrivateKeySz = sizeof(userPrivateKeyBuf);
         userPrivateKeyType = NULL;
     }
+#else
+    WOLFSSH_UNUSED(privKeyName);
+    fprintf(stderr, "File system not compiled in\n");
+    ret = WS_NOT_COMPILED;
+#endif
 
     return ret;
 }
@@ -797,6 +796,7 @@ int ClientUsePubKey(const char* pubKeyName)
 {
     int ret;
 
+#if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
     userPublicKeyAlloc = 0;
     userPublicKey = NULL; /* create new buffer based on parsed input */
     ret = wolfSSH_ReadKey_file(pubKeyName,
@@ -812,6 +812,11 @@ int ClientUsePubKey(const char* pubKeyName)
         userPublicKey = userPublicKeyBuf;
         userPublicKeySz = 0;
     }
+#else
+    WOLFSSH_UNUSED(pubKeyName);
+    fprintf(stderr, "File system not compiled in\n");
+    ret = WS_NOT_COMPILED;
+#endif
 
     return ret;
 }
@@ -822,22 +827,15 @@ int ClientLoadCA(WOLFSSH_CTX* ctx, const char* caCert)
 
     /* CA certificate to verify host cert with */
     if (caCert) {
-    #ifdef WOLFSSH_CERTS
-        byte* der = NULL;
-        word32 derSz;
-
-        ret = load_der_file(caCert, &der, &derSz);
-        if (ret == 0) {
-            if (wolfSSH_CTX_AddRootCert_buffer(ctx, der, derSz,
-                WOLFSSH_FORMAT_ASN1) != WS_SUCCESS) {
-                fprintf(stderr, "Couldn't parse in CA certificate.");
-                ret = WS_PARSE_E;
-            }
-            WFREE(der, NULL, 0);
+    #if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+            !defined(WOLFSSH_USER_FILESYSTEM)
+        ret = wolfSSH_CTX_AddRootCert_file(ctx, caCert);
+        if (ret != WS_SUCCESS) {
+            fprintf(stderr, "Couldn't parse in CA certificate.\n");
         }
     #else
         WOLFSSH_UNUSED(ctx);
-        fprintf(stderr, "Support for certificates not compiled in.");
+        fprintf(stderr, "Support for certificate files not compiled in.\n");
         ret = WS_NOT_COMPILED;
     #endif
     }

--- a/apps/wolfsshd/wolfsshd.c
+++ b/apps/wolfsshd/wolfsshd.c
@@ -484,12 +484,18 @@ static int SetupCTX(WOLFSSHD_CONFIG* conf, WOLFSSH_CTX** ctx,
 
 #if defined(WOLFSSH_OSSH_CERTS) || defined(WOLFSSH_CERTS)
     if (ret == WS_SUCCESS) {
-        /* TODO: Create a helper function that uses a file instead. */
         char* hostCert = wolfSSHD_ConfigGetHostCertFile(conf);
 
         if (hostCert != NULL) {
             byte*  data;
             word32 dataSz = 0;
+        #ifdef WOLFSSH_CERTS
+            byte* der = NULL;
+            word32 derSz = 0;
+            const byte* type = NULL;
+            word32 typeSz = 0;
+            byte flavor = WOLFSSH_CERT_FLAVOR_UNKNOWN;
+        #endif
 
             data = getBufferFromFile(hostCert, &dataSz, heap,
                 WOLFSSHD_LOAD_TRUST);
@@ -503,15 +509,31 @@ static int SetupCTX(WOLFSSHD_CONFIG* conf, WOLFSSH_CTX** ctx,
 
             if (ret == WS_SUCCESS) {
             #ifdef WOLFSSH_CERTS
-                ret = wolfSSH_CTX_UseCert_buffer(*ctx, data, dataSz,
-                    WOLFSSH_FORMAT_PEM);
-                if (ret != WS_SUCCESS) {
-                    ret = wolfSSH_CTX_UseCert_buffer(*ctx, data, dataSz,
-                        WOLFSSH_FORMAT_ASN1);
-                }
-                if (ret != WS_SUCCESS) {
+                if (dataSz == 0) {
                     wolfSSH_Log(WS_LOG_ERROR,
-                        "[SSHD] Failed to load in host certificate.");
+                        "[SSHD] Host certificate file %s is empty.", hostCert);
+                    ret = WS_BAD_FILE_E;
+                }
+                else {
+                    /* Already read through the secure gate, so not _file. */
+                    ret = wolfSSH_ReadCert_buffer(data, dataSz, &der, &derSz,
+                        &type, &typeSz, &flavor, heap);
+                    if (ret == WS_SUCCESS
+                            && flavor != WOLFSSH_CERT_FLAVOR_X509) {
+                        /* Verifying OpenSSH host certs is unimplemented. */
+                        ret = WS_UNIMPLEMENTED_E;
+                    }
+                    if (ret == WS_SUCCESS) {
+                        ret = wolfSSH_CTX_UseCert_buffer(*ctx, der, derSz,
+                            WOLFSSH_FORMAT_ASN1);
+                    }
+                    if (ret != WS_SUCCESS) {
+                        wolfSSH_Log(WS_LOG_ERROR,
+                            "[SSHD] Failed to load in host certificate.");
+                    }
+                    if (der != NULL) {
+                        WFREE(der, heap, DYNTYPE_CERT);
+                    }
                 }
             #else
                 /* Only OpenSSH host certificates could apply here, and they are
@@ -535,7 +557,6 @@ static int SetupCTX(WOLFSSHD_CONFIG* conf, WOLFSSH_CTX** ctx,
             byte*  data;
             word32 dataSz = 0;
 
-
             wolfSSH_Log(WS_LOG_INFO, "[SSHD] Using CA keys file %s", caCert);
             data = getBufferFromFile(caCert, &dataSz, heap,
                 WOLFSSHD_LOAD_TRUST);
@@ -547,7 +568,15 @@ static int SetupCTX(WOLFSSHD_CONFIG* conf, WOLFSSH_CTX** ctx,
 
             }
 
-            if (ret == WS_SUCCESS) {
+            if (ret == WS_SUCCESS && dataSz == 0) {
+                /* Empty means misconfigured, not a CA in another format. */
+                wolfSSH_Log(WS_LOG_ERROR, "[SSHD] CA keys file %s is empty.",
+                    caCert);
+                ret = WS_BAD_FILE_E;
+                freeBufferFromFile(data, heap);
+            }
+            else if (ret == WS_SUCCESS) {
+                /* A CA is never named on the wire, so it takes raw bytes. */
                 ret = wolfSSH_CTX_AddRootCert_buffer(*ctx, data, dataSz,
                     WOLFSSH_FORMAT_PEM);
                 if (ret != WS_SUCCESS) {

--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -102,17 +102,6 @@ static void ClientFreeKeyboardResponses(void)
 }
 #endif
 
-#ifdef WOLFSSH_CERTS
-#if 0
-/* compiled in for using RSA certificates instead of ECC certificate */
-static const byte publicKeyType[] = "x509v3-ssh-rsa";
-static const byte privateKeyType[] = "ssh-rsa";
-#else
-static const byte publicKeyType[] = "x509v3-ecdsa-sha2-nistp256";
-#endif
-#endif
-
-
 #ifdef WOLFSSH_TPM
     WOLFTPM2_DEV tpmDev;
     WOLFTPM2_KEY tpmKey;
@@ -288,57 +277,6 @@ static const unsigned int hanselPrivateEccSz = 223;
 
 
 #if defined(WOLFSSH_CERTS)
-
-static int load_der_file(const char* filename, byte** out, word32* outSz,
-        void* heap)
-{
-    WFILE* file;
-    byte* in;
-    long inSz;
-    int ret;
-
-    if (filename == NULL || out == NULL || outSz == NULL)
-        return -1;
-
-    ret = WFOPEN(NULL, &file, filename, "rb");
-    if (ret != 0 || file == WBADFILE)
-        return -1;
-
-    if (!WFSEEK_SUCCESS(WFSEEK(NULL, file, 0, WSEEK_END))) {
-        WFCLOSE(NULL, file);
-        return -1;
-    }
-    inSz = WFTELL(NULL, file);
-    if (inSz <= 0) {
-        WFCLOSE(NULL, file);
-        return -1;
-    }
-    WREWIND(NULL, file);
-
-    in = (byte*)WMALLOC(inSz, heap, DYNTYPE_PRIVKEY);
-    if (in == NULL) {
-        WFCLOSE(NULL, file);
-        return -1;
-    }
-
-    ret = (int)WFREAD(NULL, in, 1, inSz, file);
-    if (ret <= 0 || ret != inSz) {
-        ret = -1;
-        WFREE(in, heap, DYNTYPE_PRIVKEY);
-        in = 0;
-        inSz = 0;
-    }
-    else
-        ret = 0;
-
-    *out = in;
-    *outSz = (word32)inSz;
-
-    WFCLOSE(NULL, file);
-
-    return ret;
-}
-
 
 #if (defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME))
 static inline void ato32(const byte* c, word32* u32)
@@ -801,19 +739,23 @@ int ClientSetEcho(int type)
 int ClientUseCert(const char* certName, void* heap)
 {
     int ret = 0;
+#if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+        !defined(WOLFSSH_USER_FILESYSTEM)
+    byte flavor = WOLFSSH_CERT_FLAVOR_UNKNOWN;
+#endif
 
     if (certName != NULL) {
-    #ifdef WOLFSSH_CERTS
-        ret = load_der_file(certName, &userPublicKey, &userPublicKeySz, heap);
-        if (ret == 0) {
-            userPublicKeyType = publicKeyType;
-            userPublicKeyTypeSz = (word32)WSTRLEN((const char*)publicKeyType);
+    #if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+            !defined(WOLFSSH_USER_FILESYSTEM)
+        /* Form comes from the file, algorithm name from the certificate. */
+        ret = wolfSSH_ReadCert_file(certName, &userPublicKey, &userPublicKeySz,
+                &userPublicKeyType, &userPublicKeyTypeSz, &flavor, heap);
+        if (ret == WS_SUCCESS) {
             pubKeyLoaded = 1;
             userPublicKeyAlloc = 1;
         }
         else {
-            /* Defensive: load_der_file() clears its output pointer on the
-             * short-read failure, so put the static buffer back. */
+            /* Out params are cleared on failure; restore the static buf. */
             userPublicKey = userPublicKeyBuf;
             userPublicKeySz = 0;
             userPublicKeyType = NULL;
@@ -821,7 +763,7 @@ int ClientUseCert(const char* certName, void* heap)
         }
     #else
         (void)heap;
-        fprintf(stderr, "Certificate support not compiled in");
+        fprintf(stderr, "Certificate file support not compiled in\n");
         ret = WS_NOT_COMPILED;
     #endif
     }
@@ -1099,7 +1041,7 @@ int ClientSetPrivateKey(const char* privKeyName, int userEcc,
         WMEMSET(&tpmKey, 0, sizeof(tpmKey));
         ret = wolfSSH_TPM_InitKey(&tpmDev, privKeyName, &tpmKey, tpmKeyAuth,
                 heap);
-    #elif !defined(NO_FILESYSTEM)
+    #elif !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
         userPrivateKey = NULL; /* create new buffer based on parsed input */
         userPrivateKeyAlloc = 1;
         userPrivateKeySz = sizeof(userPrivateKeyBuf);
@@ -1145,7 +1087,7 @@ int ClientUsePubKey(const char* pubKeyName, int userEcc, void* heap)
         isPrivate = 1;
     }
     else {
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)
         userPublicKey = NULL; /* create new buffer based on parsed input */
         ret = wolfSSH_ReadKey_file(pubKeyName,
                 &userPublicKey, &userPublicKeySz,
@@ -1154,7 +1096,7 @@ int ClientUsePubKey(const char* pubKeyName, int userEcc, void* heap)
     #else
         printf("file system not compiled in!\n");
         ret = NOT_COMPILED_IN;
-    #endif /* NO_FILESYSTEM */
+    #endif /* !NO_FILESYSTEM && !WOLFSSH_USER_FILESYSTEM */
         if (ret == 0) {
             pubKeyLoaded = 1;
             userPublicKeyAlloc = 1;
@@ -1176,22 +1118,15 @@ int ClientLoadCA(WOLFSSH_CTX* ctx, const char* caCert)
 
     /* CA certificate to verify host cert with */
     if (caCert) {
-    #ifdef WOLFSSH_CERTS
-        byte* der = NULL;
-        word32 derSz;
-
-        ret = load_der_file(caCert, &der, &derSz, ctx->heap);
-        if (ret == 0) {
-            if (wolfSSH_CTX_AddRootCert_buffer(ctx, der, derSz,
-                WOLFSSH_FORMAT_ASN1) != WS_SUCCESS) {
-                fprintf(stderr, "Couldn't parse in CA certificate.");
-                ret = WS_PARSE_E;
-            }
-            WFREE(der, ctx->heap, DYNTYPE_PRIVKEY);
+    #if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+            !defined(WOLFSSH_USER_FILESYSTEM)
+        ret = wolfSSH_CTX_AddRootCert_file(ctx, caCert);
+        if (ret != WS_SUCCESS) {
+            fprintf(stderr, "Couldn't parse in CA certificate.\n");
         }
     #else
         (void)ctx;
-        fprintf(stderr, "Support for certificates not compiled in.");
+        fprintf(stderr, "Support for certificate files not compiled in.\n");
         ret = WS_NOT_COMPILED;
     #endif
     }

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -2475,23 +2475,26 @@ static int LoadPubKeyList(StrList* strList, int format, PwMapList* mapList)
                     (void)typeSz;
                 }
                 else if (format == WOLFSSH_FORMAT_PEM) {
-                    out = (byte*)WMALLOC(bufSz, NULL, 0);
-                    if (out == NULL) {
-                        fprintf(stderr, "Memory error: %s\n", fileName);
+                #ifdef WOLFSSH_CERTS
+                    const byte* type = NULL;
+                    word32 typeSz = 0;
+                    byte flavor = WOLFSSH_CERT_FLAVOR_UNKNOWN;
+
+                    if (wolfSSH_ReadCert_buffer(buf, bufSz, &out, &outSz,
+                                &type, &typeSz, &flavor, NULL) != WS_SUCCESS) {
+                        fprintf(stderr, "Cert error: %s\n", fileName);
                         ok = 0;
                     }
-                    else {
-                        int rc = wc_CertPemToDer(buf, bufSz, out, bufSz,
-                                CERT_TYPE);
 
-                        if (rc <= 0) {
-                            fprintf(stderr, "PEM error: %s\n", fileName);
-                            ok = 0;
-                        }
-                        else {
-                            outSz = (word32)rc;
-                        }
-                    }
+                    (void)type;
+                    (void)typeSz;
+                    (void)flavor;
+                #else
+                    fprintf(stderr,
+                            "Certificate support not compiled in: %s\n",
+                            fileName);
+                    ok = 0;
+                #endif
                 }
 
                 if (ok) {
@@ -3092,7 +3095,8 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
     #ifndef NO_FILESYSTEM
         char* userPubKey = NULL;
     #endif
-    #ifdef WOLFSSH_CERTS
+    #if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+            !defined(WOLFSSH_USER_FILESYSTEM)
         char* caCert = NULL;
     #endif
 
@@ -3118,7 +3122,8 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
                     break;
 
                 case 'a':
-                    #ifdef WOLFSSH_CERTS
+                    #if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+                            !defined(WOLFSSH_USER_FILESYSTEM)
                         caCert = myoptarg;
                     #endif
                     break;
@@ -3585,42 +3590,17 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
         }
         #endif
 
-        #ifdef WOLFSSH_CERTS
+        #if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+                !defined(WOLFSSH_USER_FILESYSTEM)
         if (caCert) {
-            byte* certBuf = NULL;
-            word32 certBufSz = 0;
-            int ret = 0;
-
-            load_file(caCert, NULL, &certBufSz);
-
-            if (certBufSz == 0) {
+            /* PEM or DER is detected from the file's content. */
+            if (wolfSSH_CTX_AddRootCert_file(ctx, caCert) != WS_SUCCESS) {
                 #ifdef WOLFSSH_SMALL_STACK
                 wc_ForceZero(keyLoadBuf, EXAMPLE_KEYLOAD_BUFFER_SZ);
                 WFREE(keyLoadBuf, NULL, 0);
                 #endif
-                ES_ERROR("Couldn't find size of file %s.\n", caCert);
-            }
-
-            certBuf = (byte*)WMALLOC(certBufSz, NULL, 0);
-            if (certBuf == NULL) {
-                #ifdef WOLFSSH_SMALL_STACK
-                wc_ForceZero(keyLoadBuf, EXAMPLE_KEYLOAD_BUFFER_SZ);
-                WFREE(keyLoadBuf, NULL, 0);
-                #endif
-                ES_ERROR("WMALLOC failed\n");
-            }
-            load_file(caCert, certBuf, &certBufSz);
-            ret = wolfSSH_CTX_AddRootCert_buffer(ctx, certBuf, certBufSz,
-                    WOLFSSH_FORMAT_PEM);
-            if (ret != 0) {
-                #ifdef WOLFSSH_SMALL_STACK
-                wc_ForceZero(keyLoadBuf, EXAMPLE_KEYLOAD_BUFFER_SZ);
-                WFREE(keyLoadBuf, NULL, 0);
-                #endif
-                WFREE(certBuf, NULL, 0);
                 ES_ERROR("Couldn't add root cert\n");
             }
-            WFREE(certBuf, NULL, 0);
         }
         #endif
 

--- a/examples/tpmcertserver/tpmcertclient.c
+++ b/examples/tpmcertserver/tpmcertclient.c
@@ -27,7 +27,8 @@
 #include <wolfssh/ssh.h>
 #include <wolfssh/test.h>
 
-#ifdef WOLFSSH_CERTS
+#if defined(WOLFSSH_CERTS) && !defined(NO_FILESYSTEM) && \
+        !defined(WOLFSSH_USER_FILESYSTEM)
 
 #include <stdio.h>
 #include <string.h>
@@ -54,7 +55,7 @@ static int TpmCcUserAuth(byte authType, WS_UserAuthData* authData, void* ctx)
 
 
 /* Host key acceptance callback. wolfSSH verifies the server's X.509 certificate
- * chain against the root CA loaded with wolfSSH_CTX_AddRootCert_buffer() later,
+ * chain against the root CA loaded with wolfSSH_CTX_AddRootCert_file() later,
  * during the key exchange, when it extracts the public key from the certificate.
  * Because the client only accepts x509v3 host key algorithms, that CA
  * verification is always performed. This callback just accepts the presented
@@ -65,44 +66,6 @@ static int TpmCcHostKeyCheck(const byte* pubKey, word32 pubKeySz, void* ctx)
     WOLFSSH_UNUSED(pubKeySz);
     WOLFSSH_UNUSED(ctx);
     return 0;
-}
-
-
-static int TpmCcLoadFile(const char* file, byte* buf, word32* bufSz)
-{
-    int ret = 0;
-    WFILE* f;
-    word32 fileSz = 0;
-    word32 readSz;
-
-    if (WFOPEN(NULL, &f, file, "rb") != 0) {
-        ret = -1;
-    }
-    else {
-        if (!WFSEEK_SUCCESS(WFSEEK(NULL, f, 0, WSEEK_END))) {
-            ret = -1;
-        }
-        else {
-            fileSz = (word32)WFTELL(NULL, f);
-            WREWIND(NULL, f);
-        }
-
-        if (ret != 0 || fileSz == 0 || fileSz > *bufSz) {
-            ret = -1;
-        }
-        else {
-            readSz = (word32)WFREAD(NULL, buf, 1, fileSz, f);
-            if (readSz != fileSz) {
-                ret = -1;
-            }
-            else {
-                *bufSz = fileSz;
-            }
-        }
-        WFCLOSE(NULL, f);
-    }
-
-    return ret;
 }
 
 
@@ -117,8 +80,6 @@ int main(int argc, char* argv[])
     WOLFSSH* ssh = NULL;
     WS_SOCKET_T sockFd = WOLFSSH_SOCKET_INVALID;
     SOCKADDR_IN_T addr;
-    byte caDer[2048];
-    word32 caDerSz = (word32)sizeof(caDer);
     byte txt[] = "hello from tpmcertclient\n";
     byte rxBuf[TPMCC_BUF_SZ];
 
@@ -132,11 +93,6 @@ int main(int argc, char* argv[])
             host = argv[++i];
         else if (XSTRCMP(argv[i], "-A") == 0 && i + 1 < argc)
             caFile = argv[++i];
-    }
-
-    if (TpmCcLoadFile(caFile, caDer, &caDerSz) != 0) {
-        fprintf(stderr, "Could not read CA file %s\n", caFile);
-        return 1;
     }
 
 #ifdef DEBUG_WOLFSSH
@@ -167,9 +123,9 @@ int main(int argc, char* argv[])
     }
 
     if (ret == 0) {
-        if (wolfSSH_CTX_AddRootCert_buffer(ctx, caDer, caDerSz,
-                WOLFSSH_FORMAT_ASN1) != WS_SUCCESS) {
-            fprintf(stderr, "Could not load root CA certificate\n");
+        /* PEM or DER is detected from the file's content. */
+        if (wolfSSH_CTX_AddRootCert_file(ctx, caFile) != WS_SUCCESS) {
+            fprintf(stderr, "Could not load root CA certificate %s\n", caFile);
             ret = -1;
         }
     }
@@ -251,12 +207,13 @@ int main(int argc, char* argv[])
     return (ret == 0) ? 0 : 1;
 }
 
-#else /* !WOLFSSH_CERTS */
+#else /* !WOLFSSH_CERTS || no file system */
 
 int main(void)
 {
-    printf("This example requires wolfSSH built with --enable-certs.\n");
+    printf("This example requires wolfSSH built with --enable-certs and a "
+           "file system.\n");
     return 0;
 }
 
-#endif /* WOLFSSH_CERTS */
+#endif /* WOLFSSH_CERTS && !NO_FILESYSTEM && !WOLFSSH_USER_FILESYSTEM */


### PR DESCRIPTION
### Problem
Each example and app hand-rolled its own certificate file loading: `apps/wolfssh/common.c` and `examples/client/common.c` had a `load_der_file()`, `examples/tpmcertserver` had `TpmCcLoadFile()`, echoserver used `load_file()`. All were DER-only and none detected the file's format. The client's public-key algorithm name was also a compile-time constant:

```c
static const byte publicKeyType[] = "x509v3-ecdsa-sha2-nistp256";
```

so using an RSA certificate meant flipping an `#if 0` block and rebuilding.

### Fix
`wolfSSH_ReadCert_file()` and `wolfSSH_CTX_AddRootCert_file()` (already on master) replace the local readers. PEM or DER is detected from the file's content, and the algorithm name sent on the wire comes from the certificate rather than a build flag.

| File | Change |
|---|---|
| `apps/wolfssh/common.c` | `load_der_file()` → `wolfSSH_ReadCert_file()`; drops hardcoded `publicKeyType` |
| `examples/client/common.c` | same, plus `ClientLoadCA()` → `wolfSSH_CTX_AddRootCert_file()` |
| `examples/echoserver/echoserver.c` | root CA via `_file`; `-J` PEM list via `wolfSSH_ReadCert_buffer()` |
| `examples/tpmcertserver/tpmcertclient.c` | drops `TpmCcLoadFile()` |
| `apps/wolfsshd/wolfsshd.c` | keeps the `_buffer` API — see below |

**wolfsshd deliberately keeps `_buffer`.** Its files are read through the `getBufferFromFile()` trust gate, which the `_file` helpers would bypass. It gains explicit handling instead: an empty `HostCertificate` or `TrustedUserCAKeys` file is rejected rather than silently retried as another format, and an OpenSSH-flavored host certificate returns `WS_UNIMPLEMENTED_E` instead of being reported as loaded.

**Build matrix.** The cert `_file` call sites in the client and echoserver now carry the same `!NO_FILESYSTEM && !WOLFSSH_USER_FILESYSTEM` guard their declarations have in `ssh.h`; two adjacent `wolfSSH_ReadKey_file()` guards were widened to match. echoserver's `-J` list now requires `WOLFSSH_CERTS` — it is documented as loading an X.509 PEM cert, which is unusable without it.

Net 240 lines removed, 151 added.

### Verification
- Clean under `-Werror` across 6 gcc-13 configs (enable-all, sftp-only, scp-only, zephyr, small-stack, default).
- `make check`: 11 passed, 1 skipped (external), 0 failed.
- Guard probes with negative controls: `WOLFSSH_CERTS` with `NO_FILESYSTEM`, and with `WOLFSSH_USER_FILESYSTEM`, both fail before the guards and are clean after.