### PR TITLE
Use wolfCrypt's Base16_Decode in test.h when it is available

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -53,12 +53,7 @@
 #endif
 #ifdef WOLFSSH_OSSH_CERTS
     #include <wolfssh/ossh.h>
-    #ifdef WOLFSSL_BASE64_ENCODE
-        /* Declared rather than including coding.h, whose Base16_Decode
-         * collides with the one wolfssh/test.h defines. */
-        WOLFSSL_API int Base64_Encode_NoNl(const byte* in, word32 inLen,
-                byte* out, word32* outLen);
-    #endif
+    #include <wolfssl/wolfcrypt/coding.h>
 #endif
 
 #if defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)

--- a/wolfssh/test.h
+++ b/wolfssh/test.h
@@ -1158,6 +1158,13 @@ static INLINE void build_addr_ipv6(struct sockaddr_in6* addr, const char* peer,
 
 #ifdef WOLFSSH_TEST_HEX2BIN
 
+/* Declares Base16_Decode when wolfSSL has it, and settles WOLFSSL_BASE16
+ * for the guard below. Only --enable-base16 and the options that imply it
+ * (openssh, sm2, all) build it, so the local copy is still needed. */
+#include <wolfssl/wolfcrypt/coding.h>
+
+#ifndef WOLFSSL_BASE16
+
 #define BAD 0xFF
 
 static const byte hexDecode[] =
@@ -1229,6 +1236,8 @@ static int Base16_Decode(const byte* in, word32 inLen,
     *outLen = outIdx;
     return 0;
 }
+
+#endif /* !WOLFSSL_BASE16 */
 
 
 static void FreeBins(byte* b1, byte* b2, byte* b3, byte* b4)


### PR DESCRIPTION
The static Base16_Decode in test.h collides with wolfSSL's public declaration when coding.h is included first. TPM builds hit this, as the wolfTPM headers pull in coding.h, so api.c and unit.c will not build with --enable-tpm against an --enable-all wolfSSL.

Include coding.h and compile the local copy only when WOLFSSL_BASE16 is absent. The include also settles the macro for the guard, which test.h would not otherwise see. The fallback is still needed: --enable-wolfssh alone does not set WOLFSSL_BASE16.