### PR TITLE
wolfsftp: keep the local file when resuming a get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,11 +85,10 @@ keys/*-ossh-*cert.pub
 random-test.txt
 random-test-result.txt
 test.dat
-# Scratch file the api tests write in the working directory. Removed on a
-# clean run, left behind when one aborts.
+# Scratch files the api and regression tests write in the working
+# directory. Removed on a clean run, left behind when one aborts.
 ossh-cert-line.tmp
-# Same for the regression tests' known_hosts fixtures, named by pid.
-wolfssh_kh_*.tmp
+wolfssh_*.tmp
 regress_known_hosts*.tmp
 
 # test output

--- a/src/wolfsftp.c
+++ b/src/wolfsftp.c
@@ -9775,6 +9775,9 @@ int wolfSSH_SFTP_Get(WOLFSSH* ssh, char* from,
     WS_SFTP_GET_STATE* state = NULL;
     int sz;
     int ret = WS_SUCCESS;
+#ifdef USE_WINDOWS_API
+    DWORD creationDisp;
+#endif
 
     WLOG(WS_LOG_SFTP, "Entering wolfSSH_SFTP_Get()");
     if (ssh == NULL || from == NULL || to == NULL)
@@ -9853,6 +9856,36 @@ int wolfSSH_SFTP_Get(WOLFSSH* ssh, char* from,
                 /* if resuming then check for saved offset */
                 if (resume) {
                     wolfSSH_SFTP_GetOfst(ssh, from, to, state->gOfst);
+
+                    /* A saved offset is only usable while the remote file
+                     * still holds bytes past it. */
+                    if ((state->gOfst[0] > 0 || state->gOfst[1] > 0)
+                            && (state->attrib.flags & WOLFSSH_FILEATRB_SIZE)
+                            && (state->attrib.sz[1] < state->gOfst[1]
+                                || (state->attrib.sz[1] == state->gOfst[1]
+                                    && state->attrib.sz[0]
+                                        <= state->gOfst[0]))) {
+                        WLOG(WS_LOG_SFTP, "Remote file too short");
+                        state->gOfst[0] = 0;
+                        state->gOfst[1] = 0;
+                    }
+
+                    /* a saved offset is only usable if the local file still
+                     * holds exactly that many bytes */
+                    if (state->gOfst[0] > 0 || state->gOfst[1] > 0) {
+                        WMEMSET(&state->attrib, 0, sizeof(state->attrib));
+                        if (SFTP_GetAttributes(ssh->fs, to, &state->attrib, 1,
+                                    ssh->ctx->heap) != WS_SUCCESS
+                                || (state->attrib.flags
+                                    & WOLFSSH_FILEATRB_SIZE) == 0
+                                || state->attrib.sz[0] != state->gOfst[0]
+                                || state->attrib.sz[1] != state->gOfst[1]) {
+                            WLOG(WS_LOG_SFTP,
+                                    "Size does not match, starting over");
+                            state->gOfst[0] = 0;
+                            state->gOfst[1] = 0;
+                        }
+                    }
                 }
                 state->state = STATE_GET_OPEN_LOCAL;
                 FALL_THROUGH;
