### PR TITLE
fix: cppcheck identicalInnerCondition and uninitvar findings

### DIFF
--- a/apps/wolfsshd/auth.c
+++ b/apps/wolfsshd/auth.c
@@ -2695,8 +2695,8 @@ static int RequestAuthentication(WS_UserAuthData* authData,
             DecodedCert* dCert = &sdCert;
         #endif
 
-            /* ret is still success unless the allocation above failed */
-            if (ret == WOLFSSH_USERAUTH_SUCCESS) {
+            /* NULL only when the small-stack allocation above failed */
+            if (dCert != NULL) {
                 wc_InitDecodedCert(dCert, authData->sf.publicKey.publicKey,
                         authData->sf.publicKey.publicKeySz, NULL);
                 if (wc_ParseCert(dCert, CERT_TYPE, NO_VERIFY, NULL) != 0) {

--- a/src/certman.c
+++ b/src/certman.c
@@ -404,7 +404,8 @@ int wolfSSH_CERTMAN_VerifyCerts_buffer(WOLFSSH_CERTMAN* cm,
         }
 #endif
 
-        if (ret == WS_SUCCESS) {
+        /* NULL only when the small-stack allocation above failed */
+        if (decoded != NULL) {
             wc_InitDecodedCert(decoded, certLoc[0], certLen[0], cm->heap);
             if (wc_ParseCert(decoded, WOLFSSL_FILETYPE_ASN1, NO_VERIFY, cm->cm)
                     != 0) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -21853,11 +21853,14 @@ static int CompositeEccSign(void* key, WC_RNG* rng, void* heap,
                 ret = WS_MEMORY_E;
         }
 #else
-        byte rBuf[MAX_ECC_BYTES + ECC_MAX_PAD_SZ];
-        byte sBuf[MAX_ECC_BYTES + ECC_MAX_PAD_SZ];
+        byte rStore[MAX_ECC_BYTES + ECC_MAX_PAD_SZ];
+        byte sStore[MAX_ECC_BYTES + ECC_MAX_PAD_SZ];
+        byte* rBuf = rStore;
+        byte* sBuf = sStore;
 #endif
 
-        if (ret == 0) {
+        /* NULL only when a small-stack allocation above failed */
+        if (rBuf != NULL && sBuf != NULL) {
             ret = wc_ecc_sig_to_rs(asnSig, asnSigSz, rBuf, &rSz, sBuf, &sSz);
         }
         if (ret == 0) {

--- a/src/keygen.c
+++ b/src/keygen.c
@@ -312,7 +312,8 @@ int wolfSSH_MakeMlDsaKey(byte* out, word32 outSz, word32 level)
         }
 #endif
 
-        if (ret == WS_SUCCESS) {
+        /* NULL only when the small-stack allocation above failed */
+        if (key != NULL) {
             if (wc_MlDsaKey_Init(key, NULL, INVALID_DEVID) != 0)
                 ret = WS_CRYPTO_FAILED;
             else {

--- a/src/port.c
+++ b/src/port.c
@@ -250,7 +250,7 @@ void* WS_CreateFileA(const char* fileName, unsigned long desiredAccess,
         unsigned long shareMode, unsigned long creationDisposition,
         unsigned long flags, void* heap)
 {
-    HANDLE fileHandle;
+    HANDLE fileHandle = INVALID_HANDLE_VALUE;
     wchar_t* unicodeFileName;
     size_t unicodeFileNameSz = 0;
     size_t returnSz = 0;

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -3151,6 +3151,9 @@ static int SFTP_CreateLongName(WS_SFTPNAME* name)
     mtime = (time_t)atr->mtime;
 
 #if defined(WLOCALTIME)
+    /* WLOCALTIME is a per-port macro; zero first so nothing reads a stale
+     * struct if a port leaves it untouched. */
+    WMEMSET(&localTime, 0, sizeof(localTime));
     if (!WLOCALTIME(&mtime, &localTime)) {
         return WS_MEMORY_E;
     }


### PR DESCRIPTION
The cppcheck CI job reports three identicalInnerCondition warnings and one
uninitvar error. A newer cppcheck (2.21) adds two more of the same two
kinds; both sets are fixed here.

Four sites re-tested an unchanged ret after a WOLFSSH_SMALL_STACK
allocation. cppcheck calls the inner check dead because the allocation
that can change ret is compiled out in the default build. They now test
the allocated pointer, which is what the check guards.

- certman.c, keygen.c and wolfsshd/auth.c check the DecodedCert, MlDsaKey
  and DecodedCert pointers
- internal.c CompositeEccSign gives the fixed-buffer build pointer aliases
  so both builds have the same shape, then checks the r/s pointers
- port.c initializes fileHandle, which is only assigned when mbstowcs_s
  succeeds
- wolfsftp.c zeroes localTime before WLOCALTIME, a per-port macro that
  cppcheck cannot see through with only std.cfg loaded