### PR TITLE
wolfsftp: buffer the SFTP DATA length across partial reads

### DIFF
--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -8422,7 +8422,6 @@ int wolfSSH_SFTP_SendReadPacket(WOLFSSH* ssh, byte* handle, word32 handleSz,
         const word32* ofst, byte* out, word32 outSz)
 {
     WS_SFTP_SEND_READ_STATE* state = NULL;
-    byte szFlat[UINT32_SZ];
     int ret = WS_SUCCESS;
     word32 sz;
 
@@ -8557,8 +8556,16 @@ int wolfSSH_SFTP_SendReadPacket(WOLFSSH* ssh, byte* handle, word32 handleSz,
 
             case STATE_SEND_READ_FTP_DATA:
                 WLOG(WS_LOG_SFTP, "SFTP SEND_READ STATE: FTP_DATA");
-                /* get size of string and place it into out buffer */
-                ret = wolfSSH_stream_read(ssh, szFlat, UINT32_SZ);
+                /* Trim the buffer holding the header's payload down to the
+                 * string length, which can arrive split over several reads. */
+                ret = wolfSSH_SFTP_buffer_set_size(&state->buffer, UINT32_SZ);
+                if (ret != WS_SUCCESS) {
+                    ssh->error = WS_BUFFER_E;
+                    state->state = STATE_SEND_READ_CLEANUP;
+                    continue;
+                }
+
+                ret = wolfSSH_SFTP_buffer_read(ssh, &state->buffer, UINT32_SZ);
                 if (ret < 0) {
                     if (NoticeError(ssh)) {
                         return WS_FATAL_ERROR;
@@ -8566,11 +8573,26 @@ int wolfSSH_SFTP_SendReadPacket(WOLFSSH* ssh, byte* handle, word32 handleSz,
                     state->state = STATE_SEND_READ_CLEANUP;
                     continue;
                 }
-                ato32(szFlat, &sz);
-                wolfSSH_SFTP_buffer_create(ssh, &state->buffer, sz);
-                if (wolfSSH_SFTP_buffer_size(&state->buffer) > outSz) {
+
+                /* get size of the data string */
+                wolfSSH_SFTP_buffer_rewind(&state->buffer);
+                ret = wolfSSH_SFTP_buffer_ato32(&state->buffer, &sz);
+                if (ret != WS_SUCCESS) {
+                    ssh->error = WS_BUFFER_E;
+                    state->state = STATE_SEND_READ_CLEANUP;
+                    continue;
+                }
+                if (sz > outSz) {
                     WLOG(WS_LOG_SFTP, "Server sent more data then expected");
+                    ssh->error = WS_RECV_OVERFLOW_E;
                     ret = WS_FATAL_ERROR;
+                    state->state = STATE_SEND_READ_CLEANUP;
+                    continue;
+                }
+
+                ret = wolfSSH_SFTP_buffer_create(ssh, &state->buffer, sz);
+                if (ret != WS_SUCCESS) {
+                    ssh->error = WS_MEMORY_E;
                     state->state = STATE_SEND_READ_CLEANUP;
                     continue;
                 }

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -16165,6 +16165,160 @@ static int test_SftpClientPutWriteStatusFail(void)
     return 0;
 }
 #endif /* WOLFSSH_TEST_SFTP_PUT */
+
+/* Builds an SFTP DATA reply in "out": the 9 byte header carrying the request
+ * id where a VERSION message carries the version, then the data string as the
+ * trailing bytes. Returns the size written, or 0 if it does not fit. */
+static word32 SftpBuildData(byte* out, word32 outSz, word32 reqId,
+        word32 dataSz)
+{
+    word32 msgSz;
+
+    msgSz = SftpBuildVersion(out, outSz,
+            MSG_ID_SZ + UINT32_SZ + UINT32_SZ + dataSz, WOLFSSH_FTP_DATA,
+            reqId, UINT32_SZ + dataSz);
+    if (msgSz > 0) {
+        /* the trailing bytes open with the data string length */
+        PutU32BE(out + WOLFSSH_SFTP_HEADER, dataSz);
+    }
+
+    return msgSz;
+}
+
+
+/* Drives wolfSSH_SFTP_SendReadPacket() over a DATA reply delivered in two
+ * pieces, split after "split" bytes, with RecvAlwaysWantRead standing in for a
+ * non-blocking socket. Returns 0, or a negative sentinel on a setup failure. */
+static int SftpClientDriveReadSplit(word32 dataSz, word32 split,
+        int* firstRet, int* firstErr, int* stateKept, int* secondRet,
+        byte* out, word32 outSz)
+{
+    WOLFSSH_CTX* ctx = NULL;
+    WOLFSSH*     ssh = NULL;
+    byte   msg[WOLFSSH_SFTP_HEADER + UINT32_SZ + 32];
+    byte   handle[4];
+    word32 ofst[2];
+    word32 msgSz;
+    int    result;
+
+    *firstRet  = WS_SUCCESS;
+    *firstErr  = WS_SUCCESS;
+    *stateKept = 0;
+    *secondRet = WS_SUCCESS;
+
+    WMEMSET(handle, 'h', sizeof(handle));
+    WMEMSET(out, 0, outSz);
+    ofst[0] = 0;
+    ofst[1] = 0;
+
+    result = SftpClientNewSession(&ctx, &ssh);
+    if (result == 0) {
+        msgSz = SftpBuildData(msg, (word32)sizeof(msg), ssh->reqId, dataSz);
+        if (msgSz == 0 || split >= msgSz) {
+            result = -1019;
+        }
+    }
+    if (result == 0) {
+        /* ChannelNew leaves the peer window at zero, which would fail the
+         * READ request before any reply is read */
+        ssh->channelList->peerWindowSz = 1024;
+        ssh->channelList->peerMaxPacketSz = 1024;
+
+        if (wolfSSH_TestChannelPutData(ssh->channelList, msg, split)
+                != WS_SUCCESS) {
+            result = -1020;
+        }
+    }
+    if (result == 0) {
+        *firstRet  = wolfSSH_SFTP_SendReadPacket(ssh, handle,
+                (word32)sizeof(handle), ofst, out, outSz);
+        *firstErr  = wolfSSH_get_error(ssh);
+        *stateKept = (ssh->sendReadState != NULL);
+
+        if (wolfSSH_TestChannelPutData(ssh->channelList, msg + split,
+                    msgSz - split) != WS_SUCCESS) {
+            result = -1021;
+        }
+    }
+    if (result == 0) {
+        *secondRet = wolfSSH_SFTP_SendReadPacket(ssh, handle,
+                (word32)sizeof(handle), ofst, out, outSz);
+    }
+
+    wolfSSH_free(ssh);
+    wolfSSH_CTX_free(ctx);
+    return result;
+}
+
+
+/* Regression for the SFTP DATA reply losing bytes when its four byte string
+ * length arrives split: the read must report WS_WANT_READ, keep the send read
+ * state, then complete with the payload intact on the retry. */
+static int test_SftpSendReadPacketSplit(void)
+{
+    static const word32 splits[4] = { WOLFSSH_SFTP_HEADER,
+                                      WOLFSSH_SFTP_HEADER + 1,
+                                      WOLFSSH_SFTP_HEADER + 2,
+                                      WOLFSSH_SFTP_HEADER + 3 };
+    byte   out[16];
+    word32 dataSz = 8;
+    word32 i;
+    word32 j;
+    int    rc;
+    int    firstRet;
+    int    firstErr;
+    int    stateKept;
+    int    secondRet;
+
+    for (i = 0; i < (word32)(sizeof(splits) / sizeof(splits[0])); i++) {
+        rc = SftpClientDriveReadSplit(dataSz, splits[i], &firstRet, &firstErr,
+                &stateKept, &secondRet, out, (word32)sizeof(out));
+        if (rc != 0)
+            return rc;
+        if (firstRet != WS_FATAL_ERROR)
+            return -981;
+        if (firstErr != WS_WANT_READ)
+            return -982;
+        if (!stateKept)
+            return -983;
+        if (secondRet != (int)dataSz)
+            return -984;
+        for (j = 0; j < dataSz; j++) {
+            if (out[j] != (byte)(UINT32_SZ + j))
+                return -985;
+        }
+    }
+
+    return 0;
+}
+
+
+/* A DATA reply whose string length exceeds the caller's buffer is rejected
+ * before the payload is allocated for, reporting WS_RECV_OVERFLOW_E. */
+static int test_SftpSendReadPacketOverflow(void)
+{
+    byte   out[4];
+    word32 dataSz = 8;
+    int    rc;
+    int    firstRet;
+    int    firstErr;
+    int    stateKept;
+    int    secondRet;
+
+    rc = SftpClientDriveReadSplit(dataSz, WOLFSSH_SFTP_HEADER + UINT32_SZ,
+            &firstRet, &firstErr, &stateKept, &secondRet, out,
+            (word32)sizeof(out));
+    if (rc != 0)
+        return rc;
+    if (firstRet != WS_FATAL_ERROR)
+        return -986;
+    if (firstErr != WS_RECV_OVERFLOW_E)
+        return -987;
+    if (stateKept)
+        return -988;
+
+    return 0;
+}
 #endif /* NO_WOLFSSH_CLIENT */
 #endif /* WOLFSSH_SFTP */
 
@@ -17318,6 +17472,16 @@ int wolfSSH_UnitTest(int argc, char** argv)
             (unitResult == 0 ? "SUCCESS" : "FAILED"));
     testResult = testResult || unitResult;
 #endif
+
+    unitResult = test_SftpSendReadPacketSplit();
+    printf("SftpSendReadPacketSplit: %s\n",
+            (unitResult == 0 ? "SUCCESS" : "FAILED"));
+    testResult = testResult || unitResult;
+
+    unitResult = test_SftpSendReadPacketOverflow();
+    printf("SftpSendReadPacketOverflow: %s\n",
+            (unitResult == 0 ? "SUCCESS" : "FAILED"));
+    testResult = testResult || unitResult;
 #endif
 #endif
 


### PR DESCRIPTION
### Problem
`wolfSSH_SFTP_SendReadPacket()` decoded the 4-byte string length prefixing an SFTP `DATA` reply with a single unchecked read into a stack buffer:

```c
byte szFlat[UINT32_SZ];                       /* uninitialized */
ret = wolfSSH_stream_read(ssh, szFlat, UINT32_SZ);
if (ret < 0) { ... }                          /* short reads fall through */
ato32(szFlat, &sz);
```

`wolfSSH_stream_read()` returns `min(bufSz, available)`, so a short *positive* return is routine whenever a peer's `DATA` reply straddles SSH packets. Only `ret < 0` was checked, so 1-3 delivered bytes reached `ato32()`, which read the rest of `szFlat` as uninitialized stack (CWE-457). Because `szFlat` was a stack local, the prefix bytes already consumed were unrecoverable, so the retry could not resynchronize. Closes f-8828.

### Fix (`src/wolfsftp.c`)
`STATE_SEND_READ_FTP_DATA` now decodes the length out of `state->buffer`, which lives in `ssh->sendReadState` and so survives across calls:

- **`wolfSSH_SFTP_buffer_set_size(..., UINT32_SZ)`** trims the allocation `STATE_SEND_READ_GET_HEADER` already made rather than taking a second one, and rejects a header declaring fewer than 4 payload bytes.
- **`wolfSSH_SFTP_buffer_read()`** accumulates short positive reads and retains `idx` on `WS_WANT_READ`, so a retry resumes mid-prefix.
- **`wolfSSH_SFTP_buffer_ato32()`** decodes after a rewind, bounds-checked against the buffer.
- **`sz > outSz`** is applied before allocating for the payload, and `wolfSSH_SFTP_buffer_create()`'s return is checked.
- **`ssh->error`** is set on every failure exit -- `WS_BUFFER_E` on the size and decode helpers, `WS_RECV_OVERFLOW_E` on the `outSz` bound, `WS_MEMORY_E` on the allocation -- so the caller's `NoticeError()` cannot misclassify one as retryable.
- **`szFlat`** is removed.

This is the same transformation commit `6f0cbe3f` made for the sibling VERSION-header defect (f-7505), so both halves of the client read path now use one pattern.

### Test harness (`tests/unit.c`)
Both tests are network-free, built on the existing `SftpClientNewSession()` + `wolfSSH_TestChannelPutData()` harness. No new test hooks; `SftpBuildData()` delegates to the existing `SftpBuildVersion()`.

- **`test_SftpSendReadPacketSplit()`** stages a `DATA` reply cut at each of the four points across the length prefix (0 through 3 of the 4 bytes delivered first) and asserts the first call returns `WS_FATAL_ERROR`/`WS_WANT_READ` with the send-read state retained, and that the retry returns the full payload intact.
- **`test_SftpSendReadPacketOverflow()`** delivers the header and the whole prefix in one read so the decode completes, declaring 8 payload bytes against a 4-byte `out`, and asserts `WS_FATAL_ERROR` with `WS_RECV_OVERFLOW_E` and the send-read state freed rather than retained.

### Verification
- Negative controls: against the base `src/wolfsftp.c` the split test fails at the three split points that land mid-prefix (+1, +2, +3) and passes at +0, where the whole prefix arrives in one read; with the `ssh->error = WS_RECV_OVERFLOW_E` line removed the overflow test fails on its error-code assertion. Both pass in full with the fix.
- `tests/unit.test`: 112 passed, 0 failed.
- `make check`: 12 passed, 0 failed, 1 skipped (`external.test`) of 13.
- Clean under gcc-13 `-Werror` across 6 configs (enable-all, zephyr-defines, sftp-only, scp-only, default, smallstack).
