### PR TITLE
Allow terminal and SFTP/SCP in embedded client-only builds

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -20864,7 +20864,7 @@ int SendChannelRequest(WOLFSSH* ssh, byte* name, word32 nameSz)
 }
 
 
-#if defined(WOLFSSH_TERM) && !defined(NO_FILESYSTEM)
+#if defined(WOLFSSH_TERM)
 
 /* out is always a TERMINAL_MODES_MAX_SZ buffer, and one byte is held back
  * for the terminator CreateMode() appends */

--- a/src/ssh.c
+++ b/src/ssh.c
@@ -1070,7 +1070,7 @@ int wolfSSH_connect(WOLFSSH* ssh)
             FALL_THROUGH;
 
         case CONNECT_CLIENT_CHANNEL_AGENT_REQUEST_SENT:
-        #if defined(WOLFSSH_TERM) && !defined(NO_FILESYSTEM)
+        #if defined(WOLFSSH_TERM)
             if (ssh->sendTerminalRequest) {
                 if ( (ssh->error = SendChannelTerminalRequest(ssh))
                         < WS_SUCCESS) {
@@ -1747,7 +1747,7 @@ void* wolfSSH_GetPublicKeyCheckCtx(WOLFSSH* ssh)
 }
 
 
-#if defined(WOLFSSH_TERM) && !defined(NO_FILESYSTEM)
+#if defined(WOLFSSH_TERM)
 /* Used to resize terminal window with shell connections
  * returns WS_SUCCESS on success */
 int wolfSSH_ChangeTerminalSize(WOLFSSH* ssh, word32 columns, word32 rows,
@@ -4868,8 +4868,7 @@ void* wolfSSH_GetChannelCloseCtx(WOLFSSH* ssh)
 }
 
 
-#if (defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)) && \
-    !defined(NO_WOLFSSH_SERVER)
+#if defined(WOLFSSH_SFTP) || defined(WOLFSSH_SCP)
 
 /*
  * Paths starting with a slash are absolute, rooted at "/". Any path that


### PR DESCRIPTION
Two compile-time guards exclude code that an embedded, client-only target
needs, and neither guard matches what the code behind it actually does.

`WOLFSSH_TERM` is gated on `!NO_FILESYSTEM` in three places, in `src/ssh.c` and
`src/internal.c`. Neither the window dimensions nor the terminal mode string is
read from disk; both are computed. On a target built with `NO_FILESYSTEM`,
`WOLFSSH_TERM` therefore compiles away and a client cannot request a PTY or send
its terminal modes, with no diagnostic to say why.

The SFTP and SCP client entry point in `wolfSSH_stream_read` is gated on
`!NO_WOLFSSH_SERVER`, so a client-only build cannot use SFTP or SCP even though
the guarded code is the client half.

This drops the two guards. A build that defines neither `NO_FILESYSTEM` nor
`NO_WOLFSSH_SERVER` is unaffected.

Found while running wolfSSH as an SSH and SFTP client on a bare-metal Raspberry
Pi with no filesystem and no server, serving an Acorn 8-bit host over its 1MHz
bus. With these two guards dropped the client negotiates a PTY and SFTP
transfers work; without them `WOLFSSH_TERM` is silently inert and SFTP is
unavailable.

I have kept our display defaults out of this change deliberately: the 40-column
and vt100 values that suit the Acorn host are a local choice and are not
proposed here. If a configurable default would be welcome I am happy to follow
up with one.