### PR TITLE
Enforce null termination in sshd unit tests

### DIFF
--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -465,6 +465,8 @@ static void AddShadowLineToFakeHashCache(char* line)
                 if (!duplicate) {
                     XSTRNCPY(cachedFakeHashes[numCachedFakeHashes], tmpl,
                         sizeof(cachedFakeHashes[0]));
+                    cachedFakeHashes[numCachedFakeHashes][
+                        sizeof(cachedFakeHashes[0]) - 1] = '\0';
                     numCachedFakeHashes++;
                 }
             }
@@ -562,6 +564,7 @@ void wolfSSHD_AuthInit(void)
             GetFakeHashFromTemplate(rootShadow->sp_pwdp, tmpl, sizeof(tmpl));
             if (tmpl[0] != '\0' && tmpl[1] != '\0' && tmpl[1] != '*') {
                 XSTRNCPY(cachedFakeHashes[0], tmpl, sizeof(cachedFakeHashes[0]));
+                cachedFakeHashes[0][sizeof(cachedFakeHashes[0]) - 1] = '\0';
                 numCachedFakeHashes = 1;
             }
         }


### PR DESCRIPTION
Fixes Coverity Scan issues from 2026-08-09
