### PR TITLE
tests: derive the expected ECC rejection in the priv-only key test

### DIFF
--- a/tests/unit.c
+++ b/tests/unit.c
@@ -11167,6 +11167,7 @@ static int test_IdentifyAsn1Key_EccPrivOnlyDerFailure(int curveSz,
     byte* eccDer = NULL;
     int eccDerSz;
     int i;
+    int expected = WS_CRYPTO_FAILED;
 
     WMEMSET(&eccKey, 0, sizeof(eccKey));
     if (wc_ecc_init(&eccKey) != 0) {
@@ -11209,12 +11210,30 @@ static int test_IdentifyAsn1Key_EccPrivOnlyDerFailure(int curveSz,
         }
     }
 
+    /* Some wolfSSL builds reject the zeroed scalar while decoding the DER,
+     * so IdentifyAsn1Key never reaches the derivation and reports the key
+     * as unidentified. Ask this build which rejection to expect. */
+    {
+        ecc_key probeKey;
+        word32 probeIdx = 0;
+
+        if (wc_ecc_init(&probeKey) != 0) {
+            WFREE(eccDer, NULL, 0);
+            return -6939;
+        }
+        if (wc_EccPrivateKeyDecode(eccDer, &probeIdx, &probeKey,
+                (word32)eccDerSz) != 0) {
+            expected = WS_UNIMPLEMENTED_E;
+        }
+        wc_ecc_free(&probeKey);
+    }
+
     ret = IdentifyAsn1Key(eccDer, (word32)eccDerSz, 1, NULL, NULL);
     WFREE(eccDer, NULL, 0);
 
-    if (ret != WS_CRYPTO_FAILED) {
-        printf("IdentifyAsn1Key: private-only ECC %s DER fallback derivation "
-               "expected WS_CRYPTO_FAILED, got %d\n", curveName, ret);
+    if (ret != expected) {
+        printf("IdentifyAsn1Key: private-only ECC %s DER rejection expected "
+               "%d, got %d\n", curveName, expected, ret);
         return -6938;
     }
 


### PR DESCRIPTION
`tests/unit.test` fails against any wolfSSL built from master:

```
IdentifyAsn1Key: private-only ECC P-256 DER fallback derivation expected WS_CRYPTO_FAILED, got -1017
IdentifyAsn1Key: FAILED
```

wolfSSL master commit `8bffaff` ("Check ECC private key scalar range on import
(F-1930, F-1931)", 2026-08-12) rejects a private scalar outside [1, n-1] at
import. The zeroed scalar that `test_IdentifyAsn1Key_EccPrivOnlyDerFailure`
builds now fails in `wc_EccPrivateKeyDecode` with `ECC_PRIV_KEY_E` instead of
decoding and failing later in the `wc_ecc_make_pub` fallback, so
`IdentifyAsn1Key` never sets `noPubKeyRet` and returns `WS_UNIMPLEMENTED_E`
rather than the hard-coded `WS_CRYPTO_FAILED` the test expected. The library is
right either way -- the key is rejected -- only the stage differs.

The test now decodes the corrupted DER itself and expects whichever rejection
the linked wolfSSL performs, so the assertion stays strict on both released and
master wolfSSL and does not simply accept any error.

That commit is in no wolfSSL release, so this only shows up where wolfSSL comes
from master. Verified on x86_64 Linux against wolfSSL master `9ab8a4b`
`--enable-all`: the unpatched test reproduces the failure above, the patched
test passes, and `make check` is 6 PASS / 2 SKIP / 0 FAIL. Also passes against
wolfSSL 5.9.2 `--enable-all` on macOS/arm64, Linux/arm64 and Linux/x86_64.