### PR TITLE
Run the API tests in the TPM CI job

### DIFF
--- a/.github/workflows/tpm-ssh.yml
+++ b/.github/workflows/tpm-ssh.yml
@@ -115,6 +115,25 @@ jobs:
         sudo make install
         sudo ldconfig
 
+    # Builds every check_PROGRAM -- no other job compiles wolfSSH's tests
+    # with TPM support -- but runs only api.test, the one suite with TPM
+    # tests. One cell: these tests ignore the simulator and host key.
+    - name: Run API tests
+      if: matrix.keytype == 'ecc' && matrix.sim == 'ibmswtpm2' && matrix.hostkey == 'raw'
+      run: |
+        cd wolfssh
+        # A non-TPM build compiles every TPM-guarded test out, silently.
+        if ! grep -q '^AM_CPPFLAGS = .*-DWOLFSSH_TPM' Makefile; then
+            echo "Not a TPM build; the TPM-guarded tests would compile out."
+            grep '^AM_CPPFLAGS' Makefile
+            exit 1
+        fi
+        make check TESTS=tests/api.test
+
+    - name: Show API test log on failure
+      if: failure() && (matrix.keytype == 'ecc' && matrix.sim == 'ibmswtpm2' && matrix.hostkey == 'raw')
+      run: cat wolfssh/tests/api.log || true
+
     # Server host key resident in the TPM: the private key never enters RAM.
     - name: Test TPM host key (${{ matrix.keytype }})
       if: matrix.hostkey == 'raw'
@@ -222,3 +241,4 @@ jobs:
           wolfssh/tpmcert_client.txt
           wolfssh/tpmcert_server_neg.txt
           wolfssh/tpmcert_client_neg.txt
+          wolfssh/tests/api.log


### PR DESCRIPTION
### Problem
No CI job compiles a wolfSSH **test binary** with `WOLFSSH_TPM` defined, so any test guarded on it silently compiles out everywhere and cannot gate a merge.

| Workflow | `--enable-tpm` | runs `make check` |
|---|---|---|
| `tpm-ssh.yml` | yes | no — only `make` + `make install` |
| `sanitizer.yml` | no (`--enable-all` excludes TPM) | yes |
| all others | no | mostly no |

The intersection is empty. Found while writing #1164, whose regression test is unreachable by CI for exactly this reason.

### Fix (`.github/workflows/tpm-ssh.yml`)
Adds a `make check TESTS=tests/api.test` step after `Build wolfSSH`:

- **All five `check_PROGRAM`s still compile** — `check-am` builds them regardless of the `TESTS` override. That is the point: this is the only job compiling wolfSSH's tests with TPM support.
- **Only `api.test` runs.** It holds the only TPM-specific tests in the tree: `grep -i tpm` finds 28 hits in `tests/api.c` and zero in the other five test sources.
- **Gated to one matrix cell** (`ecc` / `ibmswtpm2` / `raw`). The 2×2×2 matrix varies the simulator and the host key, neither of which these tests touch.
- **A build-config assertion precedes the run.** A build without `-DWOLFSSH_TPM` compiles the guarded tests out and still exits 0, a hollow pass. The step greps `AM_CPPFLAGS` for the define, prints what it found, and aborts if absent.
- `tests/api.log` is dumped on failure and added to the archived artifacts.

### Verification
Against a scratch prefix reproducing CI's library layout (wolfSSL with this job's exact flags, wolfTPM rebuilt against it):

- `PASS: tests/api.test`, and all five test binaries compile under `--enable-tpm --enable-certs`.
- **Negative control:** reconfigured without `--enable-tpm`, the guard fails and the step aborts.
- **Why the others are not run:** `unit.test` and `regress.test` give byte-identical output with and without the define (diffed); `testsuite.test` exits 0 having executed nothing, its body being entirely `#ifdef WOLFSSH_SHELL`/`WOLFSSH_SFTP`; `kex.test` fails; `auth.test` is not built.
- Workflow-YAML only, no C touched, so no sanitizer or preflight run.

### Not in this PR
`kex.test` fails because the example client aborts with *"You must specify a password for the TPM key"*. Two separate defects sit behind that:

- **The `-K` guard is too broad.** The client aborts whenever `tpmKeyAuth == NULL` in a TPM build, but `kex.test` passes no `-i`, so `ClientSetPrivateKey()` takes the built-in key-buffer path where `tpmKeyAuth` is unused. Fixing only this would let `kex.test` run on a software key, adding no TPM coverage.
- **A key *file* is unusable in a TPM build.** The `#elif` in `ClientSetPrivateKey()` routes every `-i` through `wolfSSH_TPM_InitKey()`, leaving no path to `wolfSSH_ReadKey_file()`.

Both point at the same gap: nothing anywhere exercises a client user-auth key held in the TPM. That deserves a purpose-built test rather than a retrofit of the KEX sweep, so it is left for a follow-up.
