### PR TITLE
ossh: check the key-type parse before the ID lookup

### DIFF
--- a/src/ossh.c
+++ b/src/ossh.c
@@ -471,50 +471,55 @@ static int GetOpenSshPublicKeyRsa(RsaKey* key, const byte* buf, word32 len,
 int GetOpenSshPublicKey(WS_KeySignature *key,
         const byte* buf, word32 len, word32* idx)
 {
-    int ret = WS_SUCCESS;
-    const byte* publicKeyType;
+    int ret;
+    const byte* publicKeyType = NULL;
     word32 publicKeyTypeSz = 0;
-    byte keyId;
+    byte keyId = ID_UNKNOWN;
 
     ret = GetStringRef(&publicKeyTypeSz, &publicKeyType, buf, len, idx);
-    keyId = NameToId((const char*)publicKeyType, publicKeyTypeSz);
 
-    switch (keyId) {
-    #ifndef WOLFSSH_NO_RSA
-        case ID_SSH_RSA:
-            ret = GetOpenSshPublicKeyRsa(&key->ks.rsa.key, buf, len, idx);
-            break;
-    #endif
-    #ifndef WOLFSSH_NO_ECDSA
-        case ID_ECDSA_SHA2_NISTP256:
-        case ID_ECDSA_SHA2_NISTP384:
-        case ID_ECDSA_SHA2_NISTP521:
-            ret = GetOpenSshPublicKeyEcc(&key->ks.ecc.key, buf, len, idx);
-            break;
-    #endif
-    #ifndef WOLFSSH_NO_ED25519
-        case ID_ED25519:
-            ret = GetOpenSshKeyPublicEd25519(&key->ks.ed25519.key, buf, len, idx);
-            break;
-    #endif
-    #ifndef WOLFSSH_NO_MLDSA
-        case ID_MLDSA44:
-            ret = GetOpenSshKeyPublicMlDsa(&key->ks.mldsa.key, buf, len,
-                                           idx, WC_ML_DSA_44);
-            break;
-        case ID_MLDSA65:
-            ret = GetOpenSshKeyPublicMlDsa(&key->ks.mldsa.key, buf, len,
-                                           idx, WC_ML_DSA_65);
-            break;
-        case ID_MLDSA87:
-            ret = GetOpenSshKeyPublicMlDsa(&key->ks.mldsa.key, buf, len,
-                                           idx, WC_ML_DSA_87);
-            break;
-    #endif
-        default:
-            ret = WS_UNIMPLEMENTED_E;
-            break;
+    if (ret == WS_SUCCESS) {
+        keyId = NameToId((const char*)publicKeyType, publicKeyTypeSz);
+
+        switch (keyId) {
+        #ifndef WOLFSSH_NO_RSA
+            case ID_SSH_RSA:
+                ret = GetOpenSshPublicKeyRsa(&key->ks.rsa.key, buf, len, idx);
+                break;
+        #endif
+        #ifndef WOLFSSH_NO_ECDSA
+            case ID_ECDSA_SHA2_NISTP256:
+            case ID_ECDSA_SHA2_NISTP384:
+            case ID_ECDSA_SHA2_NISTP521:
+                ret = GetOpenSshPublicKeyEcc(&key->ks.ecc.key, buf, len, idx);
+                break;
+        #endif
+        #ifndef WOLFSSH_NO_ED25519
+            case ID_ED25519:
+                ret = GetOpenSshKeyPublicEd25519(&key->ks.ed25519.key, buf, len,
+                                                 idx);
+                break;
+        #endif
+        #ifndef WOLFSSH_NO_MLDSA
+            case ID_MLDSA44:
+                ret = GetOpenSshKeyPublicMlDsa(&key->ks.mldsa.key, buf, len,
+                                               idx, WC_ML_DSA_44);
+                break;
+            case ID_MLDSA65:
+                ret = GetOpenSshKeyPublicMlDsa(&key->ks.mldsa.key, buf, len,
+                                               idx, WC_ML_DSA_65);
+                break;
+            case ID_MLDSA87:
+                ret = GetOpenSshKeyPublicMlDsa(&key->ks.mldsa.key, buf, len,
+                                               idx, WC_ML_DSA_87);
+                break;
+        #endif
+            default:
+                ret = WS_UNIMPLEMENTED_E;
+                break;
+        }
     }
+
     return ret;
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -2270,6 +2270,71 @@ static void test_LoadTpmSshKey_NoTrailingNewline(void)
 
 #endif /* WOLFSSH_TPM && FILESYSTEM && !USER_FILESYSTEM */
 
+#if defined(WOLFSSH_TPM) && defined(WOLFSSH_TEST_INTERNAL)
+
+/* The key type is read with GetStringRef(), which sets the length from the
+ * wire but leaves the pointer alone when the name runs past the buffer. */
+static void test_GetOpenSshPublicKey_type(void)
+{
+    /* "ssh" carrying a length of 7. */
+    static const byte truncType[] = {
+        0x00, 0x00, 0x00, 0x07, 's', 's', 'h'
+    };
+    /* Too short to hold the length prefix. */
+    static const byte truncLen[] = { 0x00, 0x00 };
+    /* Parses, but names no key. */
+    static const byte emptyType[] = { 0x00, 0x00, 0x00, 0x00 };
+    /* A known SSH key type that wolfSSH's NameIdMap does not carry. */
+    static const byte unsupportedType[] = {
+        0x00, 0x00, 0x00, 0x07, 's', 's', 'h', '-', 'd', 's', 's'
+    };
+#ifndef WOLFSSH_NO_RSA
+    /* string "ssh-rsa", mpint e, mpint n. */
+    static const byte rsaKey[] = {
+        0x00, 0x00, 0x00, 0x07, 's', 's', 'h', '-', 'r', 's', 'a',
+        0x00, 0x00, 0x00, 0x03, 0x01, 0x00, 0x01,
+        0x00, 0x00, 0x00, 0x09,
+        0x00, 0xC5, 0x1A, 0x37, 0x8B, 0x42, 0x9D, 0xE0, 0x6F
+    };
+#endif
+    WS_KeySignature keySig;
+    word32 idx;
+
+    WMEMSET(&keySig, 0, sizeof(keySig));
+
+    /* On failure idx keeps whatever was consumed, as elsewhere in the tree. */
+    idx = 0;
+    AssertIntEQ(GetOpenSshPublicKey(&keySig, truncType,
+                (word32)sizeof(truncType), &idx), WS_BUFFER_E);
+    AssertIntEQ(idx, UINT32_SZ);
+
+    idx = 0;
+    AssertIntEQ(GetOpenSshPublicKey(&keySig, truncLen,
+                (word32)sizeof(truncLen), &idx), WS_BUFFER_E);
+    AssertIntEQ(idx, 0);
+
+    idx = 0;
+    AssertIntEQ(GetOpenSshPublicKey(&keySig, emptyType,
+                (word32)sizeof(emptyType), &idx), WS_UNIMPLEMENTED_E);
+    AssertIntEQ(idx, (word32)sizeof(emptyType));
+
+    idx = 0;
+    AssertIntEQ(GetOpenSshPublicKey(&keySig, unsupportedType,
+                (word32)sizeof(unsupportedType), &idx), WS_UNIMPLEMENTED_E);
+    AssertIntEQ(idx, (word32)sizeof(unsupportedType));
+
+#ifndef WOLFSSH_NO_RSA
+    idx = 0;
+    AssertIntEQ(wc_InitRsaKey(&keySig.ks.rsa.key, NULL), 0);
+    AssertIntEQ(GetOpenSshPublicKey(&keySig, rsaKey,
+                (word32)sizeof(rsaKey), &idx), WS_SUCCESS);
+    AssertIntEQ(idx, (word32)sizeof(rsaKey));
+    AssertIntEQ(wc_FreeRsaKey(&keySig.ks.rsa.key), 0);
+#endif
+}
+
+#endif /* WOLFSSH_TPM && WOLFSSH_TEST_INTERNAL */
+
 
 static void test_wolfSSH_ReadKey_badPad(void)
 {
@@ -7484,6 +7549,9 @@ int wolfSSH_ApiTest(int argc, char** argv)
 #if defined(WOLFSSH_TPM) && !defined(NO_FILESYSTEM) && \
     !defined(NO_WRITE_TEMP_FILES) && !defined(WOLFSSH_USER_FILESYSTEM)
     test_LoadTpmSshKey_NoTrailingNewline();
+#endif
+#if defined(WOLFSSH_TPM) && defined(WOLFSSH_TEST_INTERNAL)
+    test_GetOpenSshPublicKey_type();
 #endif
     test_wolfSSH_ReadKey_shortBuffer();
     test_wolfSSH_ReadKey_noTrailingNewline();


### PR DESCRIPTION
### Problem

`GetOpenSshPublicKey()` overwrote the result of `GetStringRef()` before checking it:

```c
ret = GetStringRef(&publicKeyTypeSz, &publicKeyType, buf, len, idx);
keyId = NameToId((const char*)publicKeyType, publicKeyTypeSz);
```

`GetStringRef()` calls `GetUint32()`, which stores the wire length in `*strSz` on
success; `GetStringRef()`'s own bounds check (`src/internal.c:4569`) then fails for a
truncated key-type string and returns `WS_BUFFER_E` at line 4578 without ever
assigning `*str`. The caller's `publicKeyType` is an uninitialized local, so
`NameToId()` compared through an indeterminate pointer using a length taken from the
wire. The unchecked `ret` was then overwritten by the switch, so the parse failure was
reported as `WS_UNIMPLEMENTED_E` instead of `WS_BUFFER_E`.

Compiled only under `WOLFSSH_TPM`. The single call site is
`PrepareUserAuthRequestRsa()`, on the branch where the private key lives in the TPM
and only a public key blob is available — the input is the local user's public key
material, not a remote peer's. Closes f-11650.

### Fix (`src/ossh.c`)

- **`NameToId()` and the key-type switch** run only when `GetStringRef()` returns
  `WS_SUCCESS`; that result is returned otherwise.
- **`publicKeyType`** starts `NULL` and **`keyId`** starts `ID_UNKNOWN`.

The switch body is unchanged apart from indentation. Every other `GetStringRef()` /
`GetMpint()` call in the file already gated on `ret == WS_SUCCESS`; this was the only
one that did not.

### Tests (`tests/api.c`)

`test_GetOpenSshPublicKey_type()`, gated on `WOLFSSH_TPM` + `WOLFSSH_TEST_INTERNAL`:

| Blob | Expected | `idx` out |
|---|---|---|
| `"ssh"` under a length of 7 | `WS_BUFFER_E` | 4 |
| Length prefix truncated | `WS_BUFFER_E` | 0 |
| Empty type name | `WS_UNIMPLEMENTED_E` | 4 |
| `ssh-dss` type name, unsupported | `WS_UNIMPLEMENTED_E` | 11 |
| `ssh-rsa` + mpint `e` + mpint `n` | `WS_SUCCESS` | 31, fully consumed |

`idx` is asserted on the failure cases too: it keeps whatever was successfully
consumed and is not rolled back, matching every other `Get*` in the tree.

Runs upstream in the `tpm-ssh.yml` ecc/ibmswtpm2/raw cell, which builds the
`check_PROGRAM`s with `-DWOLFSSH_TPM` and runs `make check TESTS=tests/api.test`.

### Not in this PR

- `GetOpenSshPublicKey()` accepts trailing bytes after a well-formed blob;
  `OsshCertParse()` rejects them. Pre-existing, separate hardening.
- `--enable-tpm` fails `testsuite.test`, `kex.test` and `auth.test` on master; CI runs
  only `tests/api.test` for that config, so it has never seen those. Pre-existing.

### Verification

- `--enable-tpm --enable-certs`: build clean, `tests/api.test` passes.
- Negative control: with the `src/ossh.c` hunk reverted, the truncated-type case
  fails — `-1017 != -1004`.
- gcc-13 `-O2 -Werror` sweep: clean across 6 configs (enable-all, zephyr-defines,
  sftp-only, scp-only, default, smallstack).
