### PR TITLE
examples, tests: terminate the ES_ERROR messages with a newline

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -3159,13 +3159,13 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
 
                 case 'p':
                     if (myoptarg == NULL) {
-                        ES_ERROR("NULL port value");
+                        ES_ERROR("NULL port value\n");
                     }
                     else {
                         port = (word16)atoi(myoptarg);
                         #if !defined(NO_MAIN_DRIVER)
                             if (port == 0) {
-                                ES_ERROR("port number cannot be 0");
+                                ES_ERROR("port number cannot be 0\n");
                             }
                         #endif
                     }
@@ -3397,12 +3397,12 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
         kbAuthData.promptLanguageSz = 0;
         kbAuthData.prompts = (byte**)WMALLOC(sizeof(byte*), NULL, 0);
         if (kbAuthData.prompts == NULL) {
-            ES_ERROR("Error allocating prompts");
+            ES_ERROR("Error allocating prompts\n");
         }
         kbAuthData.promptLengths = (word32*)WMALLOC(sizeof(word32), NULL, 0);
         if (kbAuthData.promptLengths == NULL) {
             WFREE(kbAuthData.prompts, NULL, 0);
-            ES_ERROR("Error allocating promptLengths");
+            ES_ERROR("Error allocating promptLengths\n");
         }
         kbAuthData.prompts[0] = (byte*)"KB Auth Password: ";
         kbAuthData.promptLengths[0] = 18;
@@ -3410,7 +3410,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
         if (kbAuthData.promptEcho == NULL) {
             WFREE(kbAuthData.prompts, NULL, 0);
             WFREE(kbAuthData.promptLengths, NULL, 0);
-            ES_ERROR("Error allocating promptEcho");
+            ES_ERROR("Error allocating promptEcho\n");
         }
         kbAuthData.promptEcho[0] = 0;
         LoadKeyboardList(keyboardList, &pwMapList, &kbAuthData);
@@ -3432,7 +3432,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
             keyLoadBuf = (byte*)WMALLOC(EXAMPLE_KEYLOAD_BUFFER_SZ,
                     NULL, 0);
             if (keyLoadBuf == NULL) {
-                ES_ERROR("Error allocating keyLoadBuf");
+                ES_ERROR("Error allocating keyLoadBuf\n");
             }
         #else
             keyLoadBuf = buf;
@@ -3788,7 +3788,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
                                                          &clientAddrSz);
     #endif
         if (clientFd == -1) {
-            ES_ERROR("tcp accept failed");
+            ES_ERROR("tcp accept failed\n");
         }
 
         if (nonBlock)

--- a/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
+++ b/ide/Espressif/ESP-IDF/examples/wolfssh_echoserver/main/echoserver.c
@@ -2658,13 +2658,13 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
 
                 case 'p':
                     if (myoptarg == NULL) {
-                        ES_ERROR("NULL port value");
+                        ES_ERROR("NULL port value\n");
                     }
                     else {
                         port = (word16)atoi(myoptarg);
                         #if !defined(NO_MAIN_DRIVER) || defined(USE_WINDOWS_API)
                             if (port == 0) {
-                                ES_ERROR("port number cannot be 0");
+                                ES_ERROR("port number cannot be 0\n");
                             }
                         #endif
                     }
@@ -2748,7 +2748,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
 
 #ifdef WOLFSSH_TEST_BLOCK
     if (!nonBlock) {
-        ES_ERROR("Use -N when testing forced non blocking");
+        ES_ERROR("Use -N when testing forced non blocking\n");
     }
 #endif
 
@@ -2881,12 +2881,12 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
         kbAuthData.promptLanguageSz = 0;
         kbAuthData.prompts = (byte**)WMALLOC(sizeof(byte*), NULL, 0);
         if (kbAuthData.prompts == NULL) {
-            ES_ERROR("Error allocating prompts");
+            ES_ERROR("Error allocating prompts\n");
         }
         kbAuthData.promptLengths = (word32*)WMALLOC(sizeof(word32), NULL, 0);
         if (kbAuthData.promptLengths == NULL) {
             WFREE(kbAuthData.prompts, NULL, 0);
-            ES_ERROR("Error allocating promptLengths");
+            ES_ERROR("Error allocating promptLengths\n");
         }
         kbAuthData.prompts[0] = (byte*)"KB Auth Password: ";
         kbAuthData.promptLengths[0] = 18;