@@ -9865,20 +9898,23 @@ int wolfSSH_SFTP_Get(WOLFSSH* ssh, char* from,
                     else
                         ret = WFOPEN(ssh->fs, &state->fl, to, WOLFSSH_O_WRONLY);
             #elif defined(USE_WINDOWS_API)
-                    {
-                        DWORD desiredAccess = GENERIC_WRITE;
-                        if (state->gOfst[0] > 0 || state->gOfst[1] > 0)
-                            desiredAccess |= FILE_APPEND_DATA;
-                        state->fileHandle = WS_CreateFileA(to, desiredAccess,
-                            (FILE_SHARE_DELETE | FILE_SHARE_READ |
-                             FILE_SHARE_WRITE), CREATE_ALWAYS,
-                            FILE_ATTRIBUTE_NORMAL, ssh->ctx->heap);
+                    creationDisp = CREATE_ALWAYS;
+                    if (state->gOfst[0] > 0 || state->gOfst[1] > 0)
+                        creationDisp = OPEN_EXISTING;
+                    state->fileHandle = WS_CreateFileA(to, GENERIC_WRITE,
+                        (FILE_SHARE_DELETE | FILE_SHARE_READ |
+                         FILE_SHARE_WRITE), creationDisp,
+                        FILE_ATTRIBUTE_NORMAL, ssh->ctx->heap);
+                    if (state->fileHandle == INVALID_HANDLE_VALUE) {
+                        WLOG(WS_LOG_SFTP, "Unable to open output file");
+                        ssh->error = WS_BAD_FILE_E;
+                        ret = WS_FATAL_ERROR;
+                        state->state = STATE_GET_CLEANUP;
+                        continue;
                     }
-                    if (resume) {
-                        WMEMSET(&state->offset, 0, sizeof(OVERLAPPED));
-                        state->offset.OffsetHigh = state->gOfst[1];
-                        state->offset.Offset = state->gOfst[0];
-                    }
+                    WMEMSET(&state->offset, 0, sizeof(OVERLAPPED));
+                    state->offset.OffsetHigh = state->gOfst[1];
+                    state->offset.Offset = state->gOfst[0];
                 #else
                     if (state->gOfst[0] > 0 || state->gOfst[1] > 0)
                         ret = WFOPEN(ssh->fs, &state->fl, to, "ab");

--- a/tests/api.c
+++ b/tests/api.c
@@ -5901,6 +5901,24 @@ static int sftpPutToCompletion(WOLFSSH* ssh, char* from, char* to, byte resume)
 
     return ret;
 }
+
+
+/* Drives one wolfSSH_SFTP_Get() to a terminal result. */
+static int sftpGetToCompletion(WOLFSSH* ssh, char* from, char* to, byte resume)
+{
+    int ret = WS_FATAL_ERROR;
+    int tries;
+
+    for (tries = 0; tries < SFTP_MAX_RETRY_TRIES; tries++) {
+        ret = wolfSSH_SFTP_Get(ssh, from, to, resume, NULL);
+        if (ret == WS_SUCCESS ||
+                !sftp_error_is_notice(wolfSSH_get_error(ssh))) {
+            break;
+        }
+    }
+
+    return ret;
+}
 #endif /* !NO_FILESYSTEM && !WOLFSSH_USER_FILESYSTEM && !WOLFSSH_ZEPHYR */
 
 
@@ -6031,9 +6049,141 @@ static void test_wolfSSH_SFTP_PutResume(void)
 
     wolfSSH_free(ssh);
     wolfSSH_CTX_free(ctx);
-#ifdef WOLFSSH_ZEPHYR
-    k_sleep(Z_TIMEOUT_TICKS(100));
+    ThreadJoin(serThread);
+    FreeTcpReady(&ready);
+#endif /* !NO_FILESYSTEM && !WOLFSSH_USER_FILESYSTEM && !WOLFSSH_ZEPHYR */
+}
+
+
+/* A resumed get must keep the bytes already at the local destination, and
+ * must only resume onto one whose size matches the saved offset. The
+ * echoserver shares this process, so the "remote" file is local. */
+static void test_wolfSSH_SFTP_GetResume(void)
+{
+/* staging both files needs the hosted fopen()/getcwd() wrappers */
+#if !defined(NO_FILESYSTEM) && !defined(WOLFSSH_USER_FILESYSTEM) && \
+    !defined(WOLFSSH_ZEPHYR)
+    func_args ser;
+    tcp_ready ready;
+    int argsCount;
+    WS_SOCKET_T clientFd;
+
+    const char* args[10];
+    WOLFSSH_CTX* ctx = NULL;
+    WOLFSSH*     ssh = NULL;
+
+    THREAD_TYPE serThread;
+
+    byte src[SFTP_PUT_RESUME_SZ];
+    byte stale[SFTP_PUT_RESUME_SZ + SFTP_PUT_RESUME_OFST];
+    byte expect[SFTP_PUT_RESUME_SZ];
+    word32 ofst[2];
+    char srcName[] = "wolfssh_12547_src.tmp";
+    char dstName[] = "wolfssh_12547_dst.tmp";
+
+    WMEMSET(&ser, 0, sizeof(func_args));
+
+    argsCount = 0;
+    args[argsCount++] = ".";
+    args[argsCount++] = "-1";
+    args[argsCount++] = "-p";
+    args[argsCount++] = "0";
+    ser.argv   = (char**)args;
+    ser.argc   = argsCount;
+    ser.signal = &ready;
+    InitTcpReady(ser.signal);
+    ThreadStart(echoserver_test, (void*)&ser, &serThread);
+    WaitTcpReady(&ready);
+
+    sftp_client_connect(&ctx, &ssh, ready.port);
+    AssertNotNull(ctx);
+    AssertNotNull(ssh);
+
+    sftpPutFillPattern(src, (word32)sizeof(src));
+    WMEMSET(stale, 0xFF, sizeof(stale));
+    AssertIntEQ(sftpPutWriteFile(srcName, src, (word32)sizeof(src)), 0);
+
+    /* the saved offset matches the destination, so the download picks up
+     * where it left off. Staging a prefix unlike the source, and expecting it
+     * back untouched, is what separates a resume from a full re-download. */
+    AssertIntEQ(sftpPutWriteFile(dstName, stale, SFTP_PUT_RESUME_OFST), 0);
+    WMEMCPY(expect, stale, SFTP_PUT_RESUME_OFST);
+    WMEMCPY(expect + SFTP_PUT_RESUME_OFST, src + SFTP_PUT_RESUME_OFST,
+            sizeof(expect) - SFTP_PUT_RESUME_OFST);
+    ofst[0] = SFTP_PUT_RESUME_OFST;
+    ofst[1] = 0;
+    AssertIntEQ(wolfSSH_SFTP_SaveOfst(ssh, srcName, dstName, ofst),
+            WS_SUCCESS);
+    AssertIntEQ(sftpGetToCompletion(ssh, srcName, dstName, 1), WS_SUCCESS);
+    AssertIntEQ(sftpPutFileMatches(dstName, expect, (word32)sizeof(expect)),
+            0);
+
+    /* the destination is gone, so the whole file is fetched again */
+    WREMOVE(NULL, dstName);
+    ofst[0] = SFTP_PUT_RESUME_OFST;
+    ofst[1] = 0;
+    AssertIntEQ(wolfSSH_SFTP_SaveOfst(ssh, srcName, dstName, ofst),
+            WS_SUCCESS);
+    AssertIntEQ(sftpGetToCompletion(ssh, srcName, dstName, 1), WS_SUCCESS);
+    AssertIntEQ(sftpPutFileMatches(dstName, src, (word32)sizeof(src)), 0);
+
+    /* the destination is shorter than the saved offset, so the whole file is
+     * fetched again */
+    AssertIntEQ(sftpPutWriteFile(dstName, stale, SFTP_PUT_RESUME_OFST / 2), 0);
+    ofst[0] = SFTP_PUT_RESUME_OFST;
+    ofst[1] = 0;
+    AssertIntEQ(wolfSSH_SFTP_SaveOfst(ssh, srcName, dstName, ofst),
+            WS_SUCCESS);
+    AssertIntEQ(sftpGetToCompletion(ssh, srcName, dstName, 1), WS_SUCCESS);
+    AssertIntEQ(sftpPutFileMatches(dstName, src, (word32)sizeof(src)), 0);
+
+    /* the destination is longer than the saved offset, so the whole file is
+     * fetched again */
+    AssertIntEQ(sftpPutWriteFile(dstName, stale, SFTP_PUT_RESUME_OFST * 2), 0);
+    ofst[0] = SFTP_PUT_RESUME_OFST;
+    ofst[1] = 0;
+    AssertIntEQ(wolfSSH_SFTP_SaveOfst(ssh, srcName, dstName, ofst),
+            WS_SUCCESS);
+    AssertIntEQ(sftpGetToCompletion(ssh, srcName, dstName, 1), WS_SUCCESS);
+    AssertIntEQ(sftpPutFileMatches(dstName, src, (word32)sizeof(src)), 0);
+
+    /* a plain get still truncates a longer destination */
+    AssertIntEQ(sftpPutWriteFile(dstName, stale, (word32)sizeof(stale)), 0);
+    AssertIntEQ(sftpGetToCompletion(ssh, srcName, dstName, 0), WS_SUCCESS);
+    AssertIntEQ(sftpPutFileMatches(dstName, src, (word32)sizeof(src)), 0);
+
+    /* the source has nothing left past the saved offset, so the whole file
+     * is fetched again. This case shortens the source, so it runs last. */
+    AssertIntEQ(sftpPutWriteFile(dstName, stale, SFTP_PUT_RESUME_OFST), 0);
+    AssertIntEQ(sftpPutWriteFile(srcName, src, SFTP_PUT_RESUME_OFST / 2), 0);
+    ofst[0] = SFTP_PUT_RESUME_OFST;
+    ofst[1] = 0;
+    AssertIntEQ(wolfSSH_SFTP_SaveOfst(ssh, srcName, dstName, ofst),
+            WS_SUCCESS);
+    AssertIntEQ(sftpGetToCompletion(ssh, srcName, dstName, 1), WS_SUCCESS);
+    AssertIntEQ(sftpPutFileMatches(dstName, src, SFTP_PUT_RESUME_OFST / 2), 0);
+
+    WREMOVE(NULL, dstName);
+    WREMOVE(NULL, srcName);
+
+    /* take care of re-keying state before shutdown call */
+    while (wolfSSH_get_error(ssh) == WS_REKEYING) {
+        wolfSSH_worker(ssh, NULL);
+    }
+
+    argsCount = AbsorbBenignReset(ssh, wolfSSH_shutdown(ssh));
+#if DEFAULT_HIGHWATER_MARK < 8000
+    if (argsCount == WS_REKEYING) {
+        argsCount = WS_SUCCESS;
+    }
 #endif
+    AssertIntEQ(argsCount, WS_SUCCESS);
+
+    clientFd = wolfSSH_get_fd(ssh);
+    WCLOSESOCKET(clientFd);
+
+    wolfSSH_free(ssh);
+    wolfSSH_CTX_free(ctx);
     ThreadJoin(serThread);
     FreeTcpReady(&ready);
 #endif /* !NO_FILESYSTEM && !WOLFSSH_USER_FILESYSTEM && !WOLFSSH_ZEPHYR */
@@ -6051,6 +6201,7 @@ static void test_wolfSSH_SFTP_SetConfinePath(void) { ; }
 static void test_wolfSSH_SFTP_SetDefaultPath(void) { ; }
 static void test_wolfSSH_SFTP_SaveOfst(void) { ; }
 static void test_wolfSSH_SFTP_PutResume(void) { ; }
+static void test_wolfSSH_SFTP_GetResume(void) { ; }
 #endif /* WOLFSSH_SFTP && !NO_WOLFSSH_CLIENT && !SINGLE_THREADED */
 
 
@@ -7999,6 +8150,7 @@ int wolfSSH_ApiTest(int argc, char** argv)
     test_wolfSSH_SFTP_SetDefaultPath();
     test_wolfSSH_SFTP_SaveOfst();
     test_wolfSSH_SFTP_PutResume();
+    test_wolfSSH_SFTP_GetResume();
 
     /* Either SCP or SFTP */
     test_wolfSSH_RealPath();


### PR DESCRIPTION
### Problem
`wolfSSH_SFTP_Get()` opened the local destination with `CREATE_ALWAYS` on every Windows transfer, including a resumed one. The file was truncated to zero before `WriteFile()` resumed at the saved offset, so the already-downloaded prefix came back as a zero-filled gap — a `reget` on Windows silently corrupted the file it was meant to finish.

Separately, neither platform checked the saved offset against the destination's real size. On POSIX `"ab"` appends at the file's current end regardless of `gOfst`, so a destination that was deleted, replaced, or shortened between the interrupt and the `reget` got the remainder spliced in at the wrong position. The corruption is not Windows-only: on POSIX a `reget` onto a missing destination writes the remainder at offset 0, producing a 768-byte file holding `src[256..1024]`.

### Fix (`src/wolfsftp.c`)
- **`STATE_GET_LOOKUP_OFFSET`** stats the destination when the saved offset is nonzero and clears the offset unless the reported size matches it exactly, restarting the transfer from zero. This mirrors `STATE_PUT_STAT_REMOTE`, added for the upload direction in 11659, and is not `#ifdef`-guarded — it corrects the POSIX and Harmony append paths too.
- **`STATE_GET_LOOKUP_OFFSET`** also clears the saved offset when the remote size already in `state->attrib` from `STATE_GET_LSTAT` is less than or equal to it, so a shortened remote file cannot leave the local copy longer than its source. This mirrors `STATE_PUT_LOOKUP_OFFSET`.
- **`STATE_GET_OPEN_LOCAL`** passes `OPEN_EXISTING` when the write offset is nonzero and reserves `CREATE_ALWAYS` for offset zero.
- **`FILE_APPEND_DATA`** is dropped from the desired access: `GENERIC_WRITE` already grants it and the write offset comes from the `OVERLAPPED`. The open now reports `INVALID_HANDLE_VALUE` as `WS_BAD_FILE_E` rather than falling through on a stale `ret`.

Closes f-12547.

### Tests
`test_wolfSSH_SFTP_GetResume()` in `tests/api.c`, six cases over a 1024-byte source with a 256-byte offset:

| Source / destination state | `resume` | Expected result |
|---|---|---|
| holds 256 bytes unlike the source | `1` | staged prefix kept, remainder appended |
| missing | `1` | full re-download |
| shorter than the saved offset | `1` | full re-download |
| longer than the saved offset | `1` | full re-download |
| longer than the source | `0` | truncated to the source |
| source shortened below the saved offset | `1` | full re-download |

Staging a prefix that differs from the source is what separates a real resume from a re-download, and the comparison reads one byte past the expected size so a leftover tail fails.

### Verification
- GCC preflight sweep clean across all 6 configs; `make check` 7 passed / 2 skipped / 0 failed, including `scripts/sftp.test` and `get-put.test`.
- Windows (MSVC, Debug x64): `api-test` and `unit-test` both exit 0.
- Negative controls: without the size check the missing / short / long destination cases each fail independently on Linux; with `CREATE_ALWAYS` restored the resume case fails on Windows.

### Not in this PR
A failed local open jumps to `STATE_GET_CLEANUP` without closing the remote handle. This is pre-existing on every branch — the sibling `if (ret != 0)` path does the same — and routing through `STATE_GET_CLOSE_REMOTE` would overwrite `ret` and surface `WS_CLOSE_FILE_E` instead of `WS_BAD_FILE_E`, so fixing both branches properly belongs in its own change.
