### PR TITLE
Stop wPread and wPwrite dropping the high offset word

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -71,6 +71,7 @@ jobs:
         config: [
           '',
           '--enable-all',
+          '--enable-all CFLAGS=-DWOLFSSH_LOCAL_PREAD_PWRITE',
           '--enable-all --enable-ossh-certs',
           '--enable-sftp',
           '--enable-sftp --disable-sftp-zeroize',

--- a/src/port.c
+++ b/src/port.c
@@ -156,11 +156,14 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
         int wPwrite(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)
         {
-            int ret;
+            word64 offset;
+            int ret = -1;
 
-            ret = (int)lseek(fd, shortOffset[0], SEEK_SET);
-            if (ret != -1)
-                ret = (int)write(fd, buf, sz);
+            if (wResolveOffset(shortOffset, WOLFSSH_MAX_FILE_OFFSET,
+                        &offset) == 0) {
+                if (lseek(fd, (off_t)offset, SEEK_SET) != (off_t)-1)
+                    ret = (int)write(fd, buf, sz);
+            }
 
             return ret;
         }
@@ -168,11 +171,14 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
         int wPread(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)
         {
-            int ret;
+            word64 offset;
+            int ret = -1;
 
-            ret = (int)lseek(fd, shortOffset[0], SEEK_SET);
-            if (ret != -1)
-                ret = (int)read(fd, buf, sz);
+            if (wResolveOffset(shortOffset, WOLFSSH_MAX_FILE_OFFSET,
+                        &offset) == 0) {
+                if (lseek(fd, (off_t)offset, SEEK_SET) != (off_t)-1)
+                    ret = (int)read(fd, buf, sz);
+            }
 
             return ret;
         }
@@ -182,24 +188,26 @@ int wfopen(WFILE** f, const char* filename, const char* mode)
         int wPwrite(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)
         {
-            off_t offset = (off_t)shortOffset[0];
+            word64 offset;
 
-        #if SIZEOF_OFF_T == 8
-            offset = ((off_t)shortOffset[1] << 32) | offset;
-        #endif
-            return (int)pwrite(fd, buf, sz, offset);
+            if (wResolveOffset(shortOffset, WOLFSSH_MAX_FILE_OFFSET,
+                        &offset) != 0)
+                return -1;
+
+            return (int)pwrite(fd, buf, sz, (off_t)offset);
         }
 
 
         int wPread(WFD fd, unsigned char* buf, unsigned int sz,
                 const unsigned int* shortOffset)
         {
-            off_t offset = (off_t)shortOffset[0];
+            word64 offset;
 
-        #if SIZEOF_OFF_T == 8
-            offset = ((off_t)shortOffset[1] << 32) | offset;
-        #endif
-            return (int)pread(fd, buf, sz, offset);
+            if (wResolveOffset(shortOffset, WOLFSSH_MAX_FILE_OFFSET,
+                        &offset) != 0)
+                return -1;
+
+            return (int)pread(fd, buf, sz, (off_t)offset);
         }
 
     #endif /* USE_WINDOWS_API USE_OSE_API */

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -79,6 +79,21 @@
 #include <unistd.h>
 #endif
 
+/* Needs a server build that does file transfers and an off_t wide enough for
+ * a 4 GiB offset. A narrower one takes a reject path no 64-bit build hits. */
+#if !defined(NO_FILESYSTEM) && !defined(USE_WINDOWS_API) && \
+    !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSH_ZEPHYR) && \
+    !defined(FREESCALE_MQX) && !defined(MICROCHIP_MPLAB_HARMONY) && \
+    !defined(WOLFSSH_USER_FILESYSTEM) && !defined(WOLFSSH_FATFS) && \
+    (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
+    !defined(NO_WOLFSSH_SERVER) && defined(SIZEOF_OFF_T) && SIZEOF_OFF_T == 8
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#define WOLFSSH_TEST_PREAD_PWRITE
+#endif
+
 /* SendChannelTerminalRequest() reads the terminal settings of stdin, so the
  * no-tty case needs POSIX file descriptors to point stdin at /dev/null. */
 #if defined(WOLFSSH_TEST_INTERNAL) && defined(WOLFSSH_TERM) && \
@@ -15617,6 +15632,92 @@ static int test_SftpGetHandle_sizeBound(void)
 }
 #endif /* WOLFSSH_SFTP && WOLFSSH_TEST_INTERNAL */
 
