### PR TITLE
internal: gate public-key auth on every compiled signing algorithm

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9798,8 +9798,7 @@ static int DoUserAuthRequestEd25519(WOLFSSH* ssh,
 }
 #endif /* !WOLFSSH_NO_ED25519 */
 
-#if !defined(WOLFSSH_NO_RSA) || !defined(WOLFSSH_NO_ECDSA) \
-    || !defined(WOLFSSH_NO_ED25519) || !defined(WOLFSSH_NO_MLDSA)
+#ifndef WOLFSSH_NO_PUBKEY_AUTH
 /* Utility for DoUserAuthRequest() */
 static int DoUserAuthRequestPublicKey(WOLFSSH* ssh, WS_UserAuthData* authData,
                                       byte* buf, word32 len, word32* idx)
@@ -10342,7 +10341,7 @@ static int DoUserAuthRequestPublicKey(WOLFSSH* ssh, WS_UserAuthData* authData,
     WLOG(WS_LOG_DEBUG, "Leaving DoUserAuthRequestPublicKey(), ret = %d", ret);
     return ret;
 }
-#endif /* !WOLFSSH_NO_RSA/ECDSA/ED25519/MLDSA */
+#endif /* !WOLFSSH_NO_PUBKEY_AUTH */
 
 
 static int DoUserAuthRequest(WOLFSSH* ssh,
@@ -10437,8 +10436,7 @@ static int DoUserAuthRequest(WOLFSSH* ssh,
             ret = SendUserAuthKeyboardRequest(ssh, &authData);
         }
 #endif
-#if !defined(WOLFSSH_NO_RSA) || !defined(WOLFSSH_NO_ECDSA) \
-    || !defined(WOLFSSH_NO_ED25519) || !defined(WOLFSSH_NO_MLDSA)
+#ifndef WOLFSSH_NO_PUBKEY_AUTH
         else if (authNameId == ID_USERAUTH_PUBLICKEY) {
             authData.sf.publicKey.dataToSign = buf + *idx;
             ret = DoUserAuthRequestPublicKey(ssh, &authData, buf, len, &begin);
@@ -10515,8 +10513,7 @@ static int DoUserAuthFailure(WOLFSSH* ssh,
                             }
                             break;
 #endif
-#if !defined(WOLFSSH_NO_RSA) || !defined(WOLFSSH_NO_ECDSA) || \
-    defined(WOLFSSH_TPM)
+#ifndef WOLFSSH_NO_PUBKEY_AUTH
                         case ID_USERAUTH_PUBLICKEY:
                             authType |= WOLFSSH_USERAUTH_PUBLICKEY;
                             break;
@@ -18816,8 +18813,7 @@ static int BuildUserAuthRequestMlDsa(WOLFSSH* ssh,
 #endif /* !WOLFSSH_NO_MLDSA */
 
 
-#if !defined(WOLFSSH_NO_RSA) || !defined(WOLFSSH_NO_ECDSA) \
-    || !defined(WOLFSSH_NO_ED25519) || !defined(WOLFSSH_NO_MLDSA)
+#ifndef WOLFSSH_NO_PUBKEY_AUTH
 static int PrepareUserAuthRequestPublicKey(WOLFSSH* ssh, word32* payloadSz,
         WS_UserAuthData* authData, WS_KeySignature* keySig)
 {
@@ -19181,7 +19177,7 @@ static int BuildUserAuthRequestPublicKey(WOLFSSH* ssh,
 }
 
 
-#endif /* !WOLFSSH_NO_RSA/ECDSA/ED25519/MLDSA */
+#endif /* !WOLFSSH_NO_PUBKEY_AUTH */
 
 #ifdef WOLFSSH_KEYBOARD_INTERACTIVE
 int SendUserAuthKeyboardResponse(WOLFSSH* ssh)
@@ -19527,7 +19523,7 @@ static int GetAllowedAuth(WOLFSSH* ssh, char* authStr)
 #ifdef WOLFSSH_KEYBOARD_INTERACTIVE
     typeAllowed |= WOLFSSH_USERAUTH_KEYBOARD;
 #endif
-#if !defined(WOLFSSH_NO_RSA) || !defined(WOLFSSH_NO_ECDSA)
+#ifndef WOLFSSH_NO_PUBKEY_AUTH
     typeAllowed |= WOLFSSH_USERAUTH_PUBLICKEY;
 #endif
 

--- a/wolfssh/internal.h
+++ b/wolfssh/internal.h
@@ -365,6 +365,11 @@ extern "C" {
     #undef WOLFSSH_NO_ECDSA
     #define WOLFSSH_NO_ECDSA
 #endif
+#if defined(WOLFSSH_NO_RSA) && defined(WOLFSSH_NO_ECDSA) && \
+    defined(WOLFSSH_NO_ED25519) && defined(WOLFSSH_NO_MLDSA)
+    #undef WOLFSSH_NO_PUBKEY_AUTH
+    #define WOLFSSH_NO_PUBKEY_AUTH
+#endif
 #if defined(WOLFSSH_NO_RSA) || \
     (defined(WOLFSSH_NO_RSA_SHA2_256) && defined(WOLFSSH_NO_RSA_SHA2_512))
     #undef WOLFSSH_NO_OSSH_CERT_RSA


### PR DESCRIPTION
### Problem
Public-key user authentication is gated on compile-time algorithm macros in five places in `src/internal.c`, but the guards are not the same expression. Two of them list only RSA and ECDSA:

- `GetAllowedAuth()` — the server's default advertised method list
- `DoUserAuthFailure()` — the client's `ID_USERAUTH_PUBLICKEY` case

Ed25519 and ML-DSA are fully supported public-key user-auth algorithms: `DoUserAuthRequestPublicKey()`, `PrepareUserAuthRequestPublicKey()` and `BuildUserAuthRequestPublicKey()` all have real branches for them, and all three are guarded on the correct four-way predicate.

So in a build with `WOLFSSH_NO_RSA` + `WOLFSSH_NO_ECDSA` and Ed25519 (or ML-DSA) enabled, the verify and sign paths are compiled in but unreachable: the server never advertises `publickey`, and the client drops it from `authType`, so a peer list containing only `publickey` returns `WS_USER_AUTH_E`. Public-key auth is unusable in those configurations. Closes f-10542.

### Fix (`src/internal.c`, `wolfssh/internal.h`)
`wolfssh/internal.h` derives a shared predicate next to the existing `WOLFSSH_NO_RSA` / `WOLFSSH_NO_ECDSA` aggregates:

```c
#if defined(WOLFSSH_NO_RSA) && defined(WOLFSSH_NO_ECDSA) && \
    defined(WOLFSSH_NO_ED25519) && defined(WOLFSSH_NO_MLDSA)
    #undef WOLFSSH_NO_PUBKEY_AUTH
    #define WOLFSSH_NO_PUBKEY_AUTH
#endif
```

All five sites now use `#ifndef WOLFSSH_NO_PUBKEY_AUTH`, so the predicate has one definition.

**Not a pure rename at two sites** — these are the behavioral fixes:

| Site | Old guard |
|---|---|
| `GetAllowedAuth()` | `!NO_RSA \|\| !NO_ECDSA` |
| `DoUserAuthFailure()` | `!NO_RSA \|\| !NO_ECDSA \|\| WOLFSSH_TPM` |

The `WOLFSSH_TPM` term is dropped. The TPM user-auth signer exists only for RSA, and with all four algorithm families disabled the "You need at least one signing algorithm" `#error` fires, so no buildable config relied on it.

### Verification
- `--enable-all`: 11 passed, 1 skipped (`external.test`), 0 failed.
- gcc-13 `-Werror` preflight sweep: 6 configurations clean.
- Ed25519-only build (`-DWOLFSSH_NO_RSA -DWOLFSSH_NO_ECDSA` against wolfSSL with `--enable-ed25519-stream`): `src/internal.c` compiles clean, and preprocessing confirms both `typeAllowed |= WOLFSSH_USERAUTH_PUBLICKEY` and the `ID_USERAUTH_PUBLICKEY` case now survive. Negative control: both disappear with the change reverted.

### Not in this PR
No test is added: the Ed25519-only configuration cannot run `make check` today because `examples/client/common.c` and `examples/echoserver/echoserver.c` fail to compile there — they guard the ECDSA sample keys on `WOLFSSH_NO_ECC` (curve support) while selecting the key material on `WOLFSSH_NO_ECDSA_SHA2_NISTP*` (signing). That is pre-existing and tracked separately; fixing it is the prerequisite for adding an Ed25519-only CI job.