### PR TITLE
examples: use the selected algorithm for the default public key

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -895,6 +895,10 @@ THREAD_RETURN WOLFSSH_THREAD client_test(void* args)
         err_sys("You must specify a password for the TPM key");
     }
 #endif
+#ifdef WOLFSSH_NO_RSA
+    userEcc = 1;
+#endif
+
     ret = ClientSetPrivateKey(privKeyName, userEcc, NULL, tpmKeyAuth);
     if (ret != 0) {
         err_sys("Error setting private key");

--- a/examples/client/common.c
+++ b/examples/client/common.c
@@ -1008,12 +1008,23 @@ int ClientSetPrivateKey(const char* privKeyName, int userEcc,
     (void)tpmKeyAuth; /* Not used */
 
     if (privKeyName == NULL) {
+    #if defined(WOLFSSH_NO_RSA) && defined(WOLFSSH_NO_ECC)
+        /* No built-in key to load. Leave the client to authenticate
+         * some other way rather than failing here. */
+        userPrivateKeySz = 0;
+        userPrivateKeyType = NULL;
+        (void)userEcc;
+        (void)heap;
+    #else
         if (userEcc) {
         #ifndef WOLFSSH_NO_ECC
             userPrivateKeySz = sizeof(userPrivateKeyBuf);
             ret = wolfSSH_ReadKey_buffer(hanselPrivateEcc, hanselPrivateEccSz,
                     WOLFSSH_FORMAT_ASN1, &userPrivateKey, &userPrivateKeySz,
                     &userPrivateKeyType, &userPrivateKeyTypeSz, heap);
+        #else
+            fprintf(stderr, "ECC not compiled in, no default private key\n");
+            ret = WS_NOT_COMPILED;
         #endif
         }
         else {
@@ -1022,9 +1033,13 @@ int ClientSetPrivateKey(const char* privKeyName, int userEcc,
             ret = wolfSSH_ReadKey_buffer(hanselPrivateRsa, hanselPrivateRsaSz,
                     WOLFSSH_FORMAT_ASN1, &userPrivateKey, &userPrivateKeySz,
                     &userPrivateKeyType, &userPrivateKeyTypeSz, heap);
+        #else
+            fprintf(stderr, "RSA not compiled in, no default private key\n");
+            ret = WS_NOT_COMPILED;
         #endif
         }
         isPrivate = 1;
+    #endif
     }
     else {
     #if defined(WOLFSSH_TPM)
@@ -1065,6 +1080,14 @@ int ClientUsePubKey(const char* pubKeyName, int userEcc, void* heap)
     int ret = 0;
 
     if (pubKeyName == NULL) {
+    #if defined(WOLFSSH_NO_RSA) && defined(WOLFSSH_NO_ECC)
+        /* No built-in key to load. Leave the client to authenticate
+         * some other way rather than failing here. */
+        userPublicKeySz = 0;
+        userPublicKeyType = NULL;
+        (void)userEcc;
+        (void)heap;
+    #else
         byte* p = userPublicKey;
         userPublicKeySz = sizeof(userPublicKeyBuf);
 
@@ -1074,6 +1097,9 @@ int ClientUsePubKey(const char* pubKeyName, int userEcc, void* heap)
                     (word32)strlen(hanselPublicEcc), WOLFSSH_FORMAT_SSH,
                     &p, &userPublicKeySz,
                     &userPublicKeyType, &userPublicKeyTypeSz, heap);
+        #else
+            fprintf(stderr, "ECC not compiled in, no default public key\n");
+            ret = WS_NOT_COMPILED;
         #endif
         }
         else {
@@ -1082,9 +1108,13 @@ int ClientUsePubKey(const char* pubKeyName, int userEcc, void* heap)
                     (word32)strlen(hanselPublicRsa), WOLFSSH_FORMAT_SSH,
                     &p, &userPublicKeySz,
                     &userPublicKeyType, &userPublicKeyTypeSz, heap);
+        #else
+            fprintf(stderr, "RSA not compiled in, no default public key\n");
+            ret = WS_NOT_COMPILED;
         #endif
         }
         isPrivate = 1;
+    #endif
     }
     else {
     #if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM)

--- a/examples/scpclient/scpclient.c
+++ b/examples/scpclient/scpclient.c
@@ -112,6 +112,7 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
     byte nonBlock = 0;
     enum copyDir dir = copyNone;
     int ch;
+    int userEcc = 0;
     char* pubKeyName = NULL;
     char* privKeyName = NULL;
     char* certName = NULL;
@@ -218,7 +219,11 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
         err_sys("Empty path values");
     }
 
-    ret = ClientSetPrivateKey(privKeyName, 0, NULL, NULL);
+#ifdef WOLFSSH_NO_RSA
+    userEcc = 1;
+#endif
+
+    ret = ClientSetPrivateKey(privKeyName, userEcc, NULL, NULL);
     if (ret != 0) {
         err_sys("Error setting private key");
     }
@@ -231,7 +236,7 @@ THREAD_RETURN WOLFSSH_THREAD scp_client(void* args)
     else
 #endif
     {
-        ret = ClientUsePubKey(pubKeyName, 0, NULL);
+        ret = ClientUsePubKey(pubKeyName, userEcc, NULL);
     }
     if (ret != 0) {
         err_sys("Error setting public key");

--- a/examples/sftpclient/sftpclient.c
+++ b/examples/sftpclient/sftpclient.c
@@ -1709,7 +1709,7 @@ THREAD_RETURN WOLFSSH_THREAD sftpclient_test(void* args)
     else
 #endif
     {
-        ret = ClientUsePubKey(pubKeyName, 0, heap);
+        ret = ClientUsePubKey(pubKeyName, userEcc, heap);
     }
     if (ret != 0) {
         err_sys("Error setting public key");


### PR DESCRIPTION
### Problem

`examples/sftpclient/sftpclient.c` passed a literal `0` for `ClientUsePubKey()`'s `userEcc` argument while passing the real `userEcc` to `ClientSetPrivateKey()`. With no `-i` given, that argument selects between the two compiled-in default keys. Under `WOLFSSH_NO_RSA` the RSA branch is compiled out entirely, so `ret` stays at its initial `0` and the call reports success having loaded nothing — the client then offers an ECC private key with no matching public key and public-key auth fails.

Two adjacent instances of the same class: `examples/scpclient/scpclient.c` hardcoded `0` on both calls with no `WOLFSSH_NO_RSA` fallback, and `examples/client/client.c` had no fallback either.

| Client, `WOLFSSH_NO_RSA` | Before | After |
|---|---|---|
| `wolfsftp` | public key not loaded | ECC default |
| `wolfscp` | neither key loaded | ECC default |
| `client` | private key not loaded | ECC default |

### Fix (`examples/client/common.c`)

- **`ClientSetPrivateKey()` / `ClientUsePubKey()`** — all four built-in key selections gain an `#else` that names the missing algorithm on stderr and returns `WS_NOT_COMPILED`, so a compiled-out default fails at startup instead of silently. Only the `privKeyName`/`pubKeyName == NULL` path reaches these arms, so `-i` and `-j` are unaffected.
- **`sftpclient.c`** passes `userEcc` instead of `0`.
- **`scpclient.c`** gains a `userEcc` and passes it to both calls.
- **`client.c`** and **`scpclient.c`** default `userEcc = 1` under `WOLFSSH_NO_RSA`, as sftpclient already did. Required, not cosmetic: without it the new `WS_NOT_COMPILED` converts their silent no-key-loaded into `err_sys()` at startup.

Closes f-8829.

### Tests

`scripts/sftp.test` and `scripts/scp.test` authenticate with `-u jill -P upthehill`, so the built-in public-key path has no coverage today. Verified with an out-of-tree harness driving each client at `echoserver` with `-u hansel` and no `-i`: both clients fail before the fix under `WOLFSSH_NO_RSA`, pass after, and pass throughout with RSA enabled. Not added to the repo — CI runs no `WOLFSSH_NO_RSA` job for it to execute under. Happy to add both if a job is wanted.

### Verification

- gcc-13 `-O2 -Werror`, 7 configs (`--enable-all`, Zephyr defines, sftp-only, scp-only, sshd, smallstack, `-DWOLFSSH_NO_RSA`): clean.
- `make check` default config: 11 passed, 1 skipped, 0 failed.
- `make check` under `-DWOLFSSH_NO_RSA`: 10 passed, 1 skipped, 1 failed. The failure is `apps/wolfsshd/test/test_configuration`, pre-existing and unrelated — its `BuildAuthKeysLine()` hardcodes `"ssh-rsa"`, and that binary links only `apps/wolfsshd/*.c`.