@@ -2894,7 +2894,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
         if (kbAuthData.promptEcho == NULL) {
             WFREE(kbAuthData.prompts, NULL, 0);
             WFREE(kbAuthData.promptLengths, NULL, 0);
-            ES_ERROR("Error allocating promptEcho");
+            ES_ERROR("Error allocating promptEcho\n");
         }
         kbAuthData.promptEcho[0] = 0;
         wolfSSH_SetKeyboardAuthPrompts(ctx, keyboardCallback);
@@ -2913,7 +2913,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
             keyLoadBuf = (byte*)WMALLOC(EXAMPLE_KEYLOAD_BUFFER_SZ,
                     NULL, 0);
             if (keyLoadBuf == NULL) {
-                ES_ERROR("Error allocating keyLoadBuf");
+                ES_ERROR("Error allocating keyLoadBuf\n");
             }
         #else
             keyLoadBuf = buf;
@@ -3200,7 +3200,7 @@ THREAD_RETURN WOLFSSH_THREAD echoserver_test(void* args)
                                                          &clientAddrSz);
     #endif
         if (clientFd == -1) {
-            ES_ERROR("tcp accept failed");
+            ES_ERROR("tcp accept failed\n");
         }
 
         if (nonBlock)

--- a/tests/auth.c
+++ b/tests/auth.c
@@ -1814,20 +1814,20 @@ static THREAD_RETURN WOLFSSH_THREAD server_thread(void* args)
         promptData.prompts =
             (byte**)WMALLOC(sizeof(byte*) * kbResponseCount, NULL, 0);
         if (promptData.prompts == NULL) {
-            ES_ERROR("Could not allocate prompts");
+            ES_ERROR("Could not allocate prompts\n");
         }
         promptData.promptLengths =
             (word32*)WMALLOC(sizeof(word32) * kbResponseCount, NULL, 0);
         if (promptData.promptLengths == NULL) {
             WFREE(promptData.prompts, NULL, 0);
-            ES_ERROR("Could not allocate promptLengths");
+            ES_ERROR("Could not allocate promptLengths\n");
         }
         promptData.promptEcho =
             (byte*)WMALLOC(sizeof(byte) * kbResponseCount, NULL, 0);
         if (promptData.promptEcho == NULL) {
             WFREE(promptData.prompts, NULL, 0);
             WFREE(promptData.promptLengths, NULL, 0);
-            ES_ERROR("Could not allocate promptEcho");
+            ES_ERROR("Could not allocate promptEcho\n");
         }
         for (word32 prompt = 0; prompt < kbResponseCount; prompt++) {
             promptData.prompts[prompt] = (byte*)"Password: ";
@@ -1870,13 +1870,13 @@ static THREAD_RETURN WOLFSSH_THREAD server_thread(void* args)
 
     clientFd = accept(listenFd, (struct sockaddr*)&clientAddr, &clientAddrSz);
     if (clientFd == -1) {
-        ES_ERROR("tcp accept failed");
+        ES_ERROR("tcp accept failed\n");
     }
     wolfSSH_set_fd(ssh, (int)clientFd);
 
     ret = wolfSSH_accept(ssh);
     if (ret && !unbalanced) {
-        ES_ERROR("wolfSSH Accept Error");
+        ES_ERROR("wolfSSH Accept Error\n");
     }
 
     ret = wolfSSH_shutdown(ssh);
@@ -1900,7 +1900,7 @@ static THREAD_RETURN WOLFSSH_THREAD server_thread(void* args)
     wolfSSH_CTX_free(ctx);
 
     if (ret) {
-        ES_ERROR("wolfSSH Shutdown Error");
+        ES_ERROR("wolfSSH Shutdown Error\n");
     }
 
     WOLFSSL_RETURN_FROM_THREAD(0);


### PR DESCRIPTION
`ES_ERROR()` passes its arguments straight to `fprintf(stderr, ...)`, so
a message with no trailing newline runs into whatever the shell or the
test harness prints next.

- 7 sites in the echoserver, 6 in `tests/auth.c`, 8 in the Espressif copy
  of the echoserver, which carries the same macro and takes this kind of
  cross-cutting fix (e91ff50d, ab8058d7)
- the two wrapped format strings already ended with a newline

Message text only; no logic change.