+
+#ifdef WOLFSSH_TEST_PREAD_PWRITE
+/* The offset arrives as two 32-bit words, low first, so 4 GiB and up lives
+ * only in the high word. WOLFSSH_LOCAL_PREAD_PWRITE covers the lseek port. */
+static int test_PreadPwriteHighOffset(void)
+{
+    static const char nameTemplate[] = "/wolfssh_pofstXXXXXX";
+    const char* tmpDir;
+    char tmpFile[256];
+    unsigned char buf[8];
+    unsigned int shortOffset[2];
+    struct stat st;
+    int result = 0;
+    int skipped = 0;
+    int fd;
+    int ret;
+
+    shortOffset[0] = 0;
+    shortOffset[1] = 1; /* offset of exactly 4 GiB */
+
+    /* Honor TMPDIR for the scratch file, falling back to /tmp. This test can
+     * leave a 4 GiB sparse file behind. */
+    tmpDir = getenv("TMPDIR");
+    if (tmpDir == NULL || tmpDir[0] == '\0') {
+        tmpDir = "/tmp";
+    }
+    /* WSNPRINTF truncates instead of failing, so bound the directory first */
+    if (WSTRLEN(tmpDir) + sizeof(nameTemplate) > sizeof(tmpFile)) {
+        tmpDir = "/tmp";
+    }
+    WSNPRINTF(tmpFile, sizeof(tmpFile), "%s%s", tmpDir, nameTemplate);
+
+    fd = mkstemp(tmpFile);
+    if (fd == -1)
+        return -935;
+
+    if (write(fd, "0123456789ABCDEF", 16) != 16)
+        result = -936;
+
+    /* A port that drops the high word rereads the file start, not EOF. */
+    if (result == 0) {
+        WMEMSET(buf, 0, sizeof(buf));
+        ret = wPread(fd, buf, (unsigned int)sizeof(buf), shortOffset);
+        if (ret != 0)
+            result = -937;
+    }
+
+    /* Extending past 4 GiB needs holes left unallocated, so probe with a
+     * 1 MiB one. A probe that cannot write at all is a broken environment. */
+    if (result == 0) {
+        if (lseek(fd, (off_t)1 << 20, SEEK_SET) == (off_t)-1
+                || write(fd, "Z", 1) != 1 || fstat(fd, &st) != 0)
+            result = -941;
+        else if ((off_t)st.st_blocks * 512 > (off_t)1 << 19)
+            skipped = 1;
+    }
+
+    /* Only a size cap may skip this. The high word guard returns -1 without
+     * touching errno, so a rejected valid offset lands on the failure. */
+    if (result == 0 && !skipped) {
+        errno = 0;
+        ret = wPwrite(fd, (unsigned char*)"Z", 1, shortOffset);
+        if (ret < 0 && (errno == EFBIG || errno == ENOSPC))
+            skipped = 1;
+        else if (ret != 1)
+            result = -938;
+    }
+
+    if (result == 0 && !skipped) {
+        if (fstat(fd, &st) != 0)
+            result = -939;
+        else if (st.st_size != (((off_t)1 << 32) + 1))
+            result = -940;
+    }
+
+    close(fd);
+    (void)remove(tmpFile);
+
+    if (skipped)
+        printf("(large file write unsupported, read half only) ");
+
+    return result;
+}
+#endif /* WOLFSSH_TEST_PREAD_PWRITE */
+
+
 int wolfSSH_UnitTest(int argc, char** argv)
 {
     int testResult = 0, unitResult = 0;
@@ -16253,6 +16354,13 @@ int wolfSSH_UnitTest(int argc, char** argv)
     printf("OpenSshPemNegative: %s\n",
             (unitResult == 0 ? "SUCCESS" : "FAILED"));
     testResult = testResult || unitResult;
+
+#ifdef WOLFSSH_TEST_PREAD_PWRITE
+    unitResult = test_PreadPwriteHighOffset();
+    printf("PreadPwriteHighOffset: %s\n",
+            (unitResult == 0 ? "SUCCESS" : "FAILED"));
+    testResult = testResult || unitResult;
+#endif
 #ifndef WOLFSSH_NO_ECDSA_SHA2_NISTP256
     unitResult = test_OpenSshFormatNonCompositeRejected();
     printf("OpenSshFormatNonCompositeRejected: %s\n",

--- a/wolfssh/port.h
+++ b/wolfssh/port.h
@@ -717,6 +717,23 @@ extern "C" {
         #endif
     #endif
 
+    /* Assemble the two words of a split file offset into one value */
+    static inline int wResolveOffset(const unsigned int* shortOffset,
+            word64 maxOffset, word64* offset)
+    {
+        word64 combined;
+
+        if (shortOffset == NULL || offset == NULL)
+            return -1;
+
+        combined = ((word64)shortOffset[1] << 32) | (word64)shortOffset[0];
+        if (combined > maxOffset)
+            return -1;
+
+        *offset = combined;
+        return 0;
+    }
+
 #if defined(WOLFSSH_USER_FILESYSTEM)
     /* User-defined I/O support, this should be at the top of the ports list
      * to override all */
@@ -1579,6 +1596,17 @@ extern "C" {
     #define WREWINDDIR(fs,d) rewinddir(*(d))
 #endif /* NO_WOLFSSH_DIR */
 #endif
+
+/* Largest file offset the seek call of the port can take. A port seeking with
+ * a type narrower than off_t defines its own value ahead of this default. */
+#ifndef WOLFSSH_MAX_FILE_OFFSET
+    #if SIZEOF_OFF_T == 8
+        #define WOLFSSH_MAX_FILE_OFFSET W64LIT(0x7FFFFFFFFFFFFFFF)
+    #else
+        #define WOLFSSH_MAX_FILE_OFFSET W64LIT(0x7FFFFFFF)
+    #endif
+#endif
+
 #endif /* WOLFSSH_SFTP or WOLFSSH_SCP */
 
 /* SFTP path confinement must reject symbolic links because wolfSSH_RealPath


### PR DESCRIPTION
### Problem
`wPread()` / `wPwrite()` receive the SFTP file offset split into two 32-bit words, low word first — `src/wolfsftp.c` parses it that way and propagates carry into the high word. Two of the POSIX ports discarded that high word:

```c
ret = (int)lseek(fd, shortOffset[0], SEEK_SET);   /* high word dropped */
```

- The `lseek` fallback, compiled when the platform has no `pread`/`pwrite`, seeked with the low word alone. An SFTP read or write at or past 4 GiB silently hit a masked position: wrong data returned to the client on read, corruption on write.
- The native `pread`/`pwrite` pair combined the high word only under `SIZEOF_OFF_T == 8`, so a target with a 32-bit `off_t` truncated the same way.
- Separately, `(int)lseek(...)` narrowed the returned position before comparing it against `-1`, so a valid seek to `0xFFFFFFFF` was misread as an error and the transfer was skipped.

### Fix (`src/port.c`, `wolfssh/port.h`)
New `wResolveOffset()` assembles the split offset in `word64` and rejects anything above `WOLFSSH_MAX_FILE_OFFSET` — the widest value the seek call of the port can take, `2^63-1` for a 64-bit `off_t` and `2^31-1` otherwise. All four POSIX helpers reduce to that guard plus a cast, so the `SIZEOF_OFF_T` split disappears from each of them. Assembling in an unsigned type removes the signed-shift overflow, and the narrow ceiling also rejects a 2–4 GiB offset whose high word is zero. `lseek` is compared against `(off_t)-1` before any narrowing. A rejected offset surfaces as `WOLFSSH_FTP_FAILURE` for that one request; the session stays up.

**Scope:** this covers the two POSIX ports. Harmony, Zephyr, Nucleus and the `fseek` fallback still seek with the low word alone, and FATFS's `ff_pread`/`ff_pwrite` take no offset argument at all. The helper is port-neutral, so each can adopt it by defining its own `WOLFSSH_MAX_FILE_OFFSET`. f-8823 stays open for those.

### Tests (`tests/unit.c`, `.github/workflows/os-check.yml`)
`test_PreadPwriteHighOffset()` drives an offset of exactly 4 GiB: `wPread()` must report EOF past a 16-byte file — a truncating port rereads the start and returns data — and `wPwrite()` must leave `st_size` at 4 GiB + 1. The write half is skipped on a file system that fills holes, detected by a 1 MiB probe, so it never materialises 4 GiB; only `EFBIG`/`ENOSPC` may skip. The truncation lives in the `lseek` port, which no CI job compiled, so `os-check` gains an `--enable-all CFLAGS=-DWOLFSSH_LOCAL_PREAD_PWRITE` entry — the first CI coverage of that branch. The temp file now honours `TMPDIR`.

### Verification
- `make check` on `--enable-all` and on the new forced-fallback config: 11 pass, 1 skip, 0 fail.
- Negative control: reducing the helper to the low word turns the test red on the fallback build (10 pass, 1 fail). Pointing `TMPDIR` at a missing directory fails the test, confirming the path comes from the environment.
- Helper contract checked standalone under ASan + UBSan against both ceilings: 4 GiB and `2^63-1` accepted, `2^63` and above rejected; narrow ceiling accepts `0x7FFFFFFF` and rejects `0x80000000` and 3 GiB. No UB now that the assembly is unsigned.
- gcc-13 `-Werror` clean across 6 configs, including the Zephyr define set.
