### PR TITLE
Stop the linker folding main() into a skipped test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,6 +388,15 @@ AM_CONDITIONAL([BUILD_KEYBOARD_INTERACTIVE],[test "x$ENABLED_KEYBOARD_INTERACTIV
 
 AX_HARDEN_CC_COMPILER_FLAGS
 
+dnl A test that is configured out compiles down to "return 77", the automake
+dnl skip code, and so does the main() that forwards to it. Apple's linker folds
+dnl the two identical bodies together, then writes LC_MAIN entryoff 0, so the
+dnl binary starts executing at the Mach-O header and dies with SIGILL instead
+dnl of skipping. Turn the folding off where the linker understands the flag;
+dnl GNU ld rejects it and is unaffected.
+AX_CHECK_LINK_FLAG([-Wl,-no_deduplicate],
+                   [AM_LDFLAGS="$AM_LDFLAGS -Wl,-no_deduplicate"])
+
 CREATE_HEX_VERSION
 AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_CFLAGS])


### PR DESCRIPTION
A configured-out test compiles down to "return 77" and the main()
forwarding to it inlines to the same body, so Apple's ld folds the two
and writes LC_MAIN entryoff 0: the binary starts executing at the Mach-O
header and dies with SIGILL instead of skipping.

- Probe for -Wl,-no_deduplicate and add it to AM_LDFLAGS when the linker
  takes it. GNU ld rejects the flag, so Linux is left alone.
- Hits kex.test, api.test and auth.test under
  --enable-all CPPFLAGS=-DWOLFSSH_TEST_BLOCK, and kex.test again under
  --disable-server.